### PR TITLE
fix the concurrent map writes error

### DIFF
--- a/registry/cache/cache.go
+++ b/registry/cache/cache.go
@@ -100,7 +100,6 @@ func (c *cache) isValid(services []*registry.Service, ttl time.Time) bool {
 		for _, n := range s.Nodes {
 			nttl := c.nttls[s.Name][n.Id]
 			if time.Since(nttl) > 0 {
-				delete(c.nttls, s.Name)
 				return false
 			}
 		}
@@ -221,6 +220,12 @@ func (c *cache) updateNodeTTLs(name string, nodes []*registry.Node) {
 	}
 	for _, node := range nodes {
 		c.nttls[name][node.Id] = time.Now().Add(c.opts.TTL)
+	}
+	// clean up expired nodes
+	for nodeId, nttl := range c.nttls[name] {
+		if time.Since(nttl) > 0 {
+			delete(c.nttls[name], nodeId)
+		}
 	}
 }
 


### PR DESCRIPTION
Related issues:  https://github.com/micro/go-micro/issues/2743
https://github.com/owncloud/ocis/issues/10785


Fixed the concurrent map access in a `registry/cache/cache.go:103`
