### PR TITLE
feat(web): add SSE broadcaster for real-time event streaming

### DIFF
--- a/web/sse.go
+++ b/web/sse.go
@@ -1,0 +1,295 @@
+// Package web provides a web service for go-micro
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"go-micro.dev/v5/events"
+	log "go-micro.dev/v5/logger"
+)
+
+// SSEClient represents a connected SSE client
+type SSEClient struct {
+	id       string
+	send     chan []byte
+	done     chan struct{}
+	metadata map[string]string
+}
+
+// SSEBroadcaster manages SSE connections and broadcasts events to connected clients
+type SSEBroadcaster struct {
+	clients    map[*SSEClient]struct{}
+	register   chan *SSEClient
+	unregister chan *SSEClient
+	broadcast  chan []byte
+	stream     events.Stream
+	topics     []string
+	logger     log.Logger
+	mu         sync.RWMutex
+	running    bool
+	stopCh     chan struct{}
+}
+
+// SSEEvent represents an event to be sent to clients
+type SSEEvent struct {
+	ID    string      `json:"id,omitempty"`
+	Event string      `json:"event,omitempty"`
+	Data  interface{} `json:"data"`
+}
+
+// SSEOption is a function that configures the SSEBroadcaster
+type SSEOption func(*SSEBroadcaster)
+
+// WithStream sets the events stream for the broadcaster
+func WithStream(stream events.Stream) SSEOption {
+	return func(b *SSEBroadcaster) {
+		b.stream = stream
+	}
+}
+
+// WithTopics sets the topics to subscribe to
+func WithTopics(topics ...string) SSEOption {
+	return func(b *SSEBroadcaster) {
+		b.topics = topics
+	}
+}
+
+// WithSSELogger sets the logger for the broadcaster
+func WithSSELogger(logger log.Logger) SSEOption {
+	return func(b *SSEBroadcaster) {
+		b.logger = logger
+	}
+}
+
+// NewSSEBroadcaster creates a new SSE broadcaster
+func NewSSEBroadcaster(opts ...SSEOption) *SSEBroadcaster {
+	b := &SSEBroadcaster{
+		clients:    make(map[*SSEClient]struct{}),
+		register:   make(chan *SSEClient),
+		unregister: make(chan *SSEClient),
+		broadcast:  make(chan []byte, 256),
+		logger:     log.DefaultLogger,
+		stopCh:     make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(b)
+	}
+
+	return b
+}
+
+// Start begins the broadcaster's event loop and subscribes to configured topics
+func (b *SSEBroadcaster) Start() error {
+	b.mu.Lock()
+	if b.running {
+		b.mu.Unlock()
+		return nil
+	}
+	b.running = true
+	b.mu.Unlock()
+
+	// Start the main event loop
+	go b.run()
+
+	// Subscribe to topics if stream is configured
+	if b.stream != nil && len(b.topics) > 0 {
+		for _, topic := range b.topics {
+			if err := b.subscribeToTopic(topic); err != nil {
+				b.logger.Logf(log.ErrorLevel, "Failed to subscribe to topic %s: %v", topic, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Stop gracefully shuts down the broadcaster
+func (b *SSEBroadcaster) Stop() {
+	b.mu.Lock()
+	if !b.running {
+		b.mu.Unlock()
+		return
+	}
+	b.running = false
+	b.mu.Unlock()
+
+	close(b.stopCh)
+}
+
+func (b *SSEBroadcaster) run() {
+	for {
+		select {
+		case client := <-b.register:
+			b.mu.Lock()
+			b.clients[client] = struct{}{}
+			b.mu.Unlock()
+			b.logger.Logf(log.DebugLevel, "SSE client connected: %s", client.id)
+
+		case client := <-b.unregister:
+			b.mu.Lock()
+			if _, ok := b.clients[client]; ok {
+				delete(b.clients, client)
+				close(client.send)
+			}
+			b.mu.Unlock()
+			b.logger.Logf(log.DebugLevel, "SSE client disconnected: %s", client.id)
+
+		case message := <-b.broadcast:
+			b.mu.RLock()
+			for client := range b.clients {
+				select {
+				case client.send <- message:
+				default:
+					// Client buffer full, skip
+				}
+			}
+			b.mu.RUnlock()
+
+		case <-b.stopCh:
+			b.mu.Lock()
+			for client := range b.clients {
+				close(client.send)
+				delete(b.clients, client)
+			}
+			b.mu.Unlock()
+			return
+		}
+	}
+}
+
+func (b *SSEBroadcaster) subscribeToTopic(topic string) error {
+	eventChan, err := b.stream.Consume(topic)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case event := <-eventChan:
+				b.Broadcast(event.Payload)
+			case <-b.stopCh:
+				return
+			}
+		}
+	}()
+
+	b.logger.Logf(log.InfoLevel, "SSE broadcaster subscribed to topic: %s", topic)
+	return nil
+}
+
+// Broadcast sends a message to all connected clients
+func (b *SSEBroadcaster) Broadcast(data []byte) {
+	select {
+	case b.broadcast <- data:
+	default:
+		b.logger.Log(log.WarnLevel, "SSE broadcast channel full, dropping message")
+	}
+}
+
+// BroadcastEvent sends a structured event to all connected clients
+func (b *SSEBroadcaster) BroadcastEvent(eventType string, data interface{}) error {
+	event := SSEEvent{
+		ID:    fmt.Sprintf("%d", time.Now().UnixNano()),
+		Event: eventType,
+		Data:  data,
+	}
+
+	jsonData, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	b.Broadcast(jsonData)
+	return nil
+}
+
+// BroadcastHTML sends raw HTML to clients (for htmx/datastar integration)
+func (b *SSEBroadcaster) BroadcastHTML(eventType string, html string) {
+	// Format as SSE with event type for htmx sse-swap
+	message := fmt.Sprintf("event: %s\ndata: %s\n\n", eventType, html)
+	b.Broadcast([]byte(message))
+}
+
+// ClientCount returns the number of connected clients
+func (b *SSEBroadcaster) ClientCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.clients)
+}
+
+// Handler returns an http.HandlerFunc for SSE connections
+func (b *SSEBroadcaster) Handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Check if the client supports SSE
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "SSE not supported", http.StatusInternalServerError)
+			return
+		}
+
+		// Set SSE headers
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("X-Accel-Buffering", "no") // Disable nginx buffering
+
+		// Create client
+		client := &SSEClient{
+			id:   fmt.Sprintf("%d", time.Now().UnixNano()),
+			send: make(chan []byte, 64),
+			done: make(chan struct{}),
+		}
+
+		// Register client
+		b.register <- client
+
+		// Ensure cleanup on disconnect
+		defer func() {
+			b.unregister <- client
+		}()
+
+		// Send initial connection event
+		fmt.Fprintf(w, "event: connected\ndata: {\"id\":\"%s\"}\n\n", client.id)
+		flusher.Flush()
+
+		// Keep-alive ticker
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case message, ok := <-client.send:
+				if !ok {
+					return
+				}
+				// Check if message is already SSE formatted (contains "event:" or "data:")
+				if len(message) > 0 && (message[0] == 'e' || message[0] == 'd') {
+					w.Write(message)
+				} else {
+					fmt.Fprintf(w, "data: %s\n\n", message)
+				}
+				flusher.Flush()
+
+			case <-ticker.C:
+				// Send keep-alive comment
+				fmt.Fprintf(w, ": keepalive\n\n")
+				flusher.Flush()
+
+			case <-r.Context().Done():
+				return
+			}
+		}
+	}
+}
+
+// GinHandler returns a handler compatible with Gin framework
+func (b *SSEBroadcaster) GinHandler() interface{} {
+	return b.Handler()
+}

--- a/web/sse_test.go
+++ b/web/sse_test.go
@@ -1,0 +1,137 @@
+package web
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSSEBroadcaster_Basic(t *testing.T) {
+	// Create broadcaster
+	b := NewSSEBroadcaster()
+	if err := b.Start(); err != nil {
+		t.Fatalf("Failed to start broadcaster: %v", err)
+	}
+	defer b.Stop()
+
+	// Create test server
+	server := httptest.NewServer(http.HandlerFunc(b.Handler()))
+	defer server.Close()
+
+	// Connect client
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check headers
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Expected Content-Type text/event-stream, got %s", ct)
+	}
+
+	// Read initial connection event
+	reader := bufio.NewReader(resp.Body)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("Failed to read: %v", err)
+	}
+	if !strings.HasPrefix(line, "event: connected") {
+		t.Errorf("Expected connected event, got: %s", line)
+	}
+}
+
+func TestSSEBroadcaster_BroadcastEvent(t *testing.T) {
+	b := NewSSEBroadcaster()
+	if err := b.Start(); err != nil {
+		t.Fatalf("Failed to start broadcaster: %v", err)
+	}
+	defer b.Stop()
+
+	server := httptest.NewServer(http.HandlerFunc(b.Handler()))
+	defer server.Close()
+
+	// Connect client
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Wait for client to register
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast an event
+	testData := map[string]string{"message": "hello"}
+	if err := b.BroadcastEvent("test", testData); err != nil {
+		t.Fatalf("Failed to broadcast: %v", err)
+	}
+
+	// Read and verify
+	reader := bufio.NewReader(resp.Body)
+	
+	// Skip connection event
+	for i := 0; i < 3; i++ {
+		reader.ReadString('\n')
+	}
+
+	// Read broadcast event
+	line, _ := reader.ReadString('\n')
+	if !strings.HasPrefix(line, "data:") {
+		t.Errorf("Expected data line, got: %s", line)
+	}
+
+	// Parse the data
+	dataStr := strings.TrimPrefix(line, "data: ")
+	dataStr = strings.TrimSpace(dataStr)
+	
+	var event SSEEvent
+	if err := json.Unmarshal([]byte(dataStr), &event); err != nil {
+		t.Fatalf("Failed to parse event: %v", err)
+	}
+
+	if event.Event != "test" {
+		t.Errorf("Expected event type 'test', got '%s'", event.Event)
+	}
+}
+
+func TestSSEBroadcaster_ClientCount(t *testing.T) {
+	b := NewSSEBroadcaster()
+	if err := b.Start(); err != nil {
+		t.Fatalf("Failed to start broadcaster: %v", err)
+	}
+	defer b.Stop()
+
+	server := httptest.NewServer(http.HandlerFunc(b.Handler()))
+	defer server.Close()
+
+	if count := b.ClientCount(); count != 0 {
+		t.Errorf("Expected 0 clients, got %d", count)
+	}
+
+	// Connect a client
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+
+	// Wait for registration
+	time.Sleep(50 * time.Millisecond)
+
+	if count := b.ClientCount(); count != 1 {
+		t.Errorf("Expected 1 client, got %d", count)
+	}
+
+	resp.Body.Close()
+
+	// Wait for unregistration
+	time.Sleep(50 * time.Millisecond)
+
+	if count := b.ClientCount(); count != 0 {
+		t.Errorf("Expected 0 clients after disconnect, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds Server-Sent Events (SSE) support to the web package, enabling real-time updates in web applications built with go-micro.

## Features

- `SSEBroadcaster` manages connected clients and broadcasts events
- Integrates with `events.Stream` for subscribing to topics
- Supports JSON events and raw HTML (for htmx/datastar)
- Keep-alive mechanism for long-lived connections
- Thread-safe client management

## Usage

```go
broadcaster := web.NewSSEBroadcaster(
  web.WithStream(stream),
  web.WithTopics("posts", "comments"),
)
broadcaster.Start()
router.GET("/events", broadcaster.Handler())
```

## Use Cases

- Live updates without page refresh
- htmx/datastar integration (return HTML fragments)
- Foundation for MCP (Model Context Protocol) support
- Real-time dashboards and notifications

Closes #2788