### PR TITLE
Unify README and website to present consistent messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,193 +1,132 @@
 # Go Micro [![Go.Dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/go-micro.dev/v5?tab=doc) [![Go Report Card](https://goreportcard.com/badge/github.com/go-micro/go-micro)](https://goreportcard.com/report/github.com/go-micro/go-micro)
 
-Go Micro is a framework for distributed systems development.
+Go Micro is a framework for building microservices that AI agents can use.
+
+Write services in Go. They register, discover each other, and communicate via RPC and events. Every endpoint is automatically an AI-callable tool via [MCP](https://modelcontextprotocol.io/). An agent orchestrates across services so they don't have to call each other.
+
+## Quick Start
+
+Generate services from a description, start them, and talk to them:
+
+```bash
+go install go-micro.dev/v5/cmd/micro@latest
+
+micro run --prompt "a task management system with categories" --provider anthropic
+micro chat --provider anthropic
+> Create a Work category, then add a task called 'Finish report' to it
+```
+
+Or scaffold a single service by hand:
+
+```bash
+micro new helloworld
+cd helloworld
+micro run
+```
+
+Open http://localhost:8080 to see the dashboard, call endpoints, and chat with your services.
 
 ## Sponsors
 
 <a href="https://go-micro.dev/blog/3"><img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Anthropic_logo.svg" height="26" /></a>
-<br>
-
+&nbsp;&nbsp;
 <a href="https://go-micro.dev/blog/8"><img src="https://www.atlascloud.ai/logo.svg" height="26" /></a>
 
-## Overview
+## How It Works
 
-<img src="internal/website/images/generated/hero.png" alt="Go Micro microservices architecture" width="100%" />
+### 1. Write a Service
 
-Go Micro provides the core requirements for distributed systems development including RPC and Event driven communication.
-The Go Micro philosophy is sane defaults with a pluggable architecture. We provide defaults to get you started quickly
-but everything can be easily swapped out.
-
-## Features
-
-Go Micro abstracts away the details of distributed systems. Here are the main features.
-
-- **Authentication** - Auth is built in as a first class citizen. Authentication and authorization enable secure
-  zero trust networking by providing every service an identity and certificates. This additionally includes rule
-  based access control.
-
-- **Dynamic Config** - Load and hot reload dynamic config from anywhere. The config interface provides a way to load application
-  level config from any source such as env vars, file, etcd. You can merge the sources and even define fallbacks.
-
-- **Data Storage** - A simple data store interface to read, write and delete records. It includes support for many storage backends
-in the plugins repo. State and persistence becomes a core requirement beyond prototyping and Micro looks to build that into the framework.
-
-- **Data Model** - A typed data model layer with CRUD operations, queries, and multiple backends (memory, SQLite, Postgres). Define Go
-  structs with tags and get type-safe Create/Read/Update/Delete/List/Count operations. Accessible via `service.Model()` alongside
-  `service.Client()` and `service.Server()` for a complete service experience: call services, handle requests, save and query data.
-
-- **Service Discovery** - Automatic service registration and name resolution. Service discovery is at the core of micro service
-  development. When service A needs to speak to service B it needs the location of that service. The default discovery mechanism is
-  multicast DNS (mdns), a zeroconf system.
-
-- **Load Balancing** - Client side load balancing built on service discovery. Once we have the addresses of any number of instances
-  of a service we now need a way to decide which node to route to. We use random hashed load balancing to provide even distribution
-  across the services and retry a different node if there's a problem.
-
-- **Message Encoding** - Dynamic message encoding based on content-type. The client and server will use codecs along with content-type
-  to seamlessly encode and decode Go types for you. Any variety of messages could be encoded and sent from different clients. The client
-  and server handle this by default. This includes protobuf and json by default.
-
-- **RPC Client/Server** - RPC based request/response with support for bidirectional streaming. We provide an abstraction for synchronous
-  communication. A request made to a service will be automatically resolved, load balanced, dialled and streamed.
-
-- **Async Messaging** - PubSub is built in as a first class citizen for asynchronous communication and event driven architectures.
-  Event notifications are a core pattern in micro service development. The default messaging system is a HTTP event message broker.
-
-- **MCP Integration** - An MCP gateway you can integrate as a library, server or CLI command which automatically exposes services
-  as tools for agents or other AI applications. Every service/endpoint get's converted into a callable tool.
-
-- **Multi-Service Binaries** - Run multiple services in a single process with isolated state per service. Start as a modular monolith,
-  split into separate deployments when you need independent scaling. Each service gets its own server, client, and store while sharing
-  the registry and broker for inter-service communication.
-
-- **Pluggable Interfaces** - Go Micro makes use of Go interfaces for each distributed system abstraction. Because of this these interfaces
-  are pluggable and allows Go Micro to be runtime agnostic. You can plugin any underlying technology.
-
-## Getting Started
-
-To make use of Go Micro 
-
-```bash
-go get go-micro.dev/v5@v5.16.0
-```
-
-Create a service and register a handler
+A service is a struct with methods. Doc comments and `@example` tags become tool descriptions for AI agents.
 
 ```go
 package main
 
 import (
-        "go-micro.dev/v5"
+    "go-micro.dev/v5"
 )
 
 type Request struct {
-        Name string `json:"name"`
+    Name string `json:"name"`
 }
 
 type Response struct {
-        Message string `json:"message"`
+    Message string `json:"message"`
 }
 
 type Say struct{}
 
-func (h *Say) Hello(ctx context.Context, req *Request, rsp *Response) error {
-        rsp.Message = "Hello " + req.Name
-        return nil
-}
-
-func main() {
-        // create the service
-        service := micro.New("helloworld")
-
-        // register handler
-        service.Handle(new(Say))
-
-        // run the service
-        service.Run()
-}
-```
-
-Set a fixed address
-
-```go
-service := micro.New("helloworld", micro.Address(":8080"))
-```
-
-Call it via curl
-
-```bash
-curl -XPOST \
-     -H 'Content-Type: application/json' \
-     -H 'Micro-Endpoint: Say.Hello' \
-     -d '{"name": "alice"}' \
-      http://localhost:8080
-```
-
-## MCP & AI Agents
-
-<img src="internal/website/images/generated/mcp-agent.png" alt="AI agent calling microservices via MCP" width="100%" />
-
-Go Micro is designed for an **agent-first** workflow. Every service you build automatically becomes a tool that AI agents can discover and use via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
-
-- **[🤖 Agent Playground](https://go-micro.dev/docs/mcp.html)** — Chat with your services through an interactive AI agent at `/agent`
-- **[🔧 MCP Tools Registry](https://go-micro.dev/docs/mcp.html)** — Browse all services exposed as AI-callable tools at `/mcp/tools`
-- **[📖 MCP Documentation](https://go-micro.dev/docs/mcp.html)** — Full guide to MCP integration, auth, and scopes
-
-### Services as Tools
-
-Write a normal Go Micro service and it's instantly available as an MCP tool:
-
-```go
-// SayHello greets a person by name.
+// Hello greets a person by name.
 // @example {"name": "Alice"}
-func (g *GreeterService) SayHello(ctx context.Context, req *HelloRequest, rsp *HelloResponse) error {
+func (h *Say) Hello(ctx context.Context, req *Request, rsp *Response) error {
     rsp.Message = "Hello " + req.Name
     return nil
 }
+
+func main() {
+    service := micro.New("greeter")
+    service.Handle(new(Say))
+    service.Run()
+}
 ```
 
-Run with `micro run` and the agent playground and MCP tools registry are ready:
+### 2. Run It
+
+`micro run` starts your service with an API gateway, agent playground, and hot reload:
 
 ```bash
 micro run
-# Agent Playground:  http://localhost:8080/agent
-# MCP Tools:         http://localhost:8080/mcp/tools
+# Dashboard:   http://localhost:8080
+# API:         http://localhost:8080/api/{service}/{method}
+# Agent:       http://localhost:8080/agent
+# MCP Tools:   http://localhost:8080/mcp/tools
 ```
 
-Use `micro mcp serve` for local AI tools like Claude Code, or connect any MCP-compatible agent to the HTTP endpoint.
+### 3. Talk to It
 
-### micro chat
-
-For an interactive terminal session that lets you talk to your services through an LLM:
+`micro chat` discovers services from the registry, exposes every endpoint as a tool, and lets an LLM orchestrate:
 
 ```bash
-ANTHROPIC_API_KEY=sk-ant-... micro chat --provider anthropic
-> list all users
-> create an order for product 42
+micro chat --provider anthropic
+> Say hello to Alice
+→ greeter_Say_Hello({"name":"Alice"})
+← {"message":"Hello Alice"}
 ```
 
-`micro chat` discovers every service in the registry, exposes each endpoint as a tool, and lets the model orchestrate calls. The same building blocks (`ai.Tools`) work from your own services:
+When you need a capability that doesn't exist, the agent generates a new service mid-conversation, compiles it, starts it, and uses it immediately. [Read more](https://go-micro.dev/blog/13).
 
-```go
+## Features
 
-tools := ai.NewTools(service.Registry())
-discovered, _ := tools.Discover()
+| Category | What | Details |
+|----------|------|---------|
+| **Discovery** | Service registry | mDNS (default), Consul, etcd |
+| **Communication** | RPC client/server | gRPC transport, load balancing, streaming |
+| **Messaging** | Pub/sub events | NATS, RabbitMQ, HTTP broker |
+| **Storage** | Key-value store | File (bbolt), Postgres, NATS KV |
+| **Data** | Typed model layer | CRUD + queries, SQLite/Postgres backends |
+| **AI** | MCP gateway | Every endpoint is an AI tool automatically |
+| **AI** | 7 LLM providers | Anthropic, OpenAI, Gemini, Groq, Mistral, Together, Atlas Cloud |
+| **AI** | Agent orchestration | `micro chat` — LLM calls services as tools |
+| **AI** | Service generation | `micro run --prompt` — describe a system, get running services |
+| **DX** | Hot reload | `micro run` watches files, rebuilds on change |
+| **DX** | Templates | `micro new --template crud/pubsub/api` |
+| **Deploy** | One-command deploy | `micro deploy user@server` — SSH + systemd, no Docker |
+| **Plugins** | Everything swappable | All abstractions are Go interfaces |
 
-m := ai.New("anthropic",
-    ai.WithAPIKey(key),
-    ai.WithTools(tools),
-)
-resp, _ := m.Generate(ctx, &ai.Request{
-    Prompt: userInput,
-    Tools:  discovered,
-})
-```
+## CLI Workflow
 
-See the [MCP guide](https://go-micro.dev/docs/mcp.html) for authentication, scopes, and advanced usage.
+| Command | Purpose |
+|---------|---------|
+| `micro new myservice` | Scaffold a service |
+| `micro run` | Dev mode: hot reload, gateway, agent playground |
+| `micro run --prompt "..."` | Generate services from a description and run them |
+| `micro call service endpoint '{"key":"val"}'` | Call a service from the CLI |
+| `micro chat --provider anthropic` | Talk to services through an LLM |
+| `micro build` | Compile production binaries |
+| `micro deploy user@server` | Deploy via SSH + systemd |
 
-## Multi-Service Binaries
+## Multi-Service Projects
 
-Run multiple services in a single binary — start as a modular monolith, split into separate deployments later when you actually need to.
+Run multiple services together:
 
 ```go
 users := micro.New("users", micro.Address(":9001"))
@@ -196,295 +135,81 @@ orders := micro.New("orders", micro.Address(":9002"))
 users.Handle(new(Users))
 orders.Handle(new(Orders))
 
-// Run all services together with shared lifecycle
 g := micro.NewGroup(users, orders)
 g.Run()
 ```
 
-Each service gets its own server, client, store, and cache while sharing the registry, broker, and transport — so they can discover and call each other within the same process.
-
-See the [multi-service example](examples/multi-service/) for a working demo.
-
-## Data Model
-
-Go Micro includes a typed data model layer for persistence. Define a struct, tag a key field, and get type-safe CRUD and query operations backed by memory, SQLite, or Postgres.
-
-```go
-import (
-        "go-micro.dev/v5/model"
-        "go-micro.dev/v5/model/sqlite"
-)
-
-// Define your data type
-type User struct {
-        ID    string `json:"id" model:"key"`
-        Name  string `json:"name"`
-        Email string `json:"email" model:"index"`
-        Age   int    `json:"age"`
-}
-```
-
-Register your types and use the model:
-
-```go
-service := micro.New("users")
-
-// Register and use the service's model backend
-db := service.Model()
-db.Register(&User{})
-
-// CRUD operations
-db.Create(ctx, &User{ID: "1", Name: "Alice", Email: "alice@example.com", Age: 30})
-
-user := &User{}
-db.Read(ctx, "1", user)
-
-user.Name = "Alice Smith"
-db.Update(ctx, user)
-
-db.Delete(ctx, "1", &User{})
-```
-
-Query with filters, ordering, and pagination:
-
-```go
-var results []*User
-
-// Find users by field
-db.List(ctx, &results, model.Where("email", "alice@example.com"))
-
-// Complex queries
-db.List(ctx, &results,
-        model.WhereOp("age", ">=", 18),
-        model.OrderDesc("name"),
-        model.Limit(10),
-        model.Offset(20),
-)
-
-count, _ := users.Count(ctx, model.Where("age", 30))
-```
-
-Swap backends with an option:
-
-```go
-// Development: in-memory (default)
-service := micro.New("users")
-
-// Production: SQLite or Postgres
-db, _ := sqlite.New(model.WithDSN("file:app.db"))
-service := micro.New("users", micro.Model(db))
-```
-
-Every service gets `Client()`, `Server()`, and `Model()` — call services, handle requests, and save data all from the same interface.
-
-## Examples
-
-Check out [/examples](examples/) for runnable code:
-- [hello-world](examples/hello-world/) - Basic RPC service
-- [grpc-interop](examples/grpc-interop/) - Call go-micro from any gRPC client
-- [web-service](examples/web-service/) - HTTP REST API
-- [multi-service](examples/multi-service/) - Multiple services in one binary
-- [mcp](examples/mcp/) - MCP integration with AI agents
-
-See [all examples](examples/README.md) for more.
-
-## Protobuf
-
-Install the code generator and see usage in the docs:
-
-```bash
-go install go-micro.dev/v5/cmd/protoc-gen-micro@v5.16.0
-```
-
-> **Note:** Use a specific version instead of `@latest` to avoid module path conflicts. See [releases](https://github.com/micro/go-micro/releases) for the latest version.
-
-Docs: [`internal/website/docs/getting-started.md`](internal/website/docs/getting-started.md)
-
-## Command Line
-
-Install the CLI:
-
-```
-go install go-micro.dev/v5/cmd/micro@v5.16.0
-```
-
-> **Note:** Use a specific version instead of `@latest` to avoid module path conflicts. See [releases](https://github.com/micro/go-micro/releases) for the latest version.
-
-### Quick Start
-
-```bash
-micro new helloworld              # Create a new service
-cd helloworld
-micro run                          # Run with API gateway and hot reload
-```
-
-Then open http://localhost:8080 to see your service and call it from the browser.
-
-### Generate From a Prompt
-
-Describe what you need in plain English. The AI designs services, writes handlers with real business logic, compiles them, and starts them:
-
-```bash
-micro run --prompt "a task management system with categories" --provider anthropic
-```
-
-Then talk to your services through an agent:
-
-```bash
-micro chat --provider anthropic
-> Create a Work category, then add a task called 'Finish report' to it
-```
-
-The agent orchestrates across services automatically. When you need a capability that doesn't exist, the agent generates a new service mid-conversation. [Read more](https://go-micro.dev/blog/13).
-
-### Development Workflow
-
-| Stage | Command | Purpose |
-|-------|---------|---------|
-| **Create** | `micro new myservice` | Scaffold a service (`--template crud/pubsub/api`) |
-| **Develop** | `micro run` | Dev mode with hot reload and API gateway |
-| **Test** | `micro call` | Call a service endpoint from the CLI |
-| **Chat** | `micro chat` | Talk to your services through an LLM |
-| **Gateway** | `micro api` | Standalone HTTP-to-RPC gateway |
-| **Build** | `micro build` | Compile production binaries |
-| **Deploy** | `micro deploy` | Push to a remote Linux server via SSH + systemd |
-| **Dashboard** | `micro server` | Production web UI with auth |
-
-### Inspecting the Framework
-
-Every core interface has a matching command — inspect the registry, broker, store, and config from the terminal:
-
-```bash
-micro registry list                  # list services
-micro broker subscribe events        # stream a topic
-micro broker publish events 'hello'  # publish a message
-micro store write greeting hello     # write a record
-micro store read greeting            # read it back
-micro config get database.host       # read config (from DATABASE_HOST)
-```
-
-These mirror the `registry`, `broker`, `store`, and `config` packages.
-
-### micro run
-
-`micro run` starts your services with:
-- **Web Dashboard** - Browse and call services at `/`
-- **Agent Playground** - AI chat with MCP tools at `/agent`
-- **API Explorer** - Browse endpoints and schemas at `/api`
-- **API Gateway** - HTTP to RPC proxy at `/api/{service}/{method}` (no auth in dev mode)
-- **MCP Tools** - Services as AI tools at `/mcp/tools`
-- **Health Checks** - Aggregated health at `/health`
-- **Hot Reload** - Auto-rebuild on file changes
-
-> **Note:** `micro run` and `micro server` use a unified gateway architecture. See [Gateway Architecture](cmd/micro/README.md#gateway-architecture) for details.
-
-```bash
-micro run                    # Gateway on :8080
-micro run --address :3000    # Custom gateway port
-micro run --no-gateway       # Services only
-micro run --env production   # Use production environment
-```
-
-### Configuration
-
-For multi-service projects, create a `micro.mu` file:
+Or use a `micro.mu` config file:
 
 ```
 service users
     path ./users
-    port 8081
 
-service posts
-    path ./posts
-    port 8082
+service orders
+    path ./orders
     depends users
-
-env development
-    DATABASE_URL sqlite://./dev.db
 ```
 
-The gateway runs on :8080 by default, so services should use other ports.
+## Data Model
 
-### Deployment
+Typed persistence with CRUD and queries:
 
-Deploy to any Linux server with systemd:
+```go
+type User struct {
+    ID    string `json:"id" model:"key"`
+    Name  string `json:"name"`
+    Email string `json:"email" model:"index"`
+}
 
-```bash
-# On your server (one-time setup)
-curl -fsSL https://go-micro.dev/install.sh | sh
-sudo micro init --server
+db := service.Model()
+db.Register(&User{})
+db.Create(ctx, &User{ID: "1", Name: "Alice", Email: "alice@example.com"})
 
-# From your laptop
-micro deploy user@your-server
+var results []*User
+db.List(ctx, &results, model.Where("email", "alice@example.com"))
 ```
 
-The deploy command:
-1. Builds binaries for Linux
-2. Copies via SSH to the server
-3. Sets up systemd services
-4. Verifies services are healthy
+Backends: memory (default), SQLite, Postgres.
 
-Optionally run `micro server` on the deployed machine for a production web dashboard with JWT auth, user management, and API explorer.
+## AI Providers
 
-Manage deployed services:
-```bash
-micro status --remote user@server    # Check status
-micro logs --remote user@server      # View logs
-micro logs myservice --remote user@server -f  # Follow specific service
+Swap providers with a single import — same interface everywhere:
+
+| Provider | Default Model |
+|----------|---------------|
+| Anthropic | `claude-sonnet-4-20250514` |
+| OpenAI | `gpt-4o` |
+| Google Gemini | `gemini-2.5-flash` |
+| Groq | `llama-3.3-70b-versatile` |
+| Mistral | `mistral-large-latest` |
+| Together AI | `Llama-3.3-70B-Instruct-Turbo` |
+| Atlas Cloud | `llama-3.3-70b` |
+
+```go
+m := ai.New("anthropic", ai.WithAPIKey(key))
+resp, _ := m.Generate(ctx, &ai.Request{Prompt: "hello"})
 ```
 
-No Docker required. No Kubernetes. Just systemd.
+## Examples
 
-See [internal/website/docs/deployment.md](internal/website/docs/deployment.md) for full deployment guide.
+- [hello-world](examples/hello-world/) — Basic RPC service
+- [multi-service](examples/multi-service/) — Multiple services in one binary
+- [mcp](examples/mcp/) — MCP integration with AI agents
+- [grpc-interop](examples/grpc-interop/) — Call go-micro from any gRPC client
 
-See [cmd/micro/README.md](cmd/micro/README.md) for full CLI documentation.
+See [all examples](examples/README.md).
 
-Docs: [`internal/website/docs`](internal/website/docs)
+## Docs
+
+- [Getting Started](internal/website/docs/getting-started.md)
+- [AI Integration](internal/website/docs/ai-integration.md)
+- [MCP & AI Agents](internal/website/docs/mcp.md)
+- [Data Model](internal/website/docs/model.md)
+- [Deployment](internal/website/docs/deployment.md)
+- [Plugins](internal/website/docs/plugins.md)
 
 Package reference: https://pkg.go.dev/go-micro.dev/v5
 
-**User Guides:**
-- [Getting Started](internal/website/docs/getting-started.md)
-- [AI Integration](internal/website/docs/ai-integration.md) — how services, MCP, tools, and LLMs fit together
-- [MCP & AI Agents](internal/website/docs/mcp.md)
-- [Data Model](internal/website/docs/model.md)
-- [Plugins Overview](internal/website/docs/plugins.md)
-- [Deployment Guide](internal/website/docs/deployment.md)
-- [Learn by Example](internal/website/docs/examples/index.md)
-
-**Architecture & Performance:**
-- [Performance Considerations](internal/website/docs/performance.md)
-- [Reflection Usage & Philosophy](internal/website/docs/REFLECTION-EVALUATION-SUMMARY.md)
-
-**Security:**
-- [TLS Security Migration](internal/website/docs/TLS_SECURITY_UPDATE.md)
-- [Security Migration Guide](internal/website/docs/SECURITY_MIGRATION.md)
-
-## Supported AI Providers
-
-Go Micro’s `ai` package gives every provider the same interface: `Init`, `Generate`, `Stream`, and functional options. Swap providers with a single import.
-
-| Provider | Import | Default Model |
-|----------|--------|---------------|
-| **Anthropic** | `go-micro.dev/v5/ai/anthropic` | `claude-sonnet-4-20250514` |
-| **Google Gemini** | `go-micro.dev/v5/ai/gemini` | `gemini-2.5-flash` |
-| **Groq** | `go-micro.dev/v5/ai/groq` | `llama-3.3-70b-versatile` |
-| **Mistral** | `go-micro.dev/v5/ai/mistral` | `mistral-large-latest` |
-| **OpenAI** | `go-micro.dev/v5/ai/openai` | `gpt-4o` |
-| **Together AI** | `go-micro.dev/v5/ai/together` | `Llama-3.3-70B-Instruct-Turbo` |
-| **Atlas Cloud** | `go-micro.dev/v5/ai/atlascloud` | `llama-3.3-70b` |
-
-Any provider that exposes an OpenAI-compatible API can also be used directly:
-
-```go
-m := ai.New("openai",
-    ai.WithAPIKey("your-key"),
-    ai.WithBaseURL("https://api.yourprovider.com"),
-)
-```
-
-**Want to add your platform?** See the [AI Provider Integration Guide](internal/website/docs/guides/ai-provider-guide.md) for how to implement `ai.Model` and submit a PR. We welcome both code contributions and sponsorships from AI infrastructure companies — reach out via a [GitHub issue](https://github.com/micro/go-micro/issues).
-
 ## Adopters
 
-- [Sourse](https://sourse.eu) - Work in the field of earth observation, including embedded Kubernetes running onboard aircraft, and we’ve built a mission management SaaS platform using Go Micro.
+- [Sourse](https://sourse.eu) — Earth observation platform with embedded Kubernetes and SaaS built on Go Micro.

--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Go Micro - A pluggable Go framework for distributed systems and microservices" />
+    <meta name="description" content="Go Micro - A Go framework for building microservices that AI agents can use" />
     <meta name="go-import" content="go-micro.dev/v5 git https://github.com/micro/go-micro">
     <meta name="go-source" content="go-micro.dev/5 https://github.com/micro/go-micro https://github.com/micro/go-micro/tree/master{/dir} https://github.com/micro/go-micro/blob/master{/dir}/{file}#L{line}">
-    <title>Go Micro - Pluggable Go Microservices Framework</title>
+    <title>Go Micro - Microservices That AI Agents Can Use</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
       html { overflow-x: hidden; }
@@ -174,9 +174,9 @@
 
     <section class="hero">
       <div class="hero-inner">
-        <h1>Build Microservices in Go</h1>
-        <p class="tagline">A pluggable framework for distributed systems with built-in service discovery, RPC, pub/sub, and AI agent integration.</p>
-        <pre>go get go-micro.dev/v5</pre>
+        <h1>Microservices That AI Agents Can Use</h1>
+        <p class="tagline">Write services in Go. Every endpoint is automatically an AI-callable tool. An agent orchestrates across them.</p>
+        <pre>micro run --prompt "a task management system" --provider anthropic</pre>
         <div class="hero-buttons">
           <a href="/docs/getting-started.html" class="btn btn-primary">Get Started</a>
           <a href="https://github.com/micro/go-micro" class="btn btn-secondary">View on GitHub</a>
@@ -197,28 +197,28 @@
         <p class="subtitle">Sane defaults out of the box. Every abstraction is swappable.</p>
         <div class="features">
           <div class="feature">
+            <strong>Services as AI Tools</strong>
+            <p>Every endpoint is automatically callable by AI agents via Model Context Protocol.</p>
+          </div>
+          <div class="feature">
+            <strong>Agent Orchestration</strong>
+            <p><code>micro chat</code> discovers services and lets an LLM coordinate across them.</p>
+          </div>
+          <div class="feature">
+            <strong>Generate from a Prompt</strong>
+            <p><code>micro run --prompt</code> designs, generates, and starts services from plain English.</p>
+          </div>
+          <div class="feature">
             <strong>Service Discovery</strong>
             <p>Automatic registration and name resolution via mDNS, Consul, or etcd.</p>
           </div>
           <div class="feature">
-            <strong>RPC Client/Server</strong>
-            <p>Request/response and bidirectional streaming with load balancing built in.</p>
+            <strong>RPC &amp; Pub/Sub</strong>
+            <p>Request/response, streaming, and async events. gRPC, NATS, RabbitMQ built in.</p>
           </div>
           <div class="feature">
-            <strong>Pub/Sub Events</strong>
-            <p>Async messaging with NATS, RabbitMQ, or the built-in HTTP broker.</p>
-          </div>
-          <div class="feature">
-            <strong>Data Model</strong>
-            <p>Typed CRUD and queries backed by memory, SQLite, or Postgres.</p>
-          </div>
-          <div class="feature">
-            <strong>gRPC Native</strong>
-            <p>Use gRPC transport with any standard gRPC client. No lock-in.</p>
-          </div>
-          <div class="feature">
-            <strong>MCP &amp; AI Agents</strong>
-            <p>Every service is automatically an AI-callable tool via Model Context Protocol.</p>
+            <strong>Pluggable Everything</strong>
+            <p>All abstractions are Go interfaces. Swap any component without changing service code.</p>
           </div>
         </div>
       </div>
@@ -226,12 +226,16 @@
 
     <section class="section">
       <div class="two-col">
-        <div class="two-col-text">
-          <h2>Pluggable Architecture</h2>
-          <p>Services connect through a registry for discovery and a broker for events. Swap any component without changing your service code — go from mDNS to Consul, or HTTP to gRPC, with a single option.</p>
-        </div>
         <div>
-          <img src="/images/generated/architecture.png" alt="Go Micro architecture diagram" />
+          <img src="/images/generated/mcp-agent.png" alt="AI agent calling microservices via MCP" />
+        </div>
+        <div class="two-col-text">
+          <h2>Describe, Generate, Run, Chat</h2>
+          <p>Tell it what you need. The AI designs services, writes handlers with real business logic, compiles them, and starts them. Then talk to them through an agent that orchestrates across services automatically.</p>
+          <pre><span class="kw">$</span> <span class="fn">micro run</span> <span class="str">--prompt "an order system"</span>
+<span class="kw">$</span> <span class="fn">micro chat</span> <span class="str">--provider anthropic</span>
+<span class="kw">&gt;</span> Place an order for SKU-123 to London</pre>
+          <p><a href="/blog/13" class="btn btn-primary" style="margin-top: 0.75rem; display: inline-block;">See How It Works</a></p>
         </div>
       </div>
     </section>
@@ -239,13 +243,12 @@
     <section class="section-alt">
       <div class="section">
         <div class="two-col">
-          <div>
-            <img src="/images/generated/mcp-agent.png" alt="AI agent calling microservices via MCP" />
-          </div>
           <div class="two-col-text">
-            <h2>AI-Native by Default</h2>
-            <p>Every service is automatically an AI-callable tool via MCP. Call LLMs from your services with 7 providers. Generate images and video. Orchestrate services through natural language with <code>micro chat</code>.</p>
-            <p><a href="/docs/ai-integration.html" class="btn btn-primary" style="margin-top: 0.75rem; display: inline-block;">How It All Fits Together</a></p>
+            <h2>Pluggable Architecture</h2>
+            <p>Services connect through a registry for discovery and a broker for events. Swap any component without changing your service code — go from mDNS to Consul, or HTTP to gRPC, with a single option.</p>
+          </div>
+          <div>
+            <img src="/images/generated/architecture.png" alt="Go Micro architecture diagram" />
           </div>
         </div>
       </div>
@@ -255,7 +258,7 @@
       <div class="two-col">
         <div class="two-col-text">
           <h2>Developer Experience</h2>
-          <p><code>micro run</code> starts your services with hot reload, an API gateway, and an agent playground. <code>micro chat</code> lets you talk to your services through any LLM. <code>micro new --template crud</code> scaffolds a production-ready service in seconds.</p>
+          <p><code>micro run</code> starts your services with hot reload, an API gateway, and an agent playground. <code>micro chat</code> lets you talk to your services through any LLM. <code>micro deploy</code> pushes to production via SSH.</p>
         </div>
         <div>
           <img src="/images/generated/developer-experience.png" alt="Terminal showing micro run and micro chat" />


### PR DESCRIPTION
Both surfaces now lead with the same line: "Go Micro is a framework for building microservices that AI agents can use."

README:
- Leads with prompt generation + chat (the differentiator)
- Features as a compact table instead of paragraph-per-feature
- CLI workflow table
- Removed redundant sections, tightened to ~150 lines

Website:
- Hero: "Microservices That AI Agents Can Use"
- Hero command: micro run --prompt instead of go get
- Features grid reordered: AI tools, orchestration, generation first
- First two-col section: describe/generate/run/chat story
- Architecture and DX sections follow

Both tell the same story in the same order:
1. What it is (microservices framework)
2. What makes it different (every service is an AI tool)
3. How you use it (prompt → run → chat)
4. What's underneath (registry, RPC, store — all pluggable)

https://claude.ai/code/session_01QTp4SshuVmLAvvEGJe4TJd