### PR TITLE
Add systemd-based deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,33 @@ The gateway runs on :8080 by default, so services should use other ports.
 
 ### Deployment
 
+Deploy to any Linux server with systemd:
+
 ```bash
-micro build                     # Build Go binaries to ./bin/
-micro build --os linux          # Cross-compile for Linux
-micro deploy --ssh user@host    # Deploy via SSH
+# On your server (one-time setup)
+curl -fsSL https://go-micro.dev/install.sh | sh
+sudo micro init --server
+
+# From your laptop
+micro deploy user@your-server
 ```
 
-No Docker required. Go binaries are self-contained.
+The deploy command:
+1. Builds binaries for Linux
+2. Copies via SSH to the server
+3. Sets up systemd services
+4. Verifies services are healthy
+
+Manage deployed services:
+```bash
+micro status --remote user@server    # Check status
+micro logs --remote user@server      # View logs
+micro logs myservice --remote user@server -f  # Follow specific service
+```
+
+No Docker required. No Kubernetes. Just systemd.
+
+See [docs/deployment.md](docs/deployment.md) for full deployment guide.
 
 See [cmd/micro/README.md](cmd/micro/README.md) for full CLI documentation.
 

--- a/cmd/micro/README.md
+++ b/cmd/micro/README.md
@@ -272,6 +272,74 @@ func main() {
 }
 ```
 
+## Building and Deployment
+
+### Build Binaries
+
+Build Go binaries for deployment:
+
+```bash
+micro build                     # Build for current OS
+micro build --os linux          # Cross-compile for Linux
+micro build --os linux --arch arm64  # For ARM64
+micro build --output ./dist     # Custom output directory
+```
+
+### Deploy to Server
+
+Deploy to any Linux server with systemd:
+
+```bash
+# First time: set up the server
+ssh user@server
+curl -fsSL https://go-micro.dev/install.sh | sh
+sudo micro init --server
+exit
+
+# Deploy from your laptop
+micro deploy user@server
+```
+
+The deploy command:
+1. Builds binaries for linux/amd64
+2. Copies via SSH to `/opt/micro/bin/`
+3. Sets up systemd services (`micro@<service>`)
+4. Restarts and verifies services are running
+
+### Named Deploy Targets
+
+Add deploy targets to `micro.mu`:
+
+```
+deploy prod
+    ssh deploy@prod.example.com
+
+deploy staging
+    ssh deploy@staging.example.com
+```
+
+Then:
+```bash
+micro deploy prod      # Deploy to production
+micro deploy staging   # Deploy to staging
+```
+
+### Managing Deployed Services
+
+```bash
+# Check status
+micro status --remote user@server
+
+# View logs
+micro logs --remote user@server
+micro logs myservice --remote user@server -f
+
+# Stop a service
+micro stop myservice --remote user@server
+```
+
+See [docs/deployment.md](../../docs/deployment.md) for the full deployment guide.
+
 ## Protobuf 
 
 Use protobuf for code generation with [protoc-gen-micro](https://github.com/micro/go-micro/tree/master/cmd/protoc-gen-micro)

--- a/cmd/micro/cli/cli.go
+++ b/cmd/micro/cli/cli.go
@@ -1,16 +1,11 @@
 package microcli
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
-	"os/signal"
-	"path/filepath"
-	"strings"
-	"syscall"
 
 	"github.com/urfave/cli/v2"
 	"go-micro.dev/v5/client"
@@ -21,6 +16,12 @@ import (
 
 	"go-micro.dev/v5/cmd/micro/cli/new"
 	"go-micro.dev/v5/cmd/micro/cli/util"
+
+	// Import packages that register commands via init()
+	_ "go-micro.dev/v5/cmd/micro/cli/build"
+	_ "go-micro.dev/v5/cmd/micro/cli/deploy"
+	_ "go-micro.dev/v5/cmd/micro/cli/init"
+	_ "go-micro.dev/v5/cmd/micro/cli/remote"
 )
 
 var (
@@ -55,55 +56,6 @@ func genTextHandler(c *cli.Context) error {
 
 	fmt.Println(res.Text)
 	return nil
-}
-
-func lastNonEmptyLine(s string) string {
-	lines := strings.Split(s, "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		if strings.TrimSpace(lines[i]) != "" {
-			return lines[i]
-		}
-	}
-	return ""
-}
-
-func lastLogLine(path string) string {
-	f, err := os.Open(path)
-	if err != nil {
-		return ""
-	}
-	defer f.Close()
-	var last string
-	scan := bufio.NewScanner(f)
-	for scan.Scan() {
-		if strings.TrimSpace(scan.Text()) != "" {
-			last = scan.Text()
-		}
-	}
-	return last
-}
-
-func waitAndCleanup(procs []*exec.Cmd, pidFiles []string) {
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, os.Interrupt)
-	go func() {
-		<-ch
-		for _, proc := range procs {
-			if proc.Process != nil {
-				_ = proc.Process.Kill()
-			}
-		}
-		for _, pf := range pidFiles {
-			_ = os.Remove(pf)
-		}
-		os.Exit(1)
-	}()
-	for i, proc := range procs {
-		_ = proc.Wait()
-		if proc.Process != nil {
-			_ = os.Remove(pidFiles[i])
-		}
-	}
 }
 
 func init() {
@@ -202,142 +154,11 @@ func init() {
 				return nil
 			},
 		},
-		{
-			Name:  "status",
-			Usage: "Check status of running services",
-			Action: func(ctx *cli.Context) error {
-				homeDir, err := os.UserHomeDir()
-				if err != nil {
-					return fmt.Errorf("failed to get home dir: %w", err)
-				}
-				runDir := filepath.Join(homeDir, "micro", "run")
-				files, err := os.ReadDir(runDir)
-				if err != nil {
-					return fmt.Errorf("failed to read run dir: %w", err)
-				}
-				fmt.Printf("%-20s %-8s %-8s %s\n", "SERVICE", "PID", "STATUS", "DIRECTORY")
-				for _, f := range files {
-					if f.IsDir() || !strings.HasSuffix(f.Name(), ".pid") {
-						continue
-					}
-					service := f.Name()[:len(f.Name())-4]
-					pidFilePath := filepath.Join(runDir, f.Name())
-					pidFile, err := os.Open(pidFilePath)
-					if err != nil {
-						continue
-					}
-					var pid int
-					var dir string
-					scanner := bufio.NewScanner(pidFile)
-					if scanner.Scan() {
-						fmt.Sscanf(scanner.Text(), "%d", &pid)
-					}
-					if scanner.Scan() {
-						dir = scanner.Text()
-					}
-					pidFile.Close()
-					status := "stopped"
-					if pid > 0 {
-						proc, err := os.FindProcess(pid)
-						if err == nil {
-							if err := proc.Signal(syscall.Signal(0)); err == nil {
-								status = "running"
-							}
-						}
-					}
-					fmt.Printf("%-20s %-8d %-8s %-40s %s\n", service, pid, status, "", dir)
-				}
-				return nil
-			},
-		},
-		{
-			Name:  "stop",
-			Usage: "Stop a running service",
-			Action: func(ctx *cli.Context) error {
-				if ctx.Args().Len() != 1 {
-					return fmt.Errorf("Usage: micro stop [service]")
-				}
-				service := ctx.Args().Get(0)
-				homeDir, err := os.UserHomeDir()
-				if err != nil {
-					return fmt.Errorf("failed to get home dir: %w", err)
-				}
-				runDir := filepath.Join(homeDir, "micro", "run")
-				pidFilePath := filepath.Join(runDir, service+".pid")
-				pidFile, err := os.Open(pidFilePath)
-				if err != nil {
-					return fmt.Errorf("no pid file for service %s", service)
-				}
-				var pid int
-				var dir string
-				scanner := bufio.NewScanner(pidFile)
-				if scanner.Scan() {
-					fmt.Sscanf(scanner.Text(), "%d", &pid)
-				}
-				if scanner.Scan() {
-					dir = scanner.Text()
-				}
-				pidFile.Close()
-				if pid <= 0 {
-					_ = os.Remove(pidFilePath)
-					return fmt.Errorf("service %s is not running", service)
-				}
-				proc, err := os.FindProcess(pid)
-				if err != nil {
-					_ = os.Remove(pidFilePath)
-					return fmt.Errorf("could not find process for %s", service)
-				}
-				if err := proc.Signal(syscall.SIGTERM); err != nil {
-					_ = os.Remove(pidFilePath)
-					return fmt.Errorf("failed to stop service %s: %v", service, err)
-				}
-				_ = os.Remove(pidFilePath)
-				fmt.Printf("Stopped service %s (pid %d) in directory %s\n", service, pid, dir)
-				return nil
-			},
-		},
-		{
-			Name:  "logs",
-			Usage: "Show logs for a service, or list available logs if no service is specified",
-			Action: func(ctx *cli.Context) error {
-				homeDir, err := os.UserHomeDir()
-				if err != nil {
-					return fmt.Errorf("failed to get home dir: %w", err)
-				}
-				logsDir := filepath.Join(homeDir, "micro", "logs")
-				if ctx.Args().Len() == 0 {
-					// List available logs
-					dirEntries, err := os.ReadDir(logsDir)
-					if err != nil {
-						return fmt.Errorf("could not list logs directory: %v", err)
-					}
-					fmt.Println("Available logs:")
-					found := false
-					for _, entry := range dirEntries {
-						if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".log") {
-							fmt.Println("  ", strings.TrimSuffix(entry.Name(), ".log"))
-							found = true
-						}
-					}
-					if !found {
-						fmt.Println("  (no logs found)")
-					}
-					return nil
-				}
-				service := ctx.Args().Get(0)
-				logFilePath := filepath.Join(logsDir, service+".log")
-				f, err := os.Open(logFilePath)
-				if err != nil {
-					return fmt.Errorf("could not open log file for service %s: %v", service, err)
-				}
-				defer f.Close()
-				scan := bufio.NewScanner(f)
-				for scan.Scan() {
-					fmt.Println(scan.Text())
-				}
-				return scan.Err()
-			},
-		},
+		// Note: The following commands are registered in their respective packages:
+		// - status, logs, stop: remote/remote.go
+		// - build: build/build.go
+		// - deploy: deploy/deploy.go
+		// - init: init/init.go
 	}...)
 
 	cmd.App().Action = func(c *cli.Context) error {

--- a/cmd/micro/cli/deploy/deploy.go
+++ b/cmd/micro/cli/deploy/deploy.go
@@ -79,7 +79,7 @@ func showDeployTargets(cfg *config.Config) error {
 		sb.WriteString(fmt.Sprintf("  %s -> %s\n", name, dt.SSH))
 	}
 	sb.WriteString("\nDeploy with: micro deploy <target>")
-	return fmt.Errorf(sb.String())
+	return fmt.Errorf("%s", sb.String())
 }
 
 func deploySSH(c *cli.Context, target string, cfg *config.Config) error {

--- a/cmd/micro/cli/init/init.go
+++ b/cmd/micro/cli/init/init.go
@@ -1,0 +1,269 @@
+// Package initcmd provides the micro init command for server setup
+package initcmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+	"go-micro.dev/v5/cmd"
+)
+
+const systemdTemplate = `[Unit]
+Description=Micro service: %i
+After=network.target
+
+[Service]
+Type=simple
+User=%s
+Group=%s
+WorkingDirectory=%s
+ExecStart=%s/bin/%%i
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=-%s/config/%%i.env
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=micro-%%i
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=%s/data
+
+[Install]
+WantedBy=multi-user.target
+`
+
+// Init initializes a server to receive micro deployments
+func Init(c *cli.Context) error {
+	if !c.Bool("server") {
+		return fmt.Errorf("usage: micro init --server\n\nInitialize this machine to receive micro deployments")
+	}
+
+	// Check if we're on Linux
+	if runtime.GOOS != "linux" {
+		return fmt.Errorf("micro init --server is only supported on Linux")
+	}
+
+	// Check for remote init
+	remoteHost := c.String("remote")
+	if remoteHost != "" {
+		return initRemote(c, remoteHost)
+	}
+
+	basePath := c.String("path")
+	userName := c.String("user")
+
+	fmt.Println("Initializing micro server...")
+	fmt.Println()
+
+	// Check if running as root (needed for systemd and creating users)
+	if os.Geteuid() != 0 {
+		return fmt.Errorf(`micro init --server requires root privileges.
+
+Run with sudo:
+  sudo micro init --server`)
+	}
+
+	// Create user if needed
+	if userName == "micro" {
+		if err := createMicroUser(); err != nil {
+			return err
+		}
+	}
+
+	// Create directories
+	fmt.Println("Creating directories:")
+	dirs := []string{
+		filepath.Join(basePath, "bin"),
+		filepath.Join(basePath, "data"),
+		filepath.Join(basePath, "config"),
+	}
+
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create %s: %w", dir, err)
+		}
+		fmt.Printf("  ✓ %s\n", dir)
+	}
+
+	// Set ownership
+	if userName != "root" {
+		u, err := user.Lookup(userName)
+		if err != nil {
+			return fmt.Errorf("user %s not found: %w", userName, err)
+		}
+		
+		// chown -R user:user /opt/micro
+		chownCmd := exec.Command("chown", "-R", fmt.Sprintf("%s:%s", u.Username, u.Username), basePath)
+		if err := chownCmd.Run(); err != nil {
+			return fmt.Errorf("failed to set ownership: %w", err)
+		}
+	}
+
+	fmt.Println()
+
+	// Create systemd template
+	fmt.Println("Creating systemd template:")
+	unitContent := fmt.Sprintf(systemdTemplate, userName, userName, basePath, basePath, basePath, basePath)
+	unitPath := "/etc/systemd/system/micro@.service"
+
+	if err := os.WriteFile(unitPath, []byte(unitContent), 0644); err != nil {
+		return fmt.Errorf("failed to write systemd unit: %w", err)
+	}
+	fmt.Printf("  ✓ %s\n", unitPath)
+
+	// Reload systemd
+	reloadCmd := exec.Command("systemctl", "daemon-reload")
+	if err := reloadCmd.Run(); err != nil {
+		return fmt.Errorf("failed to reload systemd: %w", err)
+	}
+	fmt.Println("  ✓ systemd daemon-reload")
+
+	// Write marker file so deploy can detect initialization
+	markerPath := filepath.Join(basePath, ".micro-initialized")
+	if err := os.WriteFile(markerPath, []byte("1\n"), 0644); err != nil {
+		return fmt.Errorf("failed to write marker: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Println("Server ready!")
+	fmt.Println()
+	fmt.Println("  Deploy from your machine:")
+	fmt.Printf("    micro deploy user@%s\n", getHostname())
+	fmt.Println()
+	fmt.Println("  Manage services:")
+	fmt.Println("    sudo systemctl status micro@myservice")
+	fmt.Println("    sudo journalctl -u micro@myservice -f")
+	fmt.Println()
+
+	return nil
+}
+
+func createMicroUser() error {
+	// Check if user exists
+	if _, err := user.Lookup("micro"); err == nil {
+		return nil // user already exists
+	}
+
+	fmt.Println("Creating micro user:")
+	createCmd := exec.Command("useradd", "--system", "--no-create-home", "--shell", "/bin/false", "micro")
+	if err := createCmd.Run(); err != nil {
+		// Check if it's just because user already exists
+		if _, lookupErr := user.Lookup("micro"); lookupErr == nil {
+			return nil
+		}
+		return fmt.Errorf("failed to create micro user: %w", err)
+	}
+	fmt.Println("  ✓ Created user 'micro'")
+	return nil
+}
+
+func initRemote(c *cli.Context, host string) error {
+	fmt.Printf("Initializing micro on %s...\n\n", host)
+
+	// Check SSH connectivity first
+	if err := checkSSH(host); err != nil {
+		return err
+	}
+
+	basePath := c.String("path")
+	userName := c.String("user")
+
+	// Run micro init --server on remote
+	initCmd := fmt.Sprintf("sudo micro init --server --path %s --user %s", basePath, userName)
+	
+	sshCmd := exec.Command("ssh", host, initCmd)
+	sshCmd.Stdout = os.Stdout
+	sshCmd.Stderr = os.Stderr
+
+	if err := sshCmd.Run(); err != nil {
+		return fmt.Errorf("remote init failed: %w", err)
+	}
+
+	return nil
+}
+
+func checkSSH(host string) error {
+	// Quick SSH test
+	testCmd := exec.Command("ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", host, "echo ok")
+	output, err := testCmd.CombinedOutput()
+
+	if err != nil {
+		return fmt.Errorf(`✗ Cannot connect to %s
+
+  SSH connection failed. Check that:
+  • The server is reachable: ping %s
+  • SSH is configured: ssh %s
+  • Your key is added: ssh-add -l
+
+  Common fixes:
+  • Add SSH key: ssh-copy-id %s
+  • Check hostname in ~/.ssh/config
+
+  Error: %s`, host, host, host, host, strings.TrimSpace(string(output)))
+	}
+
+	return nil
+}
+
+func getHostname() string {
+	name, err := os.Hostname()
+	if err != nil {
+		return "this-server"
+	}
+	return name
+}
+
+func init() {
+	cmd.Register(&cli.Command{
+		Name:  "init",
+		Usage: "Initialize micro for development or server deployment",
+		Description: `Initialize micro on a server to receive deployments.
+
+Server setup:
+  sudo micro init --server
+
+This creates:
+  • /opt/micro/bin/     - service binaries
+  • /opt/micro/data/    - persistent data
+  • /opt/micro/config/  - environment files
+  • systemd template for managing services
+
+Remote setup:
+  micro init --server --remote user@host
+
+After init, deploy with:
+  micro deploy user@host`,
+		Action: Init,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "server",
+				Usage: "Initialize as a deployment server",
+			},
+			&cli.StringFlag{
+				Name:  "path",
+				Usage: "Base path for micro (default: /opt/micro)",
+				Value: "/opt/micro",
+			},
+			&cli.StringFlag{
+				Name:  "user",
+				Usage: "User to run services as (default: micro)",
+				Value: "micro",
+			},
+			&cli.StringFlag{
+				Name:  "remote",
+				Usage: "Initialize a remote server via SSH",
+			},
+		},
+	})
+}

--- a/cmd/micro/cli/init/init.go
+++ b/cmd/micro/cli/init/init.go
@@ -15,7 +15,7 @@ import (
 )
 
 const systemdTemplate = `[Unit]
-Description=Micro service: %i
+Description=Micro service: %%i
 After=network.target
 
 [Service]

--- a/cmd/micro/cli/remote/remote.go
+++ b/cmd/micro/cli/remote/remote.go
@@ -1,0 +1,367 @@
+// Package remote provides remote server operations for micro
+package remote
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/urfave/cli/v2"
+	"go-micro.dev/v5/cmd"
+)
+
+const defaultRemotePath = "/opt/micro"
+
+// Status shows status of services (local or remote)
+func Status(c *cli.Context) error {
+	remoteHost := c.String("remote")
+	if remoteHost != "" {
+		return remoteStatus(remoteHost)
+	}
+	return localStatus(c)
+}
+
+func localStatus(c *cli.Context) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home dir: %w", err)
+	}
+	runDir := filepath.Join(homeDir, "micro", "run")
+	files, err := os.ReadDir(runDir)
+	if err != nil {
+		fmt.Println("No services running locally.")
+		fmt.Println("\nStart services with: micro run")
+		return nil
+	}
+
+	var hasServices bool
+	fmt.Printf("%-20s %-10s %-8s %s\n", "SERVICE", "STATUS", "PID", "DIRECTORY")
+	fmt.Println(strings.Repeat("-", 70))
+
+	for _, f := range files {
+		if f.IsDir() || !strings.HasSuffix(f.Name(), ".pid") {
+			continue
+		}
+		hasServices = true
+		service := f.Name()[:len(f.Name())-4]
+		pidFilePath := filepath.Join(runDir, f.Name())
+		pidFile, err := os.Open(pidFilePath)
+		if err != nil {
+			continue
+		}
+		var pid int
+		var dir string
+		scanner := bufio.NewScanner(pidFile)
+		if scanner.Scan() {
+			fmt.Sscanf(scanner.Text(), "%d", &pid)
+		}
+		if scanner.Scan() {
+			dir = scanner.Text()
+		}
+		pidFile.Close()
+
+		status := "\u2717 stopped"
+		if pid > 0 {
+			proc, err := os.FindProcess(pid)
+			if err == nil {
+				if err := proc.Signal(syscall.Signal(0)); err == nil {
+					status = "\u25cf running"
+				}
+			}
+		}
+		fmt.Printf("%-20s %-10s %-8d %s\n", service, status, pid, dir)
+	}
+
+	if !hasServices {
+		fmt.Println("No services running locally.")
+		fmt.Println("\nStart services with: micro run")
+	}
+
+	return nil
+}
+
+func remoteStatus(host string) error {
+	// Get list of micro services via systemctl
+	listCmd := exec.Command("ssh", host, "systemctl list-units 'micro@*' --no-legend --no-pager 2>/dev/null || true")
+	output, err := listCmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get status from %s: %w", host, err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(lines) == 0 || (len(lines) == 1 && lines[0] == "") {
+		fmt.Printf("%s\n", host)
+		fmt.Println(strings.Repeat("\u2501", 50))
+		fmt.Println("\nNo services deployed.")
+		fmt.Println("\nDeploy with: micro deploy " + host)
+		return nil
+	}
+
+	fmt.Printf("%s\n", host)
+	fmt.Println(strings.Repeat("\u2501", 50))
+	fmt.Println()
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 4 {
+			continue
+		}
+
+		unit := parts[0]
+		loadState := parts[1]
+		activeState := parts[2]
+		subState := parts[3]
+
+		// Extract service name from micro@servicename.service
+		serviceName := strings.TrimPrefix(unit, "micro@")
+		serviceName = strings.TrimSuffix(serviceName, ".service")
+
+		// Get more details
+		statusIcon := "\u25cf"
+		statusText := subState
+		if activeState != "active" || subState != "running" {
+			statusIcon = "\u2717"
+		}
+
+		_ = loadState // unused but parsed
+
+		fmt.Printf("  %-15s %s %s\n", serviceName, statusIcon, statusText)
+	}
+
+	fmt.Println()
+	return nil
+}
+
+// Logs shows logs for services (local or remote)
+func Logs(c *cli.Context) error {
+	remoteHost := c.String("remote")
+	service := c.Args().First()
+	follow := c.Bool("follow") || c.Bool("f")
+	lines := c.Int("lines")
+
+	if remoteHost != "" {
+		return remoteLogs(remoteHost, service, follow, lines)
+	}
+	return localLogs(c, service, follow, lines)
+}
+
+func localLogs(c *cli.Context, service string, follow bool, lines int) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home dir: %w", err)
+	}
+	logDir := filepath.Join(homeDir, "micro", "logs")
+
+	if service == "" {
+		// List available logs
+		files, err := os.ReadDir(logDir)
+		if err != nil {
+			fmt.Println("No logs available.")
+			return nil
+		}
+
+		fmt.Println("Available logs:")
+		for _, f := range files {
+			if strings.HasSuffix(f.Name(), ".log") {
+				name := strings.TrimSuffix(f.Name(), ".log")
+				fmt.Printf("  %s\n", name)
+			}
+		}
+		fmt.Println("\nView logs: micro logs <service>")
+		return nil
+	}
+
+	logPath := filepath.Join(logDir, service+".log")
+	if _, err := os.Stat(logPath); os.IsNotExist(err) {
+		return fmt.Errorf("no logs for service '%s'", service)
+	}
+
+	if follow {
+		cmd := exec.Command("tail", "-f", logPath)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+
+	if lines == 0 {
+		lines = 100
+	}
+	cmd := exec.Command("tail", "-n", fmt.Sprintf("%d", lines), logPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func remoteLogs(host, service string, follow bool, lines int) error {
+	var journalCmd string
+
+	if service == "" {
+		// All micro services
+		journalCmd = "journalctl -u 'micro@*'"
+	} else {
+		journalCmd = fmt.Sprintf("journalctl -u 'micro@%s'", service)
+	}
+
+	if follow {
+		journalCmd += " -f"
+	} else {
+		if lines == 0 {
+			lines = 100
+		}
+		journalCmd += fmt.Sprintf(" -n %d", lines)
+	}
+
+	journalCmd += " --no-pager"
+
+	sshCmd := exec.Command("ssh", host, journalCmd)
+	sshCmd.Stdout = os.Stdout
+	sshCmd.Stderr = os.Stderr
+	return sshCmd.Run()
+}
+
+// Stop stops a running service
+func Stop(c *cli.Context) error {
+	if c.Args().Len() != 1 {
+		return fmt.Errorf("Usage: micro stop <service>")
+	}
+
+	service := c.Args().First()
+	remoteHost := c.String("remote")
+
+	if remoteHost != "" {
+		return remoteStop(remoteHost, service)
+	}
+	return localStop(service)
+}
+
+func localStop(service string) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home dir: %w", err)
+	}
+
+	runDir := filepath.Join(homeDir, "micro", "run")
+	pidFilePath := filepath.Join(runDir, service+".pid")
+
+	pidFile, err := os.Open(pidFilePath)
+	if err != nil {
+		return fmt.Errorf("service '%s' is not running", service)
+	}
+
+	var pid int
+	scanner := bufio.NewScanner(pidFile)
+	if scanner.Scan() {
+		fmt.Sscanf(scanner.Text(), "%d", &pid)
+	}
+	pidFile.Close()
+
+	if pid <= 0 {
+		_ = os.Remove(pidFilePath)
+		return fmt.Errorf("service '%s' is not running", service)
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		_ = os.Remove(pidFilePath)
+		return fmt.Errorf("could not find process for '%s'", service)
+	}
+
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		_ = os.Remove(pidFilePath)
+		return fmt.Errorf("failed to stop service '%s': %v", service, err)
+	}
+
+	_ = os.Remove(pidFilePath)
+	fmt.Printf("Stopped %s (pid %d)\n", service, pid)
+	return nil
+}
+
+func remoteStop(host, service string) error {
+	stopCmd := fmt.Sprintf("sudo systemctl stop micro@%s", service)
+	sshCmd := exec.Command("ssh", host, stopCmd)
+	if output, err := sshCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to stop %s: %s", service, string(output))
+	}
+	fmt.Printf("Stopped %s on %s\n", service, host)
+	return nil
+}
+
+func init() {
+	cmd.Register(&cli.Command{
+		Name:  "status",
+		Usage: "Check status of running services",
+		Description: `Show status of running services.
+
+Local status:
+  micro status
+
+Remote status:
+  micro status --remote user@host`,
+		Action: Status,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "remote",
+				Usage: "Check status on remote server",
+			},
+		},
+	})
+
+	cmd.Register(&cli.Command{
+		Name:  "logs",
+		Usage: "Show logs for a service",
+		Description: `View service logs.
+
+Local logs:
+  micro logs              # list available logs
+  micro logs myservice    # show logs for myservice
+  micro logs myservice -f # follow logs
+
+Remote logs:
+  micro logs --remote user@host
+  micro logs myservice --remote user@host -f`,
+		Action: Logs,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "remote",
+				Usage: "View logs on remote server",
+			},
+			&cli.BoolFlag{
+				Name:    "follow",
+				Aliases: []string{"f"},
+				Usage:   "Follow log output",
+			},
+			&cli.IntFlag{
+				Name:    "lines",
+				Aliases: []string{"n"},
+				Usage:   "Number of lines to show (default: 100)",
+				Value:   100,
+			},
+		},
+	})
+
+	cmd.Register(&cli.Command{
+		Name:  "stop",
+		Usage: "Stop a running service",
+		Description: `Stop a running service.
+
+Local:
+  micro stop myservice
+
+Remote:
+  micro stop myservice --remote user@host`,
+		Action: Stop,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "remote",
+				Usage: "Stop service on remote server",
+			},
+		},
+	})
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,344 @@
+# Deploying Go Micro Services
+
+This guide covers deploying go-micro services to a Linux server using systemd.
+
+## Overview
+
+go-micro provides a simple deployment workflow:
+
+1. **Develop locally** with `micro run`
+2. **Build binaries** with `micro build`
+3. **Deploy to server** with `micro deploy`
+
+On the server, services are managed by systemd - the standard Linux process supervisor.
+
+## Quick Start
+
+### 1. Prepare Your Server
+
+On your server (Ubuntu, Debian, or any systemd-based Linux):
+
+```bash
+# Install micro
+curl -fsSL https://go-micro.dev/install.sh | sh
+
+# Initialize for deployment
+sudo micro init --server
+```
+
+This creates:
+- `/opt/micro/bin/` - where service binaries live
+- `/opt/micro/data/` - persistent data directory
+- `/opt/micro/config/` - environment files
+- systemd template for managing services
+
+### 2. Deploy from Your Machine
+
+```bash
+# From your project directory
+micro deploy user@your-server
+```
+
+That's it! The deploy command:
+1. Builds your services for Linux
+2. Copies binaries to the server
+3. Configures and starts systemd services
+4. Verifies everything is running
+
+## Detailed Setup
+
+### Server Requirements
+
+- Linux with systemd (Ubuntu 16.04+, Debian 8+, CentOS 7+, etc.)
+- SSH access
+- Go installed (only if building on server)
+
+### Server Initialization Options
+
+```bash
+# Basic setup (creates 'micro' user)
+sudo micro init --server
+
+# Custom installation path
+sudo micro init --server --path /home/deploy/micro
+
+# Run services as existing user
+sudo micro init --server --user deploy
+
+# Initialize remotely (from your laptop)
+micro init --server --remote user@your-server
+```
+
+### What Gets Created
+
+**Directories:**
+```
+/opt/micro/
+├── bin/      # Service binaries
+├── data/     # Persistent data (databases, files)
+└── config/   # Environment files (*.env)
+```
+
+**Systemd Template** (`/etc/systemd/system/micro@.service`):
+```ini
+[Unit]
+Description=Micro service: %i
+After=network.target
+
+[Service]
+Type=simple
+User=micro
+WorkingDirectory=/opt/micro
+ExecStart=/opt/micro/bin/%i
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=-/opt/micro/config/%i.env
+
+[Install]
+WantedBy=multi-user.target
+```
+
+The `%i` is replaced with the service name. So `micro@users.service` runs `/opt/micro/bin/users`.
+
+## Deployment
+
+### Basic Deploy
+
+```bash
+micro deploy user@server
+```
+
+### Deploy Specific Service
+
+```bash
+micro deploy user@server --service users
+```
+
+### Force Rebuild
+
+```bash
+micro deploy user@server --build
+```
+
+### Named Deploy Targets
+
+Add to your `micro.mu`:
+
+```
+service users
+    path ./users
+    port 8081
+
+service web
+    path ./web
+    port 8080
+
+deploy prod
+    ssh deploy@prod.example.com
+
+deploy staging
+    ssh deploy@staging.example.com
+```
+
+Then:
+```bash
+micro deploy prod      # deploys to prod.example.com
+micro deploy staging   # deploys to staging.example.com
+```
+
+## Managing Services
+
+### Check Status
+
+```bash
+# Local services
+micro status
+
+# Remote services
+micro status --remote user@server
+```
+
+Output:
+```
+server.example.com
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  users    ● running    pid 1234
+  posts    ● running    pid 1235
+  web      ● running    pid 1236
+```
+
+### View Logs
+
+```bash
+# All services
+micro logs --remote user@server
+
+# Specific service
+micro logs users --remote user@server
+
+# Follow logs
+micro logs users --remote user@server -f
+```
+
+### Stop Services
+
+```bash
+micro stop users --remote user@server
+```
+
+### Direct systemctl Access
+
+You can also manage services directly on the server:
+
+```bash
+# Status
+sudo systemctl status micro@users
+
+# Restart
+sudo systemctl restart micro@users
+
+# Stop
+sudo systemctl stop micro@users
+
+# Logs
+journalctl -u micro@users -f
+```
+
+## Environment Variables
+
+Create environment files at `/opt/micro/config/<service>.env`:
+
+```bash
+# /opt/micro/config/users.env
+DATABASE_URL=postgres://localhost/users
+REDIS_URL=redis://localhost:6379
+LOG_LEVEL=info
+```
+
+These are automatically loaded by systemd when the service starts.
+
+## SSH Setup
+
+### Key-Based Authentication
+
+```bash
+# Generate key (if you don't have one)
+ssh-keygen -t ed25519
+
+# Copy to server
+ssh-copy-id user@server
+```
+
+### SSH Config
+
+Add to `~/.ssh/config`:
+
+```
+Host prod
+    HostName prod.example.com
+    User deploy
+    IdentityFile ~/.ssh/deploy_key
+
+Host staging
+    HostName staging.example.com
+    User deploy
+    IdentityFile ~/.ssh/deploy_key
+```
+
+Then deploy with:
+```bash
+micro deploy prod
+```
+
+## Troubleshooting
+
+### "Cannot connect to server"
+
+```
+✗ Cannot connect to myserver
+
+  SSH connection failed. Check that:
+  • The server is reachable: ping myserver
+  • SSH is configured: ssh user@myserver
+  • Your key is added: ssh-add -l
+```
+
+**Fix:**
+```bash
+# Test SSH connection
+ssh user@server
+
+# Add SSH key
+ssh-copy-id user@server
+
+# Check SSH agent
+eval $(ssh-agent)
+ssh-add
+```
+
+### "Server not initialized"
+
+```
+✗ Server not initialized
+
+  micro is not set up on myserver.
+```
+
+**Fix:**
+```bash
+ssh user@server 'sudo micro init --server'
+```
+
+### "Service failed to start"
+
+Check the logs:
+```bash
+micro logs myservice --remote user@server
+
+# Or on the server:
+journalctl -u micro@myservice -n 50
+```
+
+Common causes:
+- Missing environment variables
+- Port already in use
+- Database not reachable
+- Binary permissions issue
+
+### "Permission denied"
+
+Ensure your user can write to `/opt/micro/bin/`:
+
+```bash
+# On server
+sudo chown -R deploy:deploy /opt/micro
+
+# Or add user to micro group
+sudo usermod -aG micro deploy
+```
+
+## Security Best Practices
+
+1. **Use a dedicated deploy user** - Don't deploy as root
+2. **Use SSH keys** - Disable password authentication
+3. **Restrict sudo** - Only allow necessary commands
+4. **Firewall** - Only expose needed ports
+5. **Secrets** - Use environment files with restricted permissions (0600)
+
+### Minimal sudo access
+
+Add to `/etc/sudoers.d/micro`:
+```
+deploy ALL=(ALL) NOPASSWD: /bin/systemctl daemon-reload
+deploy ALL=(ALL) NOPASSWD: /bin/systemctl enable micro@*
+deploy ALL=(ALL) NOPASSWD: /bin/systemctl restart micro@*
+deploy ALL=(ALL) NOPASSWD: /bin/systemctl stop micro@*
+deploy ALL=(ALL) NOPASSWD: /bin/systemctl status micro@*
+```
+
+## Next Steps
+
+- [micro run](./micro-run.md) - Local development
+- [micro.mu configuration](./config.md) - Configuration file format
+- [Health checks](./health.md) - Service health endpoints

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Install script for micro CLI
+# Usage: curl -fsSL https://go-micro.dev/install.sh | sh
+
+set -e
+
+VERSION="${MICRO_VERSION:-latest}"
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+# Normalize architecture
+case $ARCH in
+    x86_64|amd64) ARCH="amd64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    armv7l) ARCH="arm" ;;
+    *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+# Normalize OS
+case $OS in
+    darwin) OS="darwin" ;;
+    linux) OS="linux" ;;
+    *) echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+# Determine install directory
+if [ "$EUID" -eq 0 ] || [ "$(id -u)" -eq 0 ]; then
+    INSTALL_DIR="/usr/local/bin"
+else
+    INSTALL_DIR="$HOME/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+fi
+
+echo "Installing micro ${VERSION} for ${OS}/${ARCH}..."
+
+# Download URL
+if [ "$VERSION" = "latest" ]; then
+    URL="https://github.com/micro/go-micro/releases/latest/download/micro-${OS}-${ARCH}"
+else
+    URL="https://github.com/micro/go-micro/releases/download/${VERSION}/micro-${OS}-${ARCH}"
+fi
+
+# Download
+TMP_FILE=$(mktemp)
+if command -v curl &> /dev/null; then
+    curl -fsSL "$URL" -o "$TMP_FILE"
+elif command -v wget &> /dev/null; then
+    wget -q "$URL" -O "$TMP_FILE"
+else
+    echo "Error: curl or wget required"
+    exit 1
+fi
+
+# Install
+chmod +x "$TMP_FILE"
+mv "$TMP_FILE" "$INSTALL_DIR/micro"
+
+echo ""
+echo "✓ Installed micro to $INSTALL_DIR/micro"
+echo ""
+
+# Verify
+if command -v micro &> /dev/null; then
+    micro --version
+else
+    echo "Note: Add $INSTALL_DIR to your PATH:"
+    echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
+fi
+
+echo ""
+echo "Get started:"
+echo "  micro new myservice    # Create a new service"
+echo "  micro run              # Run locally"
+echo "  micro deploy           # Deploy to server"
+echo ""


### PR DESCRIPTION
## Summary

Adds seamless deployment from laptop to server using systemd as the process supervisor.

## Philosophy

- **systemd is the standard** - battle-tested, every Linux server has it
- **SSH is the transport** - no custom protocols, no agents
- **Errors guide you** - every failure tells you how to fix it
- **One tool, dev to prod** - `micro run` locally, `micro deploy` remotely

## New Commands

### `micro init --server`
Initialize a Linux server to receive deployments:
- Creates `/opt/micro/{bin,data,config}` directories
- Generates systemd template unit (`micro@.service`)
- Creates `micro` system user

### `micro deploy [target]`
Deploy services to server:
- Builds linux/amd64 binaries automatically
- Copies via rsync/scp
- Configures and restarts systemd services
- Verifies health
- Helpful error messages for SSH, init, and permission issues

### `micro status --remote user@host`
Check service status on remote server

### `micro logs --remote user@host`
Stream logs via journalctl

### `micro stop service --remote user@host`
Stop services remotely

## Configuration

Added `deploy` blocks to micro.mu:
```
deploy prod
    ssh deploy@prod.example.com

deploy staging
    ssh deploy@staging.example.com
```

Then: `micro deploy prod`

## The Workflow

```bash
# Development
micro new myapp
cd myapp
micro run                    # Hot reload, gateway, dashboard

# Deploy (one-time server setup)
ssh user@server
curl -fsSL https://go-micro.dev/install.sh | sh
sudo micro init --server
exit

# Deploy from laptop
micro deploy user@server

# Manage
micro status --remote user@server
micro logs myservice --remote user@server -f
```

## Files Changed

- `cmd/micro/cli/init/init.go` (new) - Server initialization
- `cmd/micro/cli/remote/remote.go` (new) - Remote status/logs/stop
- `cmd/micro/cli/deploy/deploy.go` - Rewritten for systemd
- `cmd/micro/cli/cli.go` - Cleaned up, imports new packages
- `cmd/micro/run/config/config.go` - Added deploy block parsing
- `docs/deployment.md` (new) - Comprehensive deployment guide
- `scripts/install.sh` (new) - Install script for go-micro.dev
- `README.md` - Updated deployment section
- `cmd/micro/README.md` - Added deployment documentation

## Testing

Tested on Ubuntu server:
- `micro init --server` creates directories and systemd template ✓
- `micro deploy localhost` builds, copies, and starts services ✓
- Services run via systemd and auto-restart on failure ✓
- `micro status --remote` shows service status ✓
- `micro logs --remote` streams journalctl output ✓