### PR TITLE
Update documentation for RPC-based agents and remove code references

### DIFF
--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -195,19 +195,19 @@
         <div class="features">
           <div class="feature">
             <strong>Services</strong>
-            <p>Write Go handlers. They register, discover each other, and communicate via RPC and events.</p>
+            <p>Build services in Go or generate them from a prompt. They register and discover each other automatically.</p>
           </div>
           <div class="feature">
             <strong>Agents</strong>
-            <p><code>micro.NewAgent()</code> — intelligent layer that manages services with scoped tools and memory.</p>
+            <p>Intelligent layer that manages services with scoped tools, memory, and domain knowledge.</p>
           </div>
           <div class="feature">
             <strong>Flows</strong>
-            <p><code>micro.NewFlow()</code> — event-driven LLM orchestration triggered by broker events.</p>
+            <p>Event-driven LLM orchestration. Subscribe to events and let an AI decide what to do.</p>
           </div>
           <div class="feature">
-            <strong>Generate from a Prompt</strong>
-            <p><code>micro run --prompt</code> generates services and an agent, then starts everything.</p>
+            <strong>Generate</strong>
+            <p><code>micro run --prompt</code> designs services and an agent, then starts everything.</p>
           </div>
           <div class="feature">
             <strong>MCP Gateway</strong>


### PR DESCRIPTION
Landing page describes concepts, not APIs. Removed micro.NewAgent() and micro.NewFlow() code references. Features described in plain language — what they do, not how to code them.

https://claude.ai/code/session_01QTp4SshuVmLAvvEGJe4TJd