### PR TITLE
docs: update blog posts 15 and 16 to reflect RPC-based agents

### DIFF
--- a/internal/website/blog/15.md
+++ b/internal/website/blog/15.md
@@ -114,11 +114,11 @@ The service is the body. The agent is the mind assigned to it.
 
 The pieces already exist:
 
-- **Registry** — services register endpoints. Agents register alongside them with their domain knowledge and service assignments.
-- **Broker** — services communicate via events. Agents communicate the same way — agent-to-agent coordination through pub/sub.
-- **Store** — services persist data. Agents persist memory — conversation context, learned patterns, domain knowledge.
-- **`micro chat`** — today it's a single agent. Tomorrow it's a router that dispatches to the right agent based on the user's intent.
-- **`micro run --prompt`** — today it generates services. Tomorrow it generates services and their agents as a pair.
+- **Registry** — agents register as services with a proto-defined `Agent.Chat` endpoint. No special metadata hacks — they're real services.
+- **RPC** — `micro chat` calls agents via standard RPC. Agents call services via standard RPC. Agent-to-agent communication is just RPC. One protocol for everything.
+- **Store** — agents persist memory (conversation history, learned context) across restarts.
+- **`micro chat`** — discovers agents from the registry and routes to the right one based on intent.
+- **`micro run --prompt`** — generates services and an agent as a pair. Everything starts together.
 
 The framework was built for distributed systems. Agents are just the next thing we distribute.
 

--- a/internal/website/blog/16.md
+++ b/internal/website/blog/16.md
@@ -36,14 +36,29 @@ That's it. The agent:
 - Discovers `task` and `project` from the registry
 - Only sees their endpoints (scoped tools — no access to unrelated services)
 - Maintains conversation memory in the store (survives restarts)
-- Registers itself so `micro chat` and other agents can find it
+- Registers as a real service with a proto-defined `Agent.Chat` RPC endpoint
+- Discoverable by `micro chat`, other agents, or any go-micro client
+
+Under the hood, an agent IS a service. It has a real server, a real address, and a real proto definition:
+
+```protobuf
+service Agent {
+    rpc Chat(ChatRequest) returns (ChatResponse) {}
+}
+```
+
+This means you can call an agent the same way you call any service:
+
+```bash
+micro call task-mgr Agent.Chat '{"message": "What tasks are overdue?"}'
+```
 
 ## Talking to an Agent
 
 Programmatically:
 
 ```go
-resp, _ := agent.Chat(ctx, "What tasks are overdue for Alice?")
+resp, _ := agent.Ask(ctx, "What tasks are overdue for Alice?")
 fmt.Println(resp.Reply)
 ```
 


### PR DESCRIPTION
Blog 15: replaced broker-based agent communication with RPC — agents are services, they communicate via standard RPC, no pub/sub hacks. Updated the framework mapping section.

Blog 16: added proto definition, micro call example, and explanation that agents are real services with proto-defined endpoints. Updated Ask() method name.

https://claude.ai/code/session_01QTp4SshuVmLAvvEGJe4TJd