### PR TITLE
feat(ai): add ImageModel interface with Atlas Cloud and OpenAI support

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -1,8 +1,10 @@
 # AI Package
 
-The `ai` package provides a simple, high-level interface for AI model providers like Anthropic Claude and OpenAI GPT.
+The `ai` package provides simple, high-level interfaces for AI model providers. It supports text generation (`Model`) and image generation (`ImageModel`), with more modalities planned.
 
-## Interface
+## Interfaces
+
+### Text Generation (Model)
 
 The Model interface follows the same patterns as other go-micro packages (Registry, Client, Broker):
 
@@ -45,6 +47,35 @@ if err != nil {
 
 fmt.Println(resp.Reply)
 ```
+
+### Image Generation (ImageModel)
+
+```go
+type ImageModel interface {
+    GenerateImage(ctx context.Context, req *ImageRequest, opts ...GenerateOption) (*ImageResponse, error)
+    String() string
+}
+```
+
+```go
+import (
+    "go-micro.dev/v5/ai"
+    _ "go-micro.dev/v5/ai/atlascloud"
+)
+
+ig := ai.NewImage("atlascloud",
+    ai.WithAPIKey("your-api-key"),
+)
+
+resp, err := ig.GenerateImage(context.Background(), &ai.ImageRequest{
+    Prompt: "A Go gopher in space",
+    Size:   "1024x1024",
+})
+
+fmt.Println(resp.Images[0].URL)
+```
+
+Providers that support image generation: **Atlas Cloud**, **OpenAI**.
 
 ## Options
 

--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -1,14 +1,20 @@
 // Package atlascloud implements the Atlas Cloud model provider.
 //
 // Atlas Cloud is an enterprise AI infrastructure platform offering
-// high-performance LLM APIs. It exposes an OpenAI-compatible
-// chat completions endpoint.
+// high-performance LLM, image, and video APIs. It exposes
+// OpenAI-compatible endpoints for chat completions and image
+// generation.
 //
 // Usage:
 //
 //	import _ "go-micro.dev/v5/ai/atlascloud"
 //
 //	m := ai.New("atlascloud",
+//	    ai.WithAPIKey("your-api-key"),
+//	)
+//
+//	// Image generation
+//	ig := ai.NewImage("atlascloud",
 //	    ai.WithAPIKey("your-api-key"),
 //	)
 package atlascloud
@@ -27,6 +33,9 @@ import (
 
 func init() {
 	ai.Register("atlascloud", func(opts ...ai.Option) ai.Model {
+		return NewProvider(opts...)
+	})
+	ai.RegisterImage("atlascloud", func(opts ...ai.Option) ai.ImageModel {
 		return NewProvider(opts...)
 	})
 }
@@ -205,4 +214,72 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 	}
 
 	return response, rawMessage, nil
+}
+
+const defaultImageModel = "gpt-image-1"
+
+func (p *Provider) GenerateImage(ctx context.Context, req *ai.ImageRequest, opts ...ai.GenerateOption) (*ai.ImageResponse, error) {
+	model := req.Model
+	if model == "" {
+		model = defaultImageModel
+	}
+	n := req.N
+	if n <= 0 {
+		n = 1
+	}
+
+	apiReq := map[string]any{
+		"model":  model,
+		"prompt": req.Prompt,
+		"n":      n,
+	}
+	if req.Size != "" {
+		apiReq["size"] = req.Size
+	}
+
+	reqBody, err := json.Marshal(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	apiURL := strings.TrimRight(p.opts.BaseURL, "/") + "/v1/images/generations"
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+p.opts.APIKey)
+
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	respBody, _ := io.ReadAll(httpResp.Body)
+	if httpResp.StatusCode != 200 {
+		return nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+	}
+
+	var imgResp struct {
+		Data []struct {
+			URL     string `json:"url"`
+			B64JSON string `json:"b64_json"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(respBody, &imgResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	response := &ai.ImageResponse{}
+	for _, d := range imgResp.Data {
+		response.Images = append(response.Images, ai.Image{
+			URL:    d.URL,
+			Base64: d.B64JSON,
+		})
+	}
+
+	return response, nil
 }

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -102,3 +102,25 @@ func TestProvider_Registration(t *testing.T) {
 		t.Errorf("Expected 'atlascloud', got '%s'", m.String())
 	}
 }
+
+func TestProvider_ImageRegistration(t *testing.T) {
+	ig := ai.NewImage("atlascloud", ai.WithAPIKey("test"))
+	if ig == nil {
+		t.Fatal("ai.NewImage('atlascloud') returned nil — image provider not registered")
+	}
+	if ig.String() != "atlascloud" {
+		t.Errorf("Expected 'atlascloud', got '%s'", ig.String())
+	}
+}
+
+func TestProvider_GenerateImage_NoAPIKey(t *testing.T) {
+	p := NewProvider()
+	_, err := p.GenerateImage(context.Background(), &ai.ImageRequest{Prompt: "a cat"})
+	if err == nil {
+		t.Error("Expected error when API key is missing, got nil")
+	}
+}
+
+func TestProvider_ImplementsImageModel(t *testing.T) {
+	var _ ai.ImageModel = (*Provider)(nil)
+}

--- a/ai/image.go
+++ b/ai/image.go
@@ -1,0 +1,61 @@
+package ai
+
+import "context"
+
+// ImageModel provides an interface for image generation providers.
+// Providers that support image generation implement this alongside
+// or instead of Model. Use NewImage to construct, or type-assert
+// a provider that implements both:
+//
+//	p := atlascloud.NewProvider(ai.WithAPIKey(key))
+//	if ig, ok := p.(ai.ImageModel); ok {
+//	    resp, _ := ig.GenerateImage(ctx, req)
+//	}
+type ImageModel interface {
+	GenerateImage(ctx context.Context, req *ImageRequest, opts ...GenerateOption) (*ImageResponse, error)
+	String() string
+}
+
+// ImageRequest describes what image to generate.
+type ImageRequest struct {
+	// Prompt is the text description of the image to generate.
+	Prompt string
+	// Model overrides the provider's default image model.
+	Model string
+	// Size of the generated image (e.g. "1024x1024"). Provider-specific.
+	Size string
+	// N is the number of images to generate. Defaults to 1.
+	N int
+}
+
+// ImageResponse holds the generated images.
+type ImageResponse struct {
+	Images []Image
+}
+
+// Image is a single generated image, returned as a URL, base64 data, or both
+// depending on the provider and request options.
+type Image struct {
+	// URL is a remote URL where the image can be fetched.
+	URL string
+	// Base64 is the base64-encoded image data.
+	Base64 string
+}
+
+// NewImageFunc creates a new ImageModel instance.
+type NewImageFunc func(...Option) ImageModel
+
+var imageProviders = make(map[string]NewImageFunc)
+
+// RegisterImage registers an image generation provider.
+func RegisterImage(name string, fn NewImageFunc) {
+	imageProviders[name] = fn
+}
+
+// NewImage creates a new ImageModel instance based on the provider name.
+func NewImage(provider string, opts ...Option) ImageModel {
+	if fn, ok := imageProviders[provider]; ok {
+		return fn(opts...)
+	}
+	return nil
+}

--- a/ai/model.go
+++ b/ai/model.go
@@ -22,8 +22,8 @@ type Model interface {
 
 // Tool represents a tool/function that can be called by the model
 type Tool struct {
-	Name         string         // LLM-safe name (e.g., "greeter_Greeter_Hello")
-	OriginalName string         // Original name (e.g., "greeter.Greeter.Hello")
+	Name         string // LLM-safe name (e.g., "greeter_Greeter_Hello")
+	OriginalName string // Original name (e.g., "greeter.Greeter.Hello")
 	Description  string
 	Properties   map[string]any // JSON schema for tool parameters
 }
@@ -95,14 +95,14 @@ func New(provider string, opts ...Option) Model {
 	if fn, ok := providers[provider]; ok {
 		return fn(opts...)
 	}
-	
+
 	// Default to first registered provider
 	if len(providers) > 0 {
 		for _, fn := range providers {
 			return fn(opts...)
 		}
 	}
-	
+
 	return nil
 }
 

--- a/ai/openai/openai.go
+++ b/ai/openai/openai.go
@@ -17,6 +17,9 @@ func init() {
 	ai.Register("openai", func(opts ...ai.Option) ai.Model {
 		return NewProvider(opts...)
 	})
+	ai.RegisterImage("openai", func(opts ...ai.Option) ai.ImageModel {
+		return NewProvider(opts...)
+	})
 }
 
 // Provider implements the ai.Model interface for OpenAI
@@ -223,4 +226,72 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 	}
 
 	return response, rawMessage, nil
+}
+
+const defaultImageModel = "gpt-image-1"
+
+func (p *Provider) GenerateImage(ctx context.Context, req *ai.ImageRequest, opts ...ai.GenerateOption) (*ai.ImageResponse, error) {
+	model := req.Model
+	if model == "" {
+		model = defaultImageModel
+	}
+	n := req.N
+	if n <= 0 {
+		n = 1
+	}
+
+	apiReq := map[string]any{
+		"model":  model,
+		"prompt": req.Prompt,
+		"n":      n,
+	}
+	if req.Size != "" {
+		apiReq["size"] = req.Size
+	}
+
+	reqBody, err := json.Marshal(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	apiURL := strings.TrimRight(p.opts.BaseURL, "/") + "/v1/images/generations"
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+p.opts.APIKey)
+
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	respBody, _ := io.ReadAll(httpResp.Body)
+	if httpResp.StatusCode != 200 {
+		return nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+	}
+
+	var imgResp struct {
+		Data []struct {
+			URL     string `json:"url"`
+			B64JSON string `json:"b64_json"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(respBody, &imgResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	response := &ai.ImageResponse{}
+	for _, d := range imgResp.Data {
+		response.Images = append(response.Images, ai.Image{
+			URL:    d.URL,
+			Base64: d.B64JSON,
+		})
+	}
+
+	return response, nil
 }

--- a/ai/openai/openai_test.go
+++ b/ai/openai/openai_test.go
@@ -92,3 +92,25 @@ func TestProvider_Stream_NotImplemented(t *testing.T) {
 		t.Error("Expected error for unimplemented streaming, got nil")
 	}
 }
+
+func TestProvider_ImageRegistration(t *testing.T) {
+	ig := ai.NewImage("openai", ai.WithAPIKey("test"))
+	if ig == nil {
+		t.Fatal("ai.NewImage('openai') returned nil — image provider not registered")
+	}
+	if ig.String() != "openai" {
+		t.Errorf("Expected 'openai', got '%s'", ig.String())
+	}
+}
+
+func TestProvider_GenerateImage_NoAPIKey(t *testing.T) {
+	p := NewProvider()
+	_, err := p.GenerateImage(context.Background(), &ai.ImageRequest{Prompt: "a cat"})
+	if err == nil {
+		t.Error("Expected error when API key is missing, got nil")
+	}
+}
+
+func TestProvider_ImplementsImageModel(t *testing.T) {
+	var _ ai.ImageModel = (*Provider)(nil)
+}

--- a/internal/website/blog/8.md
+++ b/internal/website/blog/8.md
@@ -58,6 +58,26 @@ m := ai.New("atlascloud",
 )
 ```
 
+### Image Generation
+
+Atlas Cloud's image generation models are available through Go Micro's `ImageModel` interface. Generate images from text prompts with the same pattern as text generation:
+
+```go
+ig := ai.NewImage("atlascloud",
+    ai.WithAPIKey("your-key"),
+)
+
+resp, err := ig.GenerateImage(ctx, &ai.ImageRequest{
+    Prompt: "A futuristic city skyline at sunset, digital art",
+    Size:   "1024x1024",
+})
+
+// resp.Images[0].URL contains the generated image
+fmt.Println(resp.Images[0].URL)
+```
+
+Atlas Cloud supports models like `gpt-image-1`, `flux-2`, and more from their 300+ model catalog. The same `ImageModel` interface works with OpenAI too — swap the provider name and your code stays the same.
+
 ### Tool Calling
 
 Atlas Cloud supports OpenAI-compatible function calling, which means it works with Go Micro's tool execution flow. Services registered in the registry become tools that the model can call:

--- a/internal/website/docs/guides/atlascloud-integration.md
+++ b/internal/website/docs/guides/atlascloud-integration.md
@@ -103,6 +103,61 @@ m := ai.New("atlascloud",
 )
 ```
 
+## Image Generation
+
+Atlas Cloud supports text-to-image generation through the `ai.ImageModel` interface. This uses the same OpenAI-compatible `/v1/images/generations` endpoint.
+
+```go
+import (
+    "context"
+    "fmt"
+
+    "go-micro.dev/v5/ai"
+    _ "go-micro.dev/v5/ai/atlascloud"
+)
+
+func main() {
+    ig := ai.NewImage("atlascloud",
+        ai.WithAPIKey("your-key"),
+    )
+
+    resp, err := ig.GenerateImage(context.Background(), &ai.ImageRequest{
+        Prompt: "A Go gopher building microservices, digital art",
+        Size:   "1024x1024",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Image returned as URL or base64, depending on the model
+    fmt.Println(resp.Images[0].URL)
+}
+```
+
+### ImageRequest Options
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `Prompt` | *required* | Text description of the image |
+| `Model` | `gpt-image-1` | Image model to use |
+| `Size` | provider default | Image dimensions (e.g. `"1024x1024"`) |
+| `N` | `1` | Number of images to generate |
+
+### Available Image Models
+
+Atlas Cloud offers image models including `gpt-image-1`, `flux-2`, `nano-banana-pro`, and more. Check [atlascloud.ai](https://www.atlascloud.ai/) for the full catalog.
+
+```go
+ig.GenerateImage(ctx, &ai.ImageRequest{
+    Prompt: "A mountain landscape",
+    Model:  "flux-2",
+    Size:   "1024x1024",
+    N:      2,
+})
+```
+
+The `ai.ImageModel` interface is also implemented by the OpenAI provider, so switching between providers is a one-line change.
+
 ## Using with Services (Tool Calling)
 
 Atlas Cloud supports OpenAI-compatible function calling. Combined with Go Micro's `ai/tools` package, your services become tools that the model can call:


### PR DESCRIPTION
Add ai.ImageModel interface for text-to-image generation alongside the existing ai.Model for text. Uses the same options pattern (WithAPIKey, WithBaseURL) and the same provider registration system (RegisterImage/NewImage).

Implement GenerateImage for Atlas Cloud and OpenAI providers via the OpenAI-compatible /v1/images/generations endpoint. Default image model is gpt-image-1. Responses return images as URL, base64, or both depending on the provider.

Update Atlas Cloud blog post and integration guide with image generation examples. Update ai/README.md with ImageModel docs.