### PR TITLE
Use go install

### DIFF
--- a/cmd/protoc-gen-micro/README.md
+++ b/cmd/protoc-gen-micro/README.md
@@ -5,7 +5,7 @@ This is protobuf code generation for go-micro. We use protoc-gen-micro to reduce
 ## Install
 
 ```
-go get github.com/asim/go-micro/cmd/protoc-gen-micro/v3
+go install github.com/asim/go-micro/cmd/protoc-gen-micro/v3
 ```
 
 Also required: 


### PR DESCRIPTION
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
