### PR TITLE
docs: add Atlas Cloud sponsorship blog post and integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Go Micro is a framework for distributed systems development.
 <a href="https://go-micro.dev/blog/3">
   <img src="https://www.logo.wine/a/logo/Anthropic/Anthropic-Logo.wine.svg" style="width: 200px" />
 </a>
+&nbsp;&nbsp;
+<a href="https://go-micro.dev/blog/8">
+  <img src="https://www.atlascloud.ai/logo.svg" style="width: 200px" />
+</a>
 
 ## Overview
 

--- a/internal/website/_data/navigation.yml
+++ b/internal/website/_data/navigation.yml
@@ -30,6 +30,10 @@ examples:
   - title: Real-World Examples
     url: /docs/examples/realworld/
 guides:
+  - title: Atlas Cloud Integration
+    url: /docs/guides/atlascloud-integration.html
+  - title: AI Provider Guide
+    url: /docs/guides/ai-provider-guide.html
   - title: Comparison
     url: /docs/guides/comparison.html
   - title: Migration Guides

--- a/internal/website/blog/8.md
+++ b/internal/website/blog/8.md
@@ -1,0 +1,150 @@
+---
+layout: blog
+title: "Atlas Cloud Sponsors Go Micro: 300+ AI Models, One Integration"
+permalink: /blog/8
+description: "Atlas Cloud joins as an official Go Micro sponsor, bringing 300+ AI models across text, image, and video to the framework's ai package."
+---
+
+# Atlas Cloud Sponsors Go Micro: 300+ AI Models, One Integration
+
+*May 28, 2026 • By the Go Micro Team*
+
+We're excited to announce that **[Atlas Cloud](https://www.atlascloud.ai/)** is sponsoring Go Micro as an official AI provider partner. Atlas Cloud is now a first-class provider in the `ai` package, giving Go Micro users access to 300+ models across text, image, and video through a single integration.
+
+## The Sponsorship
+
+Atlas Cloud is an enterprise AI infrastructure platform that provides a unified API for LLM, image, and video generation. They partner with OpenRouter and ComfyUI, offer SOC 2 and HIPAA compliance, and run a custom inference engine (Atlas Photon) with FP4 quantization for fast, cost-effective inference.
+
+Their sponsorship supports Go Micro's continued development as an AI-native microservices framework. Like Anthropic's Claude Max sponsorship that accelerated our [MCP integration](/blog/3), Atlas Cloud's support helps us maintain and expand the framework for the growing community of developers building AI-powered services.
+
+## What Atlas Cloud Brings
+
+Atlas Cloud's platform stands out for three reasons:
+
+**Breadth of models.** Over 300 curated models including DeepSeek, Qwen, GLM, Kimi for text; GPT Image, Flux, ERNIE for images; and Seedance, Kling, Wan, Veo for video. New SOTA models are deployed on day zero of release.
+
+**OpenAI-compatible API.** Atlas Cloud exposes a `/v1/chat/completions` endpoint that's a drop-in replacement for OpenAI. If you're already using the OpenAI SDK, switching to Atlas Cloud is a one-line change — just swap the base URL.
+
+**Enterprise-ready.** SOC 2 certified, HIPAA compliant, pay-as-you-go pricing with no minimums. Competitive rates, often 48-54% below comparable providers.
+
+## The Integration
+
+Atlas Cloud is available in Go Micro's `ai` package as a registered provider. Here's the quick start:
+
+```go
+import (
+    "go-micro.dev/v5/ai"
+    _ "go-micro.dev/v5/ai/atlascloud"
+)
+
+m := ai.New("atlascloud",
+    ai.WithAPIKey("your-atlas-cloud-key"),
+)
+
+resp, err := m.Generate(ctx, &ai.Request{
+    Prompt:       "Explain microservices in one paragraph",
+    SystemPrompt: "You are a helpful assistant",
+})
+fmt.Println(resp.Reply)
+```
+
+The default model is `llama-3.3-70b` and the default base URL is `https://api.atlascloud.ai`. Both are configurable:
+
+```go
+m := ai.New("atlascloud",
+    ai.WithAPIKey("your-key"),
+    ai.WithModel("deepseek-v4"),
+    ai.WithBaseURL("https://api.atlascloud.ai"),
+)
+```
+
+### Tool Calling
+
+Atlas Cloud supports OpenAI-compatible function calling, which means it works with Go Micro's tool execution flow. Services registered in the registry become tools that the model can call:
+
+```go
+import "go-micro.dev/v5/ai/tools"
+
+set := tools.New(service.Registry())
+discovered, _ := set.Discover()
+
+m := ai.New("atlascloud",
+    ai.WithAPIKey(key),
+    ai.WithToolHandler(set.Handler(service.Client())),
+)
+
+resp, _ := m.Generate(ctx, &ai.Request{
+    Prompt: "List all users and send a welcome email to each",
+    Tools:  discovered,
+})
+```
+
+The model discovers your services, picks the right endpoints, and the `ToolHandler` executes the RPCs. This works identically to how it works with Anthropic or OpenAI — the provider is swappable.
+
+### micro chat
+
+Atlas Cloud works out of the box with the `micro chat` CLI:
+
+```bash
+ATLASCLOUD_API_KEY=your-key micro chat --provider atlascloud
+> list all orders from the last week
+> create a new user named Alice with role admin
+```
+
+### micro run
+
+When running `micro run` or `micro server`, Atlas Cloud is auto-detected if you set the base URL:
+
+```bash
+export MICRO_AI_API_KEY=your-atlas-cloud-key
+export MICRO_AI_BASE_URL=https://api.atlascloud.ai
+micro run
+```
+
+The agent playground at `/agent` will use Atlas Cloud for all LLM calls.
+
+## Provider Lineup
+
+With Atlas Cloud, Go Micro now supports seven AI providers:
+
+| Provider | API Format | Default Model |
+|----------|-----------|---------------|
+| **Anthropic** | Native (Messages API) | `claude-sonnet-4-20250514` |
+| **Google Gemini** | Native (generateContent) | `gemini-2.5-flash` |
+| **OpenAI** | Native (chat/completions) | `gpt-4o` |
+| **Atlas Cloud** | OpenAI-compatible | `llama-3.3-70b` |
+| **Groq** | OpenAI-compatible | `llama-3.3-70b-versatile` |
+| **Mistral** | OpenAI-compatible | `mistral-large-latest` |
+| **Together AI** | OpenAI-compatible | `Llama-3.3-70B-Instruct-Turbo` |
+
+All providers implement the same `ai.Model` interface and work with `ai/tools`, `micro chat`, and the agent playground.
+
+## Getting Started
+
+1. **Sign up** at [atlascloud.ai](https://www.atlascloud.ai/) and get an API key
+2. **Import** the provider:
+
+```go
+import _ "go-micro.dev/v5/ai/atlascloud"
+```
+
+3. **Use it** in your service, the CLI, or the agent playground
+
+See the full [Atlas Cloud Integration Guide](/docs/guides/atlascloud-integration) for detailed examples, environment variable configuration, and model selection.
+
+## What This Means
+
+Go Micro's position is that every microservice should be agent-accessible, and the model powering the agent should be your choice. Atlas Cloud's 300+ models mean developers aren't locked into a single provider or pricing tier. A service built with Go Micro works with Claude, GPT-4, Gemini, Llama, DeepSeek, or any of the hundreds of models Atlas Cloud offers — same code, different import.
+
+We're grateful to Atlas Cloud for their sponsorship and excited to have them as part of the Go Micro ecosystem.
+
+---
+
+*Go Micro is an open source framework for distributed systems development. [Star us on GitHub](https://github.com/micro/go-micro).*
+
+*Thanks to Atlas Cloud for sponsoring Go Micro and supporting the open source community.*
+
+<div class="post-nav">
+  <div><a href="/blog/7">&larr; Your Microservices Are Already an AI Platform</a></div>
+  <div><a href="/blog/">All Posts</a></div>
+</div>

--- a/internal/website/blog/index.html
+++ b/internal/website/blog/index.html
@@ -12,6 +12,13 @@ permalink: /blog/
 <div class="posts">
 
   <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
+    <h2 style="margin: 0 0 0.5rem;"><a href="/blog/8">Atlas Cloud Sponsors Go Micro: 300+ AI Models, One Integration</a></h2>
+    <p class="meta" style="color: #666; font-size: 0.85rem;">May 28, 2026</p>
+    <p>Atlas Cloud joins as an official Go Micro sponsor, bringing 300+ AI models across text, image, and video to the framework's ai package.</p>
+    <a href="/blog/8">Read more &rarr;</a>
+  </article>
+
+  <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
     <h2 style="margin: 0 0 0.5rem;"><a href="/blog/7">Your Microservices Are Already an AI Platform</a></h2>
     <p class="meta" style="color: #666; font-size: 0.85rem;">March 5, 2026</p>
     <p>How existing Go Micro services become agent-accessible with zero code changes. A walkthrough using the micro/blog platform as a real-world example.</p>

--- a/internal/website/docs/guides/atlascloud-integration.md
+++ b/internal/website/docs/guides/atlascloud-integration.md
@@ -1,0 +1,248 @@
+---
+layout: default
+title: Atlas Cloud Integration
+---
+
+# Atlas Cloud Integration Guide
+
+[Atlas Cloud](https://www.atlascloud.ai/) is an enterprise AI infrastructure platform offering 300+ models across text, image, and video through a unified, OpenAI-compatible API. It is an official Go Micro sponsor and a first-class provider in the `ai` package.
+
+## Quick Start
+
+Install or update Go Micro:
+
+```bash
+go get go-micro.dev/v5@latest
+```
+
+Import the Atlas Cloud provider and use it:
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "go-micro.dev/v5/ai"
+    _ "go-micro.dev/v5/ai/atlascloud"
+)
+
+func main() {
+    m := ai.New("atlascloud",
+        ai.WithAPIKey("your-atlas-cloud-key"),
+    )
+
+    resp, err := m.Generate(context.Background(), &ai.Request{
+        Prompt:       "What is Go Micro?",
+        SystemPrompt: "You are a helpful assistant.",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(resp.Reply)
+}
+```
+
+## Configuration
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `ai.WithAPIKey(key)` | *required* | Your Atlas Cloud API key |
+| `ai.WithModel(name)` | `llama-3.3-70b` | Model to use (see [Model Selection](#model-selection)) |
+| `ai.WithBaseURL(url)` | `https://api.atlascloud.ai` | API base URL |
+
+### Environment Variables
+
+The `micro chat` CLI and `micro run` / `micro server` read configuration from environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `ATLASCLOUD_API_KEY` | API key (used by `micro chat --provider atlascloud`) |
+| `MICRO_AI_API_KEY` | Generic API key (used by all providers) |
+| `MICRO_AI_PROVIDER` | Set to `atlascloud` to select the provider |
+| `MICRO_AI_MODEL` | Override the default model |
+| `MICRO_AI_BASE_URL` | Override the base URL |
+
+When using `micro chat`, the provider-specific variable takes precedence:
+
+```bash
+ATLASCLOUD_API_KEY=your-key micro chat --provider atlascloud
+```
+
+When using `micro run` or `micro server`, set the generic variables:
+
+```bash
+export MICRO_AI_API_KEY=your-key
+export MICRO_AI_BASE_URL=https://api.atlascloud.ai
+micro run
+```
+
+The server auto-detects Atlas Cloud from the base URL.
+
+## Model Selection
+
+Atlas Cloud offers 300+ models. Some popular choices for the chat completions API:
+
+| Model | Use Case |
+|-------|----------|
+| `llama-3.3-70b` | General-purpose (default) |
+| `deepseek-v4` | Coding and reasoning |
+| `qwen-3.6` | Multilingual |
+
+Check [atlascloud.ai](https://www.atlascloud.ai/) for the full model catalog. New SOTA models are available on day zero of release.
+
+```go
+m := ai.New("atlascloud",
+    ai.WithAPIKey(key),
+    ai.WithModel("deepseek-v4"),
+)
+```
+
+## Using with Services (Tool Calling)
+
+Atlas Cloud supports OpenAI-compatible function calling. Combined with Go Micro's `ai/tools` package, your services become tools that the model can call:
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "go-micro.dev/v5"
+    "go-micro.dev/v5/ai"
+    "go-micro.dev/v5/ai/tools"
+    _ "go-micro.dev/v5/ai/atlascloud"
+)
+
+func main() {
+    service := micro.New("my-agent")
+    service.Init()
+
+    // Discover all services as tools
+    set := tools.New(service.Registry())
+    discovered, err := set.Discover()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Create a model with tool execution
+    m := ai.New("atlascloud",
+        ai.WithAPIKey("your-key"),
+        ai.WithToolHandler(set.Handler(service.Client())),
+    )
+
+    // The model can now call your services
+    resp, err := m.Generate(context.Background(), &ai.Request{
+        Prompt:       "List all users and send each a welcome email",
+        SystemPrompt: "You are a service orchestrator.",
+        Tools:        discovered,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(resp.Answer)
+}
+```
+
+### How it works
+
+1. `tools.New(registry)` creates a tool set bound to the service registry
+2. `set.Discover()` walks the registry and returns every endpoint as an `ai.Tool`
+3. `set.Handler(client)` returns an `ai.ToolHandler` that executes tool calls via RPC
+4. When the model decides to call a tool, the handler routes to the correct service
+
+This works identically across all providers. Swap `"atlascloud"` for `"anthropic"` or `"openai"` and the same services, tools, and handlers work without changes.
+
+## Using with micro chat
+
+`micro chat` is an interactive terminal agent. Start your services, then chat:
+
+```bash
+# Terminal 1: start services
+micro run
+
+# Terminal 2: chat with Atlas Cloud
+ATLASCLOUD_API_KEY=your-key micro chat --provider atlascloud
+> what services are running?
+> get user alice@example.com
+> create a new order for product-42
+```
+
+For a single prompt (non-interactive):
+
+```bash
+micro chat --provider atlascloud --prompt "list all services"
+```
+
+## Using with micro run
+
+The agent playground at `/agent` uses whatever AI provider is configured. To use Atlas Cloud:
+
+```bash
+export MICRO_AI_API_KEY=your-atlas-cloud-key
+export MICRO_AI_BASE_URL=https://api.atlascloud.ai
+micro run
+```
+
+Open `http://localhost:8080/agent` and chat with your services through Atlas Cloud.
+
+## Using with MCP
+
+The MCP gateway (`micro mcp serve`) exposes services as tools for external AI agents. Atlas Cloud's models can be used by any MCP-compatible agent that connects to the gateway. The gateway itself doesn't depend on a specific AI provider — it serves tools over MCP, and the agent on the other end chooses which model to use.
+
+## Swapping Providers
+
+All Go Micro AI providers implement the same `ai.Model` interface. To switch from Atlas Cloud to another provider, change the import and the provider name:
+
+```go
+// Atlas Cloud
+import _ "go-micro.dev/v5/ai/atlascloud"
+m := ai.New("atlascloud", ai.WithAPIKey(key))
+
+// Anthropic
+import _ "go-micro.dev/v5/ai/anthropic"
+m := ai.New("anthropic", ai.WithAPIKey(key))
+
+// OpenAI
+import _ "go-micro.dev/v5/ai/openai"
+m := ai.New("openai", ai.WithAPIKey(key))
+```
+
+The rest of your code — tool discovery, handler wiring, request/response handling — stays the same.
+
+## API Compatibility
+
+Atlas Cloud exposes an OpenAI-compatible `/v1/chat/completions` endpoint. This means:
+
+- **Existing OpenAI SDK code** works by changing the base URL
+- **Tool calling** uses the same `tools` and `tool_calls` format as OpenAI
+- **Streaming** follows the OpenAI SSE format (when implemented)
+
+If you're already using the `openai` provider, you can point it at Atlas Cloud directly:
+
+```go
+import _ "go-micro.dev/v5/ai/openai"
+
+m := ai.New("openai",
+    ai.WithAPIKey("your-atlas-cloud-key"),
+    ai.WithBaseURL("https://api.atlascloud.ai"),
+    ai.WithModel("llama-3.3-70b"),
+)
+```
+
+The dedicated `atlascloud` provider simply sets these defaults for you.
+
+## Links
+
+- [Atlas Cloud](https://www.atlascloud.ai/) — Sign up and get an API key
+- [AI Provider Integration Guide](/docs/guides/ai-provider-guide) — How providers are built
+- [ai/tools package](https://pkg.go.dev/go-micro.dev/v5/ai/tools) — Service-to-tool discovery
+- [Blog: Atlas Cloud Sponsors Go Micro](/blog/8) — Announcement post


### PR DESCRIPTION
Add blog/8 announcing Atlas Cloud as an official Go Micro sponsor. Covers the sponsorship, Atlas Cloud's platform (300+ models, OpenAI compatibility, enterprise compliance), and how the integration works with the ai package, ai/tools, micro chat, and micro run.

Add guides/atlascloud-integration.md with full setup instructions: quick start, configuration options, environment variables, model selection, tool calling with services, and provider swapping.

Add Atlas Cloud and AI Provider guides to the docs sidebar navigation. Add sponsorship link to README header.