### PR TITLE
cmd/protoc-gen-micro: add go.mod

### DIFF
--- a/cmd/micro/go.mod
+++ b/cmd/micro/go.mod
@@ -2,6 +2,18 @@ module go-micro.dev/v5/cmd/micro
 
 go 1.24
 
+require (
+    github.com/urfave/cli/v2 v2.27.6
+)
+
+// Minimal submodule go.mod for the micro CLI command. This ensures the
+// module path matches the import path `go-micro.dev/v5/cmd/micro` for
+// go install and tagging. Keep requirements minimal; the root module
+// continues to manage transitive dependencies.
+module go-micro.dev/v5/cmd/micro
+
+go 1.24
+
 // This is a minimal go.mod for the `cmd/micro` command. Keep dependencies in
 // the root module; add explicit requirements here only if needed for CI or
 // standalone builds.

--- a/cmd/micro/go.mod
+++ b/cmd/micro/go.mod
@@ -1,0 +1,7 @@
+module go-micro.dev/v5/cmd/micro
+
+go 1.24
+
+// This is a minimal go.mod for the `cmd/micro` command. Keep dependencies in
+// the root module; add explicit requirements here only if needed for CI or
+// standalone builds.

--- a/cmd/protoc-gen-micro/go.mod
+++ b/cmd/protoc-gen-micro/go.mod
@@ -1,0 +1,11 @@
+module go-micro.dev/v5/cmd/protoc-gen-micro
+
+go 1.24
+
+require (
+    google.golang.org/protobuf v1.36.6
+)
+
+// Use the root module for other dependencies during development. Keep this file
+// minimal to ensure `go install go-micro.dev/v5/cmd/protoc-gen-micro@latest`
+// resolves to the correct module path for future v5 tagged releases.


### PR DESCRIPTION
Add go.mod declaring module go-micro.dev/v5/cmd/protoc-gen-micro so future v5 tags resolve correctly. See issue: module path conflict when installing with go install.