### PR TITLE
fixing #2308

### DIFF
--- a/plugins/broker/grpc/grpc.go
+++ b/plugins/broker/grpc/grpc.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	proto "github.com/asim/go-micro/plugins/broker/grpc/v4/proto"
 	"github.com/google/uuid"
 	"go-micro.dev/v4/broker"
 	"go-micro.dev/v4/cmd"
@@ -23,7 +24,6 @@ import (
 	maddr "go-micro.dev/v4/util/addr"
 	mnet "go-micro.dev/v4/util/net"
 	mls "go-micro.dev/v4/util/tls"
-	proto "github.com/asim/go-micro/plugins/broker/grpc/v4/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -505,7 +505,7 @@ func (h *grpcBroker) Subscribe(topic string, handler broker.Handler, opts ...bro
 	// register service
 	node := &registry.Node{
 		Id:      id,
-		Address: fmt.Sprintf("%s:%d", addr, port),
+		Address: net.JoinHostPort(addr, fmt.Sprint(port)),
 		Metadata: map[string]string{
 			"secure": fmt.Sprintf("%t", secure),
 		},

--- a/plugins/registry/consul/watcher.go
+++ b/plugins/registry/consul/watcher.go
@@ -2,12 +2,13 @@ package consul
 
 import (
 	"fmt"
+	"net"
 	"sync"
 
-	"go-micro.dev/v4/registry"
-	regutil "go-micro.dev/v4/util/registry"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/api/watch"
+	"go-micro.dev/v4/registry"
+	regutil "go-micro.dev/v4/util/registry"
 )
 
 type consulWatcher struct {
@@ -44,7 +45,7 @@ func newConsulWatcher(cr *consulRegistry, opts ...registry.WatchOption) (registr
 	}
 
 	wp.Handler = cw.handle
-	go wp.RunWithClientAndHclog(cr.Client(),wp.Logger)
+	go wp.RunWithClientAndHclog(cr.Client(), wp.Logger)
 	cw.wp = wp
 
 	return cw, nil
@@ -102,7 +103,7 @@ func (cw *consulWatcher) serviceHandler(idx uint64, data interface{}) {
 
 		svc.Nodes = append(svc.Nodes, &registry.Node{
 			Id:       id,
-			Address:  fmt.Sprintf("%s:%d", address, e.Service.Port),
+			Address:  net.JoinHostPort(address, fmt.Sprint(e.Service.Port)),
 			Metadata: decodeMetadata(e.Service.Tags),
 		})
 	}

--- a/plugins/registry/eureka/marshalling.go
+++ b/plugins/registry/eureka/marshalling.go
@@ -48,12 +48,12 @@ func appToService(app *fargo.Application) []*registry.Service {
 			}
 		}
 
-                host, _, _ := net.SplitHostPort(addr)
+		host, _, _ := net.SplitHostPort(addr)
 
 		// append node
 		service.Nodes = append(service.Nodes, &registry.Node{
 			Id:       id,
-			Address:  fmt.Sprintf("%s:%d", host, port),
+			Address:  net.JoinHostPort(host, fmt.Sprint(port)),
 			Metadata: metadata,
 		})
 

--- a/plugins/selector/dns/dns.go
+++ b/plugins/selector/dns/dns.go
@@ -67,7 +67,7 @@ func (d *dnsSelector) Select(service string, opts ...selector.SelectOption) (sel
 	for _, node := range srv {
 		nodes = append(nodes, &registry.Node{
 			Id:      node.Target,
-			Address: fmt.Sprintf("%s:%d", node.Target, node.Port),
+			Address: net.JoinHostPort(node.Target, fmt.Sprint(node.Port)),
 		})
 	}
 

--- a/plugins/server/http/extractor.go
+++ b/plugins/server/http/extractor.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"strconv"
 	"strings"
@@ -36,7 +37,7 @@ func serviceDef(opts server.Options) *registry.Service {
 
 	node := &registry.Node{
 		Id:       opts.Name + "-" + opts.Id,
-		Address:  fmt.Sprintf("%s:%d", addr, port),
+		Address:  net.JoinHostPort(addr, fmt.Sprint(port)),
 		Metadata: opts.Metadata,
 	}
 

--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -15,9 +15,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"go-micro.dev/v4/logger"
 	"go-micro.dev/v4/util/mdns"
-	"github.com/google/uuid"
 )
 
 var (
@@ -366,7 +366,7 @@ func (m *mdnsRegistry) GetService(service string, opts ...GetOption) ([]*Service
 				}
 				s.Nodes = append(s.Nodes, &Node{
 					Id:       strings.TrimSuffix(e.Name, "."+p.Service+"."+p.Domain+"."),
-					Address:  fmt.Sprintf("%s:%d", addr, e.Port),
+					Address:  net.JoinHostPort(addr, fmt.Sprint(e.Port)),
 					Metadata: txt.Metadata,
 				})
 
@@ -593,7 +593,7 @@ func (m *mdnsWatcher) Next() (*Result, error) {
 
 			service.Nodes = append(service.Nodes, &Node{
 				Id:       strings.TrimSuffix(e.Name, suffix),
-				Address:  fmt.Sprintf("%s:%d", addr, e.Port),
+				Address:  net.JoinHostPort(addr, fmt.Sprint(e.Port)),
 				Metadata: txt.Metadata,
 			})
 

--- a/web/service.go
+++ b/web/service.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -13,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/urfave/cli/v2"
 	"go-micro.dev/v4"
 	"go-micro.dev/v4/logger"
 	"go-micro.dev/v4/registry"
@@ -22,7 +22,6 @@ import (
 	mnet "go-micro.dev/v4/util/net"
 	signalutil "go-micro.dev/v4/util/signal"
 	mls "go-micro.dev/v4/util/tls"
-	"github.com/urfave/cli/v2"
 )
 
 type service struct {
@@ -85,7 +84,7 @@ func (s *service) genSrv() *registry.Service {
 		Version: s.opts.Version,
 		Nodes: []*registry.Node{{
 			Id:       s.opts.Id,
-			Address:  fmt.Sprintf("%s:%s", addr, port),
+			Address:  net.JoinHostPort(addr, port),
 			Metadata: s.opts.Metadata,
 		}},
 	}


### PR DESCRIPTION
IPV6 too many colons in address

net.SplitHostPort need ipv6 address in [host]:port format
