### PR TITLE
fix consul watcher address handling

### DIFF
--- a/registry/consul/watcher.go
+++ b/registry/consul/watcher.go
@@ -1,13 +1,12 @@
 package consul
 
 import (
-	"fmt"
-	"net"
 	"sync"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/api/watch"
 	"go-micro.dev/v5/registry"
+	mnet "go-micro.dev/v5/util/net"
 	regutil "go-micro.dev/v5/util/registry"
 )
 
@@ -106,7 +105,7 @@ func (cw *consulWatcher) serviceHandler(idx uint64, data interface{}) {
 
 		svc.Nodes = append(svc.Nodes, &registry.Node{
 			Id:       id,
-			Address:  net.JoinHostPort(address, fmt.Sprint(e.Service.Port)),
+			Address:  mnet.HostPort(address, e.Service.Port),
 			Metadata: decodeMetadata(e.Service.Tags),
 		})
 	}


### PR DESCRIPTION
When registering NATS nodes with dynamic inbox addresses (e.g., _INBOX.dFQLvUUb31dyqfXzrsfBFw), net.JoinHostPort in registry/consul/watcher.go forcibly appends a default port (:0) to the address.
Consul watcher caches the invalid address until TTL expires, Affected nodes become unreachable for the entire ​TTL duration (default: 1 minute)​.