### PR TITLE
feat: add testing package for in-process service testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,14 +164,16 @@ service users
     path ./users
     port 8081
 
-service api
-    path ./api
-    port 8080
+service posts
+    path ./posts
+    port 8082
     depends users
 
 env development
     DATABASE_URL sqlite://./dev.db
 ```
+
+The gateway runs on :8080 by default, so services should use other ports.
 
 See [cmd/micro/README.md](cmd/micro/README.md) for full CLI documentation.
 

--- a/internal/website/docs/guides/testing.md
+++ b/internal/website/docs/guides/testing.md
@@ -1,0 +1,171 @@
+---
+layout: default
+---
+
+# Testing Micro Services
+
+The `testing` package provides utilities for testing micro services in isolation.
+
+## Quick Start
+
+```go
+import (
+    "testing"
+    microtesting "go-micro.dev/v5/testing"
+)
+
+func TestGreeter(t *testing.T) {
+    h := microtesting.NewHarness(t)
+    defer h.Stop()
+
+    h.Name("greeter").Register(new(GreeterHandler))
+    h.Start()
+
+    var rsp HelloResponse
+    err := h.Call("GreeterHandler.Hello", &HelloRequest{Name: "World"}, &rsp)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if rsp.Message != "Hello World" {
+        t.Errorf("expected 'Hello World', got '%s'", rsp.Message)
+    }
+}
+```
+
+## How It Works
+
+The harness creates isolated instances of:
+- **Registry** - In-memory registry for service discovery
+- **Transport** - HTTP transport for RPC
+- **Broker** - In-memory broker for events
+
+This allows your service to run without affecting or being affected by other services.
+
+## API
+
+### Creating a Harness
+
+```go
+h := microtesting.NewHarness(t)
+defer h.Stop()  // Always stop to clean up
+```
+
+### Configuring
+
+```go
+h.Name("myservice")      // Set service name (default: "test")
+h.Register(handler)      // Set the handler
+h.Start()                // Start the service
+```
+
+### Making Calls
+
+```go
+// Simple call
+err := h.Call("Handler.Method", &request, &response)
+
+// With context
+err := h.CallContext(ctx, "Handler.Method", &request, &response)
+```
+
+### Assertions
+
+```go
+// Check service is running
+h.AssertServiceRunning()
+
+// Check call succeeds
+h.AssertCallSucceeds("Handler.Method", &req, &rsp)
+
+// Check call fails
+h.AssertCallFails("Handler.Method", &req, &rsp)
+```
+
+### Advanced Access
+
+```go
+// Get the client for custom calls
+client := h.Client()
+
+// Get the server
+server := h.Server()
+
+// Get the registry
+reg := h.Registry()
+```
+
+## Example: Testing a User Service
+
+```go
+package users
+
+import (
+    "context"
+    "testing"
+    microtesting "go-micro.dev/v5/testing"
+)
+
+type UsersHandler struct {
+    users map[string]*User
+}
+
+type User struct {
+    ID   string
+    Name string
+}
+
+type CreateRequest struct {
+    Name string
+}
+
+type CreateResponse struct {
+    User *User
+}
+
+func (h *UsersHandler) Create(ctx context.Context, req *CreateRequest, rsp *CreateResponse) error {
+    user := &User{ID: "123", Name: req.Name}
+    h.users[user.ID] = user
+    rsp.User = user
+    return nil
+}
+
+func TestUsersCreate(t *testing.T) {
+    h := microtesting.NewHarness(t)
+    defer h.Stop()
+
+    handler := &UsersHandler{users: make(map[string]*User)}
+    h.Name("users").Register(handler)
+    h.Start()
+
+    var rsp CreateResponse
+    h.AssertCallSucceeds("UsersHandler.Create", &CreateRequest{Name: "Alice"}, &rsp)
+
+    if rsp.User == nil {
+        t.Fatal("user is nil")
+    }
+    if rsp.User.Name != "Alice" {
+        t.Errorf("expected Alice, got %s", rsp.User.Name)
+    }
+
+    // Verify the user was stored
+    if _, ok := handler.users["123"]; !ok {
+        t.Error("user not stored in handler")
+    }
+}
+```
+
+## Limitations
+
+Due to go-micro's global defaults, each harness should test **one service**. If you need to test service-to-service communication, consider:
+
+1. **Integration tests** - Run services as separate processes
+2. **Mock clients** - Mock the client calls to dependent services
+3. **Contract tests** - Test service interfaces separately
+
+## Tips
+
+1. **Always defer Stop()** - Ensures cleanup even if test fails
+2. **Use meaningful names** - `h.Name("users")` makes logs clearer
+3. **Test edge cases** - Use `AssertCallFails` for error paths
+4. **Keep handlers simple** - Complex handlers are harder to test

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,0 +1,231 @@
+// Package testing provides utilities for testing micro services.
+//
+// Due to go-micro's global defaults, running multiple services in one process
+// requires careful isolation. This package provides helpers for the common case
+// of testing a single service.
+//
+// Basic usage:
+//
+//	func TestUserService(t *testing.T) {
+//	    h := testing.NewHarness(t)
+//	    defer h.Stop()
+//	
+//	    // Register your service handler
+//	    h.Register(new(UsersHandler))
+//	
+//	    // Start the harness
+//	    h.Start()
+//	
+//	    // Call the service
+//	    var rsp UserResponse
+//	    err := h.Call("Users.Create", &CreateRequest{Name: "Alice"}, &rsp)
+//	    if err != nil {
+//	        t.Fatal(err)
+//	    }
+//	}
+package testing
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"go-micro.dev/v5/broker"
+	"go-micro.dev/v5/client"
+	"go-micro.dev/v5/registry"
+	"go-micro.dev/v5/server"
+	"go-micro.dev/v5/transport"
+)
+
+// Harness provides an in-process test environment for a micro service
+type Harness struct {
+	t         *testing.T
+	name      string
+	handler   interface{}
+	registry  registry.Registry
+	transport transport.Transport
+	broker    broker.Broker
+	server    server.Server
+	client    client.Client
+	started   bool
+	mu        sync.Mutex
+}
+
+// NewHarness creates a new test harness
+func NewHarness(t *testing.T) *Harness {
+	// Create isolated instances for testing
+	reg := registry.NewMemoryRegistry()
+	tr := transport.NewHTTPTransport()
+	br := broker.NewMemoryBroker()
+
+	return &Harness{
+		t:         t,
+		name:      "test",
+		registry:  reg,
+		transport: tr,
+		broker:    br,
+	}
+}
+
+// Name sets the service name (default: "test")
+func (h *Harness) Name(name string) *Harness {
+	h.name = name
+	return h
+}
+
+// Register sets the handler for the service
+func (h *Harness) Register(handler interface{}) *Harness {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.started {
+		h.t.Fatal("cannot register handler after Start()")
+	}
+
+	h.handler = handler
+	return h
+}
+
+// Start starts the service
+func (h *Harness) Start() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.started {
+		return
+	}
+
+	if h.handler == nil {
+		h.t.Fatal("no handler registered, call Register() first")
+	}
+
+	// Connect broker
+	if err := h.broker.Connect(); err != nil {
+		h.t.Fatalf("failed to connect broker: %v", err)
+	}
+
+	// Create server with isolated transport
+	h.server = server.NewServer(
+		server.Name(h.name),
+		server.Registry(h.registry),
+		server.Transport(h.transport),
+		server.Broker(h.broker),
+		server.Address("127.0.0.1:0"),
+	)
+
+	// Register handler
+	if err := h.server.Handle(h.server.NewHandler(h.handler)); err != nil {
+		h.t.Fatalf("failed to register handler: %v", err)
+	}
+
+	// Start server
+	if err := h.server.Start(); err != nil {
+		h.t.Fatalf("failed to start server: %v", err)
+	}
+
+	// Create client with same registry/transport
+	h.client = client.NewClient(
+		client.Registry(h.registry),
+		client.Transport(h.transport),
+		client.Broker(h.broker),
+		client.RequestTimeout(5*time.Second),
+	)
+
+	// Wait for registration
+	h.waitForService()
+
+	h.started = true
+}
+
+func (h *Harness) waitForService() {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		services, err := h.registry.GetService(h.name)
+		if err == nil && len(services) > 0 && len(services[0].Nodes) > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	h.t.Fatalf("service %s did not register in time", h.name)
+}
+
+// Stop stops the service
+func (h *Harness) Stop() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.server != nil {
+		h.server.Stop()
+	}
+	if h.broker != nil {
+		h.broker.Disconnect()
+	}
+
+	h.started = false
+}
+
+// Call invokes a service method
+func (h *Harness) Call(endpoint string, req, rsp interface{}) error {
+	return h.CallContext(context.Background(), endpoint, req, rsp)
+}
+
+// CallContext invokes a service method with context
+func (h *Harness) CallContext(ctx context.Context, endpoint string, req, rsp interface{}) error {
+	if !h.started {
+		return fmt.Errorf("harness not started, call Start() first")
+	}
+
+	request := h.client.NewRequest(h.name, endpoint, req)
+	return h.client.Call(ctx, request, rsp)
+}
+
+// Client returns the test client for advanced usage
+func (h *Harness) Client() client.Client {
+	return h.client
+}
+
+// Server returns the test server for advanced usage  
+func (h *Harness) Server() server.Server {
+	return h.server
+}
+
+// Registry returns the test registry for advanced usage
+func (h *Harness) Registry() registry.Registry {
+	return h.registry
+}
+
+// --- Assertions ---
+
+// AssertServiceRunning checks that the service is registered
+func (h *Harness) AssertServiceRunning() {
+	h.t.Helper()
+
+	services, err := h.registry.GetService(h.name)
+	if err != nil {
+		h.t.Errorf("service %s not found: %v", h.name, err)
+		return
+	}
+	if len(services) == 0 || len(services[0].Nodes) == 0 {
+		h.t.Errorf("service %s has no running instances", h.name)
+	}
+}
+
+// AssertCallSucceeds checks that a call succeeds
+func (h *Harness) AssertCallSucceeds(endpoint string, req, rsp interface{}) {
+	h.t.Helper()
+
+	if err := h.Call(endpoint, req, rsp); err != nil {
+		h.t.Errorf("call %s failed: %v", endpoint, err)
+	}
+}
+
+// AssertCallFails checks that a call fails
+func (h *Harness) AssertCallFails(endpoint string, req, rsp interface{}) {
+	h.t.Helper()
+
+	if err := h.Call(endpoint, req, rsp); err == nil {
+		h.t.Errorf("expected call %s to fail, but it succeeded", endpoint)
+	}
+}

--- a/testing/testing_test.go
+++ b/testing/testing_test.go
@@ -1,0 +1,111 @@
+package testing
+
+import (
+	"context"
+	"testing"
+)
+
+// Simple test handler
+type GreeterHandler struct{}
+
+type HelloRequest struct {
+	Name string `json:"name"`
+}
+
+type HelloResponse struct {
+	Message string `json:"message"`
+}
+
+func (g *GreeterHandler) Hello(ctx context.Context, req *HelloRequest, rsp *HelloResponse) error {
+	rsp.Message = "Hello " + req.Name
+	return nil
+}
+
+func TestHarnessBasic(t *testing.T) {
+	h := NewHarness(t)
+	defer h.Stop()
+
+	h.Name("greeter").Register(new(GreeterHandler))
+	h.Start()
+
+	// Check service is running
+	h.AssertServiceRunning()
+
+	// Make a call
+	var rsp HelloResponse
+	err := h.Call("GreeterHandler.Hello", &HelloRequest{Name: "World"}, &rsp)
+	if err != nil {
+		t.Fatalf("call failed: %v", err)
+	}
+
+	if rsp.Message != "Hello World" {
+		t.Errorf("expected 'Hello World', got '%s'", rsp.Message)
+	}
+}
+
+func TestHarnessCallBeforeStart(t *testing.T) {
+	h := NewHarness(t)
+	defer h.Stop()
+
+	h.Register(new(GreeterHandler))
+	// Don't call Start()
+
+	var rsp HelloResponse
+	err := h.Call("GreeterHandler.Hello", &HelloRequest{Name: "World"}, &rsp)
+	if err == nil {
+		t.Error("expected error when calling before Start()")
+	}
+}
+
+func TestHarnessAssertCallSucceeds(t *testing.T) {
+	h := NewHarness(t)
+	defer h.Stop()
+
+	h.Name("greeter").Register(new(GreeterHandler))
+	h.Start()
+
+	var rsp HelloResponse
+	h.AssertCallSucceeds("GreeterHandler.Hello", &HelloRequest{Name: "Test"}, &rsp)
+
+	if rsp.Message != "Hello Test" {
+		t.Errorf("expected 'Hello Test', got '%s'", rsp.Message)
+	}
+}
+
+func TestHarnessClientAndServer(t *testing.T) {
+	h := NewHarness(t)
+	defer h.Stop()
+
+	h.Name("greeter").Register(new(GreeterHandler))
+	h.Start()
+
+	// Check we can access client and server
+	if h.Client() == nil {
+		t.Fatal("client is nil")
+	}
+	if h.Server() == nil {
+		t.Fatal("server is nil")
+	}
+	if h.Registry() == nil {
+		t.Fatal("registry is nil")
+	}
+}
+
+func TestHarnessWithContext(t *testing.T) {
+	h := NewHarness(t)
+	defer h.Stop()
+
+	h.Name("greeter").Register(new(GreeterHandler))
+	h.Start()
+
+	ctx := context.Background()
+	var rsp HelloResponse
+	err := h.CallContext(ctx, "GreeterHandler.Hello", &HelloRequest{Name: "Context"}, &rsp)
+	if err != nil {
+		t.Fatalf("call with context failed: %v", err)
+	}
+
+	if rsp.Message != "Hello Context" {
+		t.Errorf("expected 'Hello Context', got '%s'", rsp.Message)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `testing` package for testing micro services in isolation, without needing external processes.

## Usage

```go
import microtesting "go-micro.dev/v5/testing"

func TestUserService(t *testing.T) {
    h := microtesting.NewHarness(t)
    defer h.Stop()

    h.Name("users").Register(new(UsersHandler))
    h.Start()

    var rsp CreateResponse
    err := h.Call("UsersHandler.Create", &CreateRequest{Name: "Alice"}, &rsp)
    if err != nil {
        t.Fatal(err)
    }

    if rsp.User.Name != "Alice" {
        t.Errorf("expected Alice, got %s", rsp.User.Name)
    }
}
```

## Features

- **Isolated environment** - Each harness has its own registry, transport, and broker
- **Simple API** - `Name()`, `Register()`, `Start()`, `Stop()`
- **Call helpers** - `Call()`, `CallContext()`
- **Assertions** - `AssertServiceRunning()`, `AssertCallSucceeds()`, `AssertCallFails()`
- **Advanced access** - `Client()`, `Server()`, `Registry()` for custom usage

## Design Note

Due to go-micro's global defaults (single transport, server per process), each harness tests **one service**. For multi-service testing, use integration tests or mock the client calls.

## Files

- `testing/testing.go` - Harness implementation
- `testing/testing_test.go` - Tests
- `internal/website/docs/guides/testing.md` - Documentation

Also fixes README.md example that showed conflicting port 8080 for both gateway and service.