### PR TITLE
Add blog link to homepage

### DIFF
--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -251,9 +251,9 @@
       
       <div class="links">
         <a href="docs/" class="primary">Documentation</a>
+        <a href="blog/" class="secondary">Blog</a>
         <a href="https://github.com/micro/go-micro" class="secondary">GitHub</a>
         <a href="https://pkg.go.dev/go-micro.dev/v5" class="secondary">Reference</a>
-        <a href="badge.html" class="secondary">Get Badge</a>
       </div>
       
       <div class="showcase">


### PR DESCRIPTION
Link to /blog/ from the main navigation, replacing the badge link.