### PR TITLE
Add update rule to Makefile generated by gomu

### DIFF
--- a/cmd/gomu/cmd/cli/new/new.go
+++ b/cmd/gomu/cmd/cli/new/new.go
@@ -168,22 +168,23 @@ func createProject(ctx *cli.Context, pt string) error {
 
 func clientComments(name, dir string) []string {
 	return []string{
-		"cd " + dir,
-		"make tidy\n",
+		"\ninstall dependencies:",
+		"\ncd " + dir,
+		"make update tidy",
 	}
 }
 
 func protoComments(name, dir string) []string {
 	return []string{
-		"\ndownload protoc zip packages (protoc-$VERSION-$PLATFORM.zip) and install:\n",
-		"visit https://github.com/protocolbuffers/protobuf/releases/latest",
-		"\ndownload protobuf for go-micro:\n",
-		"go get -u google.golang.org/protobuf/proto",
+		"\ndownload protoc zip packages (protoc-$VERSION-$PLATFORM.zip) and install:",
+		"\nvisit https://github.com/protocolbuffers/protobuf/releases/latest",
+		"\ndownload protobuf for go-micro:",
+		"\ngo get -u google.golang.org/protobuf/proto",
 		"go install github.com/golang/protobuf/protoc-gen-go@latest",
 		"go install github.com/asim/go-micro/cmd/protoc-gen-micro/v4@latest",
-		"\ncompile the proto file " + name + ".proto:\n",
-		"cd " + dir,
-		"make proto tidy\n",
+		"\ncompile the proto file " + name + ".proto and install dependencies:",
+		"\ncd " + dir,
+		"make proto update tidy",
 	}
 }
 

--- a/cmd/gomu/generator/template/makefile.go
+++ b/cmd/gomu/generator/template/makefile.go
@@ -13,6 +13,10 @@ init:
 proto:
 	@protoc --proto_path=. --micro_out=. --go_out=:. proto/{{.Service}}.proto
 
+.PHONY: update
+update:
+	@go get -u
+
 .PHONY: tidy
 tidy:
 	@go mod tidy


### PR DESCRIPTION
I realized that when writing `require go-micro.dev/v4 v4.1.0` in the `go.mod` file, `go mod tidy` will install that exact version of `go-micro.dev/v4`. As of right now, v4.1.0 is not the latest version version, and preferably we shouldn't be updating gomu's Go Modules template everytime a new release is tagged, but still want gomu users to generate projects using the latest Go Micro version.

In an attempt to solve this problem, I'm opting to add a new Makefile rule for new projects generated by gomu, `update` that runs `go get -u`. This aggressively updates any dependencies your Go Modules project may have.  `go mod tidy` is then able to prune the `go.mod` and `go.sum` files by removing the unnecessary checksums and transitive dependencies (e.g. `// indirect`), that were added to by go get -u due to newer semver available.

Put one and one together and you get two. In addition to adding an `update` rule to the Makefile generated for new projects by gomu, I'm also updating the proto and client comments printed when new projects have been generated to promote the `update` rule.

References:

- https://stackoverflow.com/questions/67201708/go-update-all-modules