### PR TITLE
docs: add 'become a sponsor' call-to-action linking to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Write services — they register, discover each other, and communicate via RPC a
 &nbsp;&nbsp;
 <a href="https://go-micro.dev/blog/8"><img src="https://www.atlascloud.ai/logo.svg" height="26" /></a>
 
+**Want to support Go Micro and see your logo here?** [Become a sponsor](https://discord.gg/WeMU5AGxD) — reach out on Discord.
+
 ## Quick Start
 
 Install the CLI:

--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -273,6 +273,8 @@
           <img src="https://www.atlascloud.ai/logo.svg" alt="Atlas Cloud" style="height: 28px; opacity: 0.7; transition: opacity 0.2s; box-shadow: none;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'" />
         </a>
       </div>
+      <p class="subtitle" style="margin-top: 2.25rem;">Want to support Go Micro and put your logo here?</p>
+      <a href="https://discord.gg/WeMU5AGxD" class="btn btn-secondary">Become a sponsor</a>
     </section>
 
     <section class="section-alt">


### PR DESCRIPTION
Now that there are a couple of sponsors, invite more: a short CTA under the Sponsors section in the README and on the landing page, pointing to the Discord to get in touch.