### PR TITLE
chore: update Discord invite link everywhere

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -48,4 +48,4 @@ Add any other context about the problem here.
 - [Troubleshooting Guide](https://github.com/micro/go-micro/tree/master/internal/website/docs/getting-started.md)
 - [Examples](https://github.com/micro/go-micro/tree/master/examples)
 - [API Reference](https://pkg.go.dev/go-micro.dev/v5)
-- [Discord Community](https://discord.gg/jwTYuUVAGh)
+- [Discord Community](https://discord.gg/WeMU5AGxD)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -39,4 +39,4 @@ Add any other context, code examples, or screenshots about the feature request h
 - [Roadmap](https://github.com/micro/go-micro/blob/master/ROADMAP.md)
 - [Contributing Guide](https://github.com/micro/go-micro/blob/master/CONTRIBUTING.md)
 - [Architecture Docs](https://github.com/micro/go-micro/tree/master/internal/website/docs/architecture.md)
-- [Discord Community](https://discord.gg/jwTYuUVAGh)
+- [Discord Community](https://discord.gg/WeMU5AGxD)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -174,6 +174,6 @@ We currently do not offer a bug bounty program, but we greatly appreciate respon
 
 For security questions that are not vulnerabilities, please:
 - Open a discussion: https://github.com/micro/go-micro/discussions
-- Join Discord: https://discord.gg/jwTYuUVAGh
+- Join Discord: https://discord.gg/WeMU5AGxD
 - Email: support@go-micro.dev
 

--- a/contrib/go-micro-llamaindex/README.md
+++ b/contrib/go-micro-llamaindex/README.md
@@ -324,4 +324,4 @@ Apache 2.0 - See [LICENSE](../../LICENSE) for details.
 ## Support
 
 - GitHub Discussions: https://github.com/micro/go-micro/discussions
-- Discord: https://discord.gg/jwTYuUVAGh
+- Discord: https://discord.gg/WeMU5AGxD

--- a/contrib/langchain-go-micro/CONTRIBUTING.md
+++ b/contrib/langchain-go-micro/CONTRIBUTING.md
@@ -102,4 +102,4 @@ pytest tests/integration/ -v
 ## Questions?
 
 - GitHub Discussions: https://github.com/micro/go-micro/discussions
-- Discord: https://discord.gg/jwTYuUVAGh
+- Discord: https://discord.gg/WeMU5AGxD

--- a/contrib/langchain-go-micro/README.md
+++ b/contrib/langchain-go-micro/README.md
@@ -370,4 +370,4 @@ Apache 2.0 - See [LICENSE](../../LICENSE) for details.
 ## Support
 
 - GitHub Discussions: https://github.com/micro/go-micro/discussions
-- Discord: https://discord.gg/jwTYuUVAGh
+- Discord: https://discord.gg/WeMU5AGxD

--- a/internal/docs/ROADMAP_2026.md
+++ b/internal/docs/ROADMAP_2026.md
@@ -957,7 +957,7 @@ Let's make it Go Micro.
 
 **Questions? Feedback?**
 - GitHub Discussions: https://github.com/micro/go-micro/discussions
-- Discord: https://discord.gg/jwTYuUVAGh
+- Discord: https://discord.gg/WeMU5AGxD
 
 ---
 

--- a/internal/website/blog/13.md
+++ b/internal/website/blog/13.md
@@ -177,4 +177,4 @@ The future of microservices isn't fewer services. It's making them so easy to cr
 
 ---
 
-*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/go-micro), or read the [docs](https://go-micro.dev/docs).*
+*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/WeMU5AGxD), or read the [docs](https://go-micro.dev/docs).*

--- a/internal/website/blog/14.md
+++ b/internal/website/blog/14.md
@@ -102,4 +102,4 @@ micro chat --provider anthropic
 
 ---
 
-*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/go-micro), or read the [docs](https://go-micro.dev/docs).*
+*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/WeMU5AGxD), or read the [docs](https://go-micro.dev/docs).*

--- a/internal/website/docs/guides/cli-gateway.md
+++ b/internal/website/docs/guides/cli-gateway.md
@@ -423,5 +423,5 @@ micro server --address :9000
 ## Need Help?
 
 - **Issues**: [github.com/micro/go-micro/issues](https://github.com/micro/go-micro/issues)
-- **Discord**: [discord.gg/jwTYuUVAGh](https://discord.gg/jwTYuUVAGh)
+- **Discord**: [discord.gg/WeMU5AGxD](https://discord.gg/WeMU5AGxD)
 - **Docs**: [go-micro.dev/docs](https://go-micro.dev/docs)

--- a/internal/website/docs/quickstart.md
+++ b/internal/website/docs/quickstart.md
@@ -87,7 +87,7 @@ publisher.Publish(ctx, &UserCreatedEvent{
 
 ## Get Help
 
-- **[Discord Community](https://discord.gg/jwTYuUVAGh)** - Chat with other users
+- **[Discord Community](https://discord.gg/WeMU5AGxD)** - Chat with other users
 - **[GitHub Issues](https://github.com/micro/go-micro/issues)** - Report bugs or request features
 - **[Documentation](https://go-micro.dev/docs/)** - Complete docs
 

--- a/internal/website/docs/roadmap-2026.md
+++ b/internal/website/docs/roadmap-2026.md
@@ -230,7 +230,7 @@ For the complete roadmap including business model details, risk mitigation, and 
 - [MCP Integration Guide](/docs/mcp)
 - [Blog: AI-Native Microservices](/blog/2)
 - [Examples](/examples)
-- [Discord Community](https://discord.gg/jwTYuUVAGh)
+- [Discord Community](https://discord.gg/WeMU5AGxD)
 
 ---
 


### PR DESCRIPTION
Replace discord.gg/jwTYuUVAGh and discord.gg/go-micro with discord.gg/WeMU5AGxD across all docs, blog posts, issue templates, security policy, and contrib READMEs.

https://claude.ai/code/session_01QTp4SshuVmLAvvEGJe4TJd