### PR TITLE
Unify README and website documentation for Go Micro framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@ Write services in Go. They register, discover each other, and communicate via RP
 
 ## Quick Start
 
-Install Micro
+Install the CLI:
 
 ```bash
-go install go-micro.dev/v5/cmd/micro@v5.25.0
+# Binary (no Go required)
+curl -fsSL https://go-micro.dev/install.sh | sh
+
+# Or with Go
+go install go-micro.dev/v5/cmd/micro@latest
 ```
 
 Generate services from a description, start them, and talk to them:


### PR DESCRIPTION
Show curl install.sh first (no Go required), go install second. Uses the existing install script at go-micro.dev/install.sh which downloads pre-built binaries from GitHub releases.

https://claude.ai/code/session_01QTp4SshuVmLAvvEGJe4TJd