### PR TITLE
blog: 'When the Event Is the Prompt' (#21) + autonomous agent-flow ha…

### DIFF
--- a/internal/harness/agent-flow/main.go
+++ b/internal/harness/agent-flow/main.go
@@ -1,0 +1,272 @@
+// Agent Flow harness — "the event is the prompt".
+//
+// No human types anything. A user.created event lands on the broker, a
+// Flow renders it into a prompt and hands it to a registered agent, and
+// the agent reasons and acts through its services — creating a workspace
+// and sending a welcome. The whole stack is real (services, registry,
+// RPC, broker, the agent loop, store); only the LLM is mocked, so it
+// runs without an API key. Swap -provider to run it against a live model.
+//
+// Run:
+//
+//	go run ./internal/harness/agent-flow
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"go-micro.dev/v5/agent"
+	"go-micro.dev/v5/ai"
+	"go-micro.dev/v5/broker"
+	"go-micro.dev/v5/client"
+	"go-micro.dev/v5/flow"
+	"go-micro.dev/v5/registry"
+	"go-micro.dev/v5/selector"
+	"go-micro.dev/v5/service"
+	"go-micro.dev/v5/store"
+)
+
+// ---------------------------------------------------------------------------
+// real services
+// ---------------------------------------------------------------------------
+
+type Workspace struct {
+	ID    string `json:"id"`
+	Owner string `json:"owner"`
+}
+
+type CreateRequest struct {
+	Owner string `json:"owner" description:"Owner email of the workspace (required)"`
+}
+type CreateResponse struct {
+	Workspace *Workspace `json:"workspace"`
+}
+
+type WorkspaceService struct {
+	mu sync.Mutex
+	n  int
+}
+
+// Create provisions a workspace for a new user.
+// @example {"owner": "alice@acme.com"}
+func (s *WorkspaceService) Create(ctx context.Context, req *CreateRequest, rsp *CreateResponse) error {
+	s.mu.Lock()
+	s.n++
+	id := fmt.Sprintf("ws-%d", s.n)
+	s.mu.Unlock()
+	fmt.Printf("    \033[32m[workspace]\033[0m created %s for %s\n", id, req.Owner)
+	rsp.Workspace = &Workspace{ID: id, Owner: req.Owner}
+	return nil
+}
+
+func (s *WorkspaceService) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.n
+}
+
+type SendRequest struct {
+	To      string `json:"to" description:"Recipient address (required)"`
+	Message string `json:"message" description:"Message body (required)"`
+}
+type SendResponse struct {
+	Sent bool `json:"sent"`
+}
+type NotifyService struct {
+	mu sync.Mutex
+	n  int
+}
+
+// Send delivers a notification message to a recipient.
+// @example {"to": "alice@acme.com", "message": "Welcome"}
+func (s *NotifyService) Send(ctx context.Context, req *SendRequest, rsp *SendResponse) error {
+	s.mu.Lock()
+	s.n++
+	s.mu.Unlock()
+	fmt.Printf("    \033[35m[notify]\033[0m 📨 to=%s message=%q\n", req.To, req.Message)
+	rsp.Sent = true
+	return nil
+}
+
+func (s *NotifyService) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.n
+}
+
+// ---------------------------------------------------------------------------
+// mock LLM — the only fake. It reasons by the tools it's offered.
+// ---------------------------------------------------------------------------
+
+type mockModel struct{ opts ai.Options }
+
+func newMock(opts ...ai.Option) ai.Model {
+	m := &mockModel{}
+	_ = m.Init(opts...)
+	return m
+}
+
+func (m *mockModel) Init(opts ...ai.Option) error {
+	for _, o := range opts {
+		o(&m.opts)
+	}
+	return nil
+}
+func (m *mockModel) Options() ai.Options { return m.opts }
+func (m *mockModel) String() string      { return "mock" }
+func (m *mockModel) Stream(ctx context.Context, req *ai.Request, _ ...ai.GenerateOption) (ai.Stream, error) {
+	return nil, fmt.Errorf("stream not supported by mock")
+}
+
+func findTool(tools []ai.Tool, sub string) string {
+	for _, t := range tools {
+		if strings.Contains(t.Name, sub) {
+			return t.Name
+		}
+	}
+	return ""
+}
+
+func (m *mockModel) call(name string, input map[string]any) {
+	args, _ := json.Marshal(input)
+	fmt.Printf("  \033[33m[onboarder]\033[0m → %s(%s)\n", name, args)
+	if m.opts.ToolHandler != nil {
+		m.opts.ToolHandler(name, input)
+	}
+}
+
+func (m *mockModel) Generate(ctx context.Context, req *ai.Request, _ ...ai.GenerateOption) (*ai.Response, error) {
+	owner := "alice@acme.com"
+	if create := findTool(req.Tools, "Create"); create != "" {
+		m.call(create, map[string]any{"owner": owner})
+	}
+	if send := findTool(req.Tools, "Send"); send != "" {
+		m.call(send, map[string]any{"to": owner, "message": "Welcome — your workspace is ready."})
+	}
+	return &ai.Response{Answer: "Onboarded " + owner + "."}, nil
+}
+
+// ---------------------------------------------------------------------------
+// wiring
+// ---------------------------------------------------------------------------
+
+func providerKey(provider string) string {
+	if v := os.Getenv("MICRO_AI_API_KEY"); v != "" {
+		return v
+	}
+	env := map[string]string{
+		"anthropic": "ANTHROPIC_API_KEY", "openai": "OPENAI_API_KEY",
+		"gemini": "GEMINI_API_KEY", "groq": "GROQ_API_KEY", "mistral": "MISTRAL_API_KEY",
+		"together": "TOGETHER_API_KEY", "atlascloud": "ATLASCLOUD_API_KEY",
+	}[provider]
+	return os.Getenv(env)
+}
+
+func waitFor(reg registry.Registry, name string) {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if svcs, err := reg.GetService(name); err == nil && len(svcs) > 0 && len(svcs[0].Nodes) > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func main() {
+	provider := flag.String("provider", "mock", "LLM provider: mock (default), anthropic, openai, ...")
+	flag.Parse()
+
+	apiKey := ""
+	if *provider == "mock" {
+		ai.Register("mock", newMock)
+	} else {
+		apiKey = providerKey(*provider)
+		if apiKey == "" {
+			fmt.Printf("no API key for provider %q — set MICRO_AI_API_KEY or the provider's key env\n", *provider)
+			return
+		}
+	}
+
+	fmt.Printf("\n\033[1mAgent Flow — the event is the prompt (provider: %s)\033[0m\n", *provider)
+	fmt.Print("No human prompt: a user.created event triggers an agent that onboards the user.\n\n")
+
+	reg := registry.NewMemoryRegistry()
+	br := broker.NewMemoryBroker()
+	if err := br.Connect(); err != nil {
+		fmt.Println("broker connect:", err)
+		os.Exit(1)
+	}
+	cl := client.NewClient(client.Registry(reg), client.Selector(selector.NewSelector(selector.Registry(reg))))
+	mem := store.NewMemoryStore()
+
+	wsSvc := new(WorkspaceService)
+	ws := service.New(service.Name("workspace"), service.Registry(reg), service.Client(cl))
+	ws.Handle(wsSvc)
+	go ws.Run()
+
+	ntSvc := new(NotifyService)
+	nt := service.New(service.Name("notify"), service.Registry(reg), service.Client(cl))
+	nt.Handle(ntSvc)
+	go nt.Run()
+
+	// The onboarder agent, registered so the flow can reach it over RPC.
+	onboarder := agent.New(
+		agent.Name("onboarder"),
+		agent.Services("workspace", "notify"),
+		agent.Prompt("You onboard new users. Create their workspace and send a welcome message."),
+		agent.Provider(*provider),
+		agent.APIKey(apiKey),
+		agent.WithRegistry(reg), agent.WithClient(cl), agent.WithStore(mem),
+	)
+	go onboarder.Run()
+	defer onboarder.Stop()
+
+	waitFor(reg, "workspace")
+	waitFor(reg, "notify")
+	waitFor(reg, "onboarder")
+
+	// A workflow that turns the event into a prompt for the agent.
+	f := flow.New("onboard",
+		flow.Trigger("events.user.created"),
+		flow.Agent("onboarder"),
+		flow.Prompt("A new user signed up: {{.Data}}. Get them set up."),
+	)
+	if err := f.Register(reg, br, cl); err != nil {
+		fmt.Println("flow register:", err)
+		os.Exit(1)
+	}
+
+	fmt.Print("\033[1m> event:\033[0m publishing events.user.created {\"email\":\"alice@acme.com\"}\n\n")
+
+	// The event — no human in the loop.
+	if err := br.Publish("events.user.created", &broker.Message{
+		Body: []byte(`{"email":"alice@acme.com"}`),
+	}); err != nil {
+		fmt.Println("publish:", err)
+		os.Exit(1)
+	}
+
+	// Wait for the agent to finish acting.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if ntSvc.count() >= 1 && wsSvc.count() >= 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	fmt.Printf("\n\033[1mresult:\033[0m workspaces created=%d, notifications sent=%d\n", wsSvc.count(), ntSvc.count())
+	if rs := f.Results(); len(rs) > 0 {
+		fmt.Printf("flow reply: %s\n", rs[len(rs)-1].Reply)
+	}
+	if wsSvc.count() >= 1 && ntSvc.count() >= 1 {
+		fmt.Println("\n\033[32m✓ the agent onboarded the user — triggered by an event, not a prompt\033[0m")
+	}
+}

--- a/internal/harness/agent-flow/main_test.go
+++ b/internal/harness/agent-flow/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"go-micro.dev/v5/agent"
+	"go-micro.dev/v5/ai"
+	"go-micro.dev/v5/broker"
+	"go-micro.dev/v5/client"
+	"go-micro.dev/v5/flow"
+	"go-micro.dev/v5/registry"
+	"go-micro.dev/v5/selector"
+	"go-micro.dev/v5/service"
+	"go-micro.dev/v5/store"
+)
+
+// TestEventTriggersAgentNoPrompt proves "the event is the prompt": a
+// broker event drives a Flow that hands off to a registered agent, which
+// reasons and acts through its services — workspace created, welcome
+// sent — with no human prompt anywhere. Real services, registry, RPC,
+// broker, agent loop, store; only the LLM is mocked. No mDNS, no sleeps
+// beyond polling for the asynchronous side effect.
+func TestEventTriggersAgentNoPrompt(t *testing.T) {
+	ai.Register("mock", newMock)
+
+	reg := registry.NewMemoryRegistry()
+	br := broker.NewMemoryBroker()
+	if err := br.Connect(); err != nil {
+		t.Fatalf("broker connect: %v", err)
+	}
+	cl := client.NewClient(
+		client.Registry(reg),
+		client.Selector(selector.NewSelector(selector.Registry(reg))),
+	)
+	mem := store.NewMemoryStore()
+
+	wsSvc := new(WorkspaceService)
+	ws := service.New(service.Name("workspace"), service.Registry(reg), service.Client(cl))
+	if err := ws.Handle(wsSvc); err != nil {
+		t.Fatalf("handle workspace: %v", err)
+	}
+	go ws.Run()
+
+	ntSvc := new(NotifyService)
+	nt := service.New(service.Name("notify"), service.Registry(reg), service.Client(cl))
+	if err := nt.Handle(ntSvc); err != nil {
+		t.Fatalf("handle notify: %v", err)
+	}
+	go nt.Run()
+
+	onboarder := agent.New(
+		agent.Name("onboarder"),
+		agent.Services("workspace", "notify"),
+		agent.Prompt("You onboard new users. Create their workspace and send a welcome message."),
+		agent.Provider("mock"),
+		agent.WithRegistry(reg), agent.WithClient(cl), agent.WithStore(mem),
+	)
+	go onboarder.Run()
+	defer onboarder.Stop()
+
+	waitFor(reg, "workspace")
+	waitFor(reg, "notify")
+	waitFor(reg, "onboarder")
+
+	f := flow.New("onboard",
+		flow.Trigger("events.user.created"),
+		flow.Agent("onboarder"),
+		flow.Prompt("A new user signed up: {{.Data}}. Get them set up."),
+	)
+	if err := f.Register(reg, br, cl); err != nil {
+		t.Fatalf("flow register: %v", err)
+	}
+
+	// The event — nobody typed a prompt.
+	if err := br.Publish("events.user.created", &broker.Message{
+		Body: []byte(`{"email":"alice@acme.com"}`),
+	}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	// Wait for the agent to act (delivery is asynchronous).
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if wsSvc.count() >= 1 && ntSvc.count() >= 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if got := wsSvc.count(); got != 1 {
+		t.Errorf("workspace created %d times, want 1", got)
+	}
+	if got := ntSvc.count(); got != 1 {
+		t.Errorf("notify sent %d times, want 1 (event->flow->agent chain broken)", got)
+	}
+	if rs := f.Results(); len(rs) == 0 || rs[len(rs)-1].Reply == "" {
+		t.Errorf("flow recorded no result for the event")
+	}
+}

--- a/internal/website/blog/21.md
+++ b/internal/website/blog/21.md
@@ -1,0 +1,76 @@
+---
+layout: blog
+title: "When the Event Is the Prompt"
+permalink: /blog/21
+description: "Most agents wait for a human to type something. The useful ones don't — they run because something happened in the system. A Flow turns an event into the prompt, and an agent acts on its own."
+---
+
+# When the Event Is the Prompt
+
+*June 15, 2026 &bull; Asim Aslam*
+
+Almost every agent demo starts the same way: a human types a prompt, the agent responds. That framing is a habit from chat, and it hides the more useful case. The agents worth running don't wait for you to ask. They run because something happened — a user signed up, a payment failed, a deployment finished, a metric crossed a line. In those systems there is no prompt, because there is no human in the loop. The event is the prompt.
+
+Go Micro has had the pieces for this since we added [workflows](/blog/18): a `Flow` subscribes to a broker topic, and an `Agent` reasons and acts. Putting them together is the point of this post.
+
+## The shape
+
+A workflow is the deterministic half — it knows *when* to run (an event arrives) and turns that event into a prompt. An agent is the dynamic half — it decides *what to do* about it. Connect them and you get an agent that runs on events, unattended.
+
+```go
+// The agent: it onboards new users using its services.
+onboarder := micro.NewAgent("onboarder",
+    micro.AgentServices("workspace", "notify"),
+    micro.AgentPrompt("You onboard new users. Create their workspace and send a welcome."),
+    micro.AgentProvider("anthropic"),
+)
+go onboarder.Run()
+
+// The workflow: when a user signs up, hand the event to the agent.
+f := micro.NewFlow("onboard",
+    micro.FlowTrigger("events.user.created"),
+    micro.FlowPrompt("A new user signed up: {{.Data}}. Get them set up."),
+    micro.FlowAgent("onboarder"),
+)
+```
+
+When a `user.created` event lands on the broker, the flow renders it into a prompt and hands it to the onboarder over RPC. The agent looks at its tools, creates the workspace, sends the welcome, and stops. No one typed anything.
+
+There's a runnable version of exactly this in [`internal/harness/agent-flow`](https://github.com/micro/go-micro/tree/master/internal/harness/agent-flow) — real services, registry, RPC, broker, and the agent loop, with only the model mocked so it runs without a key:
+
+```
+> event: publishing events.user.created {"email":"alice@acme.com"}
+
+  [onboarder] → workspace_WorkspaceService_Create({"owner":"alice@acme.com"})
+    [workspace] created ws-1 for alice@acme.com
+  [onboarder] → notify_NotifyService_Send({"to":"alice@acme.com","message":"Welcome — your workspace is ready."})
+    [notify] 📨 to=alice@acme.com message="Welcome — your workspace is ready."
+
+✓ the agent onboarded the user — triggered by an event, not a prompt
+```
+
+## This is where microagents become real
+
+A chat agent is something you visit. An event-driven agent is something that runs. That difference is what makes [an agent for everything](/blog/20) practical: each domain gets a small agent that wakes on its own events and acts. Payments has an agent that responds to failed charges. Ops has one that reacts to alerts. Support has one that triages new tickets. None of them is a monolithic brain holding the whole system in one context; each is scoped, each runs on its events, and they reach each other over RPC when they need to. It's the microservices decomposition, applied to the intelligence.
+
+The mechanics are already there: an agent is a service, agents call each other with `delegate`, and a flow is the trigger. The only thing that changed is the absence of a person at the start of the loop.
+
+## What running unattended demands
+
+Taking the human out of the loop raises the bar, and it's worth being honest about that rather than pretending it's free.
+
+- **Guardrails stop being optional.** When you're sitting in a chat you are the stopping condition — you see a wrong turn and intervene. An event-driven agent has no one watching, so the bounds have to be in the code: `MaxSteps` to cap what it can do per event, and `ApproveTool` to gate the actions that genuinely need a human or a policy check. For an unattended agent these are load-bearing, not nice-to-haves.
+- **Observability becomes the interface.** If no one is reading the agent's replies, the trace of what it did is the only way to know it did the right thing. The reply text matters less than a record of the tools it called and the results it got.
+- **Execution has to be durable.** An event-driven agent may run longer than a request, and it has to survive a restart without dropping the work or repeating it. Its memory is already store-backed and durable; the loop itself needs to be checkpointed and resumable in the same way.
+
+The first of these is shipped today. The other two are the next things to build, and they're the same gaps the [last post](/blog/20) named — autonomy is what makes them urgent.
+
+## Three primitives, one substrate
+
+This is the whole picture coming together:
+
+- a **service** is a capability;
+- an **agent** is intelligence pointed at capabilities;
+- a **workflow** is the trigger — and when the trigger is an event, it is also the prompt.
+
+You compose them. A workflow turns an event into a prompt, an agent reasons about it, services do the work, and other agents pick up the parts they own. The human moves from typing every instruction to setting the system up and letting it run. That is the shift worth building for: not better chat, but software that acts on its own — on the same services, agents, and workflows you already have.

--- a/internal/website/blog/index.html
+++ b/internal/website/blog/index.html
@@ -12,6 +12,13 @@ permalink: /blog/
 <div class="posts">
 
   <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
+    <h2 style="margin: 0 0 0.5rem;"><a href="/blog/21">When the Event Is the Prompt</a></h2>
+    <p class="meta" style="color: #666; font-size: 0.85rem;">June 15, 2026</p>
+    <p>Most agents wait for a human to type something. The useful ones don't — they run because something happened in the system. A Flow turns an event into the prompt, and an agent acts on its own.</p>
+    <a href="/blog/21">Read more &rarr;</a>
+  </article>
+
+  <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
     <h2 style="margin: 0 0 0.5rem;"><a href="/blog/20">Doubling Down on Agents</a></h2>
     <p class="meta" style="color: #666; font-size: 0.85rem;">June 10, 2026</p>
     <p>Go Micro made services easy by being opinionated, batteries-included, and pluggable. We're applying the same model to agents — a model, memory, and tools that compose like a service does.</p>


### PR DESCRIPTION
…rness

The autonomy direction: agents that run on events, not human prompts.

- internal/harness/agent-flow: a runnable, deterministic demo — a user.created broker event drives a Flow that hands off to a registered agent (FlowAgent), which creates a workspace and sends a welcome over real RPC. Only the LLM is mocked; passes under -race.
- blog/21: 'When the Event Is the Prompt' — the shift from agents you talk to, to agents that act on their own; where microagents become real; and the honest bar autonomy raises (guardrails, observability, durable/resumable execution — the next things to build).