### PR TITLE
fix data race in memory.update

### DIFF
--- a/config/loader/memory/memory.go
+++ b/config/loader/memory/memory.go
@@ -183,10 +183,12 @@ func (m *memory) update() {
 
 		val, _ := vals.Get(w.path...)
 
+		m.RLock()
 		uv := updateValue{
 			version: m.snap.Version,
 			value:   val,
 		}
+		m.RUnlock()
 
 		select {
 		case w.updates <- uv:


### PR DESCRIPTION
Fix data race in memory.update -
someone forgot to acquire read lock around this access, and it hit me in unit tests in my project, with DATA RACE warning pointing at this unguarded read (the write side was already OK).

With this change, the issue seems to be resolved.