### PR TITLE
feat(x402): opt-in agent-native payments for tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,19 @@ agent := micro.NewAgent("assistant",
 
 **Memory** is durable and store-backed by default (Postgres, NATS KV, or file), so an agent picks up where it left off after a restart — or supply your own with `AgentMemory`. **Tools** are your services automatically, plus any function you register with `AgentTool`.
 
+### Paid tools (x402)
+
+Every endpoint is an AI-callable tool — and it can be a *paid* tool. Go Micro supports [x402](https://x402.org), the HTTP 402 payment standard for agents, so a tool can require a stablecoin payment and an agent can settle it autonomously. It's opt-in and carries no crypto in the framework: verification is delegated to a pluggable facilitator (Coinbase, Alchemy, self-hosted), so Base and Solana are just different facilitators.
+
+```bash
+# Charge for tool calls at the MCP gateway (off unless you set a pay-to address)
+micro mcp serve --x402-pay-to 0xYourAddress --x402-network solana --x402-amount 10000
+# Per-tool amounts via a config file
+micro mcp serve --x402-config x402.json
+```
+
+See the [Payments (x402) guide](internal/website/docs/guides/x402-payments.md).
+
 ## Features
 
 ### AI
@@ -344,6 +357,7 @@ See [all examples](examples/README.md).
 - [Agents and Workflows](internal/website/docs/guides/agents-and-workflows.md)
 - [Agent Design](internal/docs/AGENT_DESIGN.md)
 - [Plan & Delegate](internal/website/docs/guides/plan-delegate.md)
+- [Payments (x402)](internal/website/docs/guides/x402-payments.md)
 - [MCP & AI Agents](internal/website/docs/mcp.md)
 - [Data Model](internal/website/docs/model.md)
 - [Deployment](internal/website/docs/deployment.md)

--- a/cmd/micro-mcp-gateway/main.go
+++ b/cmd/micro-mcp-gateway/main.go
@@ -73,9 +73,9 @@ func main() {
 				EnvVars: []string{"X402_PAY_TO"},
 			},
 			&cli.StringFlag{
-				Name:    "x402-price",
-				Usage:   "Per-call price in the asset's smallest unit (e.g. 10000 = 0.01 USDC)",
-				EnvVars: []string{"X402_PRICE"},
+				Name:    "x402-amount",
+				Usage:   "Default amount required per tool call, in the asset's smallest unit (e.g. 10000 = 0.01 USDC)",
+				EnvVars: []string{"X402_AMOUNT"},
 			},
 			&cli.StringFlag{
 				Name:    "x402-network",
@@ -87,6 +87,11 @@ func main() {
 				Name:    "x402-facilitator",
 				Usage:   "x402 facilitator URL (Coinbase CDP, Alchemy, or self-hosted)",
 				EnvVars: []string{"X402_FACILITATOR"},
+			},
+			&cli.StringFlag{
+				Name:    "x402-config",
+				Usage:   "Path to an x402 config file (payTo, network, asset, amount, per-tool amounts); overrides the x402-* flags",
+				EnvVars: []string{"X402_CONFIG"},
 			},
 			&cli.Float64Flag{
 				Name:    "rate-limit",
@@ -153,11 +158,18 @@ func run(c *cli.Context) error {
 		Logger:   logger,
 	}
 
-	// Opt-in x402 payments: enabled when a pay-to address is given.
-	if payTo := c.String("x402-pay-to"); payTo != "" {
+	// Opt-in x402 payments: a config file (per-tool amounts) or flags.
+	if cfgPath := c.String("x402-config"); cfgPath != "" {
+		cfg, err := x402.LoadConfig(cfgPath)
+		if err != nil {
+			return fmt.Errorf("x402 config: %w", err)
+		}
+		opts.Payment = cfg
+		logger.Printf("x402 payments enabled from %s (payTo %s)", cfgPath, cfg.PayTo)
+	} else if payTo := c.String("x402-pay-to"); payTo != "" {
 		opts.Payment = &x402.Config{
 			PayTo:          payTo,
-			Price:          c.String("x402-price"),
+			Amount:         c.String("x402-amount"),
 			Network:        c.String("x402-network"),
 			FacilitatorURL: c.String("x402-facilitator"),
 		}

--- a/cmd/micro/mcp/mcp.go
+++ b/cmd/micro/mcp/mcp.go
@@ -90,8 +90,8 @@ Examples:
 						Usage: "Enable x402 payments for tool calls; the address payments are sent to",
 					},
 					&cli.StringFlag{
-						Name:  "x402_price",
-						Usage: "Per-call price in the asset's smallest unit (e.g. 10000 = 0.01 USDC)",
+						Name:  "x402_amount",
+						Usage: "Default amount required per tool call, in the asset's smallest unit (e.g. 10000 = 0.01 USDC)",
 					},
 					&cli.StringFlag{
 						Name:  "x402_network",
@@ -101,6 +101,10 @@ Examples:
 					&cli.StringFlag{
 						Name:  "x402_facilitator",
 						Usage: "x402 facilitator URL (Coinbase CDP, Alchemy, or self-hosted)",
+					},
+					&cli.StringFlag{
+						Name:  "x402_config",
+						Usage: "Path to an x402 config file (payTo, network, asset, amount, per-tool amounts); overrides the x402_* flags",
 					},
 				},
 				Action: serveAction,
@@ -251,11 +255,17 @@ func serveAction(ctx *cli.Context) error {
 		Logger:   log.Default(),
 	}
 
-	// Opt-in x402 payments: enabled when a pay-to address is given.
-	if payTo := ctx.String("x402_pay_to"); payTo != "" {
+	// Opt-in x402 payments: a config file (per-tool amounts) or flags.
+	if cfgPath := ctx.String("x402_config"); cfgPath != "" {
+		cfg, err := x402.LoadConfig(cfgPath)
+		if err != nil {
+			return err
+		}
+		opts.Payment = cfg
+	} else if payTo := ctx.String("x402_pay_to"); payTo != "" {
 		opts.Payment = &x402.Config{
 			PayTo:          payTo,
-			Price:          ctx.String("x402_price"),
+			Amount:         ctx.String("x402_amount"),
 			Network:        ctx.String("x402_network"),
 			FacilitatorURL: ctx.String("x402_facilitator"),
 		}

--- a/gateway/mcp/mcp.go
+++ b/gateway/mcp/mcp.go
@@ -559,15 +559,18 @@ func (s *Server) watchServices() {
 func (s *Server) serveHTTP() error {
 	mux := http.NewServeMux()
 
-	// MCP endpoints. Tool calls can be gated behind an x402 payment;
-	// listing tools and health stay free.
-	var call http.Handler = http.HandlerFunc(s.handleCallTool)
+	// MCP endpoints. Tool calls can be gated behind an x402 payment
+	// (enforced per-tool inside handleCallTool); listing tools and health
+	// stay free.
 	if s.opts.Payment != nil {
-		call = x402.Middleware(*s.opts.Payment)(call)
-		s.opts.Logger.Printf("[mcp] x402 payments enabled (network=%s, payTo=%s)", s.opts.Payment.Network, s.opts.Payment.PayTo)
+		net := s.opts.Payment.Network
+		if net == "" {
+			net = "base"
+		}
+		s.opts.Logger.Printf("[mcp] x402 payments enabled (network=%s, payTo=%s)", net, s.opts.Payment.PayTo)
 	}
 	mux.HandleFunc("/mcp/tools", s.handleListTools)
-	mux.Handle("/mcp/call", call)
+	mux.HandleFunc("/mcp/call", s.handleCallTool)
 	mux.HandleFunc("/health", s.handleHealth)
 
 	// WebSocket endpoint for bidirectional streaming
@@ -638,6 +641,15 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 	if !exists {
 		http.Error(w, "Tool not found", http.StatusNotFound)
 		return
+	}
+
+	// x402 payment gate: require the tool's amount before doing work.
+	// Free tools (amount "" or "0") pass through; Require writes the 402
+	// challenge itself when payment is missing or invalid.
+	if s.opts.Payment != nil {
+		if !s.opts.Payment.Require(w, r, s.opts.Payment.AmountFor(req.Tool), req.Tool) {
+			return
+		}
 	}
 
 	// Generate trace ID for this call

--- a/internal/website/_data/navigation.yml
+++ b/internal/website/_data/navigation.yml
@@ -36,6 +36,8 @@ guides:
     url: /docs/guides/agents-and-workflows.html
   - title: Plan & Delegate
     url: /docs/guides/plan-delegate.html
+  - title: Payments (x402)
+    url: /docs/guides/x402-payments.html
   - title: Atlas Cloud Integration
     url: /docs/guides/atlascloud-integration.html
   - title: AI Provider Guide

--- a/internal/website/blog/22.md
+++ b/internal/website/blog/22.md
@@ -35,7 +35,7 @@ So Go Micro stays chain-agnostic. "Base through Coinbase" and "Solana through Al
 pay := x402.Middleware(x402.Config{
     PayTo:   "0xYourAddress",      // where payments go
     Network: "solana",            // or "base", ...
-    Price:   "10000",             // smallest units, e.g. 0.01 USDC
+    Amount:  "10000",             // smallest units, e.g. 0.01 USDC
 })
 mux.Handle("/paid", pay(handler))
 ```
@@ -48,11 +48,25 @@ Because every Go Micro endpoint is already an AI-callable tool through the MCP g
 micro mcp serve --address :3000 \
     --x402-pay-to 0xYourAddress \
     --x402-network solana \
-    --x402-price 10000 \
+    --x402-amount 10000 \
     --x402-facilitator https://facilitator.example
 ```
 
 With payments enabled, the `/mcp/call` endpoint requires a verified payment; listing tools and health checks stay free. Without the flag, nothing changes. The standalone gateway takes the same options via flags or environment variables, so you can put a paid gateway in front of services you didn't write.
+
+Different tools can cost different amounts. Because pricing is an operator concern — the payTo address is the operator's, and prices change without redeploying anyone's service — it's set at the gateway with a config file, the same way per-tool scopes and rate limits already are:
+
+```json
+{ "payTo": "0xYourAddress", "network": "solana", "asset": "USDC",
+  "amount": "0",
+  "amounts": { "weather.Weather.Forecast": "10000", "search.Search.Query": "5000" } }
+```
+
+```bash
+micro mcp serve --address :3000 --x402-config x402.json
+```
+
+`amount` is the default (here `0` — free), and `amounts` sets per-tool overrides. There's no "pricing" abstraction in the framework; it's just the x402 amount, resolved per tool, in the protocol's own vocabulary.
 
 ## Why this matters
 
@@ -61,7 +75,7 @@ Go Micro's premise has been that every service is a tool an agent can call. x402
 ## Honest about the edges
 
 - **It's opt-in and dependency-light.** No pay-to address, no payments. Go Micro pulls in no chain libraries — the facilitator does that work.
-- **Pricing starts simple.** A flat price per tool call today; richer models — per-tool pricing, metered usage, subscriptions — are the harder design work to come.
+- **Amounts start simple.** A default amount, or per-tool amounts via the gateway config today; metered usage and prepaid balances (the place a "credit" concept would actually fit) are the harder design work to come.
 - **A paying agent needs a budget.** Blog 21 argued that unattended agents need guardrails; an unattended agent that spends money needs them most. A spend cap belongs next to `MaxSteps` and `ApproveTool`, and it's the next piece to build on the agent side.
 
 Agents that act, and now can pay. Services, agents, workflows, and payments — the substrate for software that operates, and transacts, on its own.

--- a/internal/website/docs/guides/x402-payments.md
+++ b/internal/website/docs/guides/x402-payments.md
@@ -1,0 +1,84 @@
+---
+layout: default
+---
+
+# Payments (x402)
+
+Go Micro can require a payment before a tool runs, using [x402](https://x402.org) — the open HTTP **402 Payment Required** standard for stablecoin payments, designed for AI agents and onchain APIs. It lets every Go Micro endpoint, already exposed as an AI-callable tool, become a *paid* tool: a service answers a call with `402` and payment requirements, the client pays and retries, and the gateway verifies the payment before serving.
+
+Payments are **opt-in** and **dependency-light**. Go Micro carries no chain or crypto code — it speaks the protocol and delegates verification and settlement to a pluggable **facilitator** (Coinbase CDP, Alchemy, or self-hosted), so Base and Solana are just different facilitators behind one interface.
+
+## The wrapper
+
+The core is HTTP middleware in `go-micro.dev/v5/wrapper/x402`:
+
+```go
+import "go-micro.dev/v5/wrapper/x402"
+
+pay := x402.Middleware(x402.Config{
+    PayTo:          "0xYourAddress",            // where payments go (required)
+    Network:        "base",                     // or "solana", ...
+    Amount:         "10000",                    // smallest units, e.g. 0.01 USDC
+    FacilitatorURL: "https://facilitator.example",
+})
+mux.Handle("/paid", pay(handler))
+```
+
+A request with no `X-PAYMENT` header gets a `402` with the requirements; once a payment verifies through the facilitator, the request is served (with settlement details on the `X-PAYMENT-RESPONSE` header).
+
+### Pluggable facilitator
+
+`Config.Facilitator` is an interface; the default is an `HTTPFacilitator` pointed at `FacilitatorURL`. Implement your own to target any chain or hosted service:
+
+```go
+type Facilitator interface {
+    Verify(ctx context.Context, payment string, req Requirements) (Result, error)
+}
+```
+
+## At the MCP gateway
+
+Because every endpoint is already an MCP tool, the gateway is where you charge. Payments are wired into both `micro mcp serve` and the standalone `micro-mcp-gateway`, gated on `/mcp/call` (listing tools and health stay free), and **off unless you set a pay-to address**.
+
+```bash
+micro mcp serve --address :3000 \
+    --x402-pay-to 0xYourAddress \
+    --x402-network solana \
+    --x402-amount 10000 \
+    --x402-facilitator https://facilitator.example
+```
+
+## Per-tool amounts
+
+Different tools can cost different amounts. Pricing is an **operator** concern — the payTo address is the operator's, and amounts change without redeploying anyone's service — so it's configured at the gateway with a file, the same way per-tool scopes and rate limits are. Point the gateway at an x402 config:
+
+```bash
+micro mcp serve --address :3000 --x402-config x402.json
+```
+
+```json
+{
+  "payTo": "0xYourAddress",
+  "network": "solana",
+  "asset": "USDC",
+  "amount": "0",
+  "amounts": {
+    "weather.Weather.Forecast": "10000",
+    "search.Search.Query": "5000"
+  }
+}
+```
+
+`amount` is the default (here `"0"` — free unless priced), and `amounts` sets per-tool overrides keyed by tool name. There is no "pricing" abstraction; it's the x402 `amount`, resolved per tool, in the protocol's own vocabulary. The standalone gateway accepts the same file via `--x402-config` or the `X402_CONFIG` environment variable.
+
+## Notes
+
+- **Opt-in.** No pay-to address (and no config), no payments — nothing changes.
+- **No crypto in the framework.** The facilitator does verification and settlement on-chain; Go Micro speaks HTTP.
+- **A paying agent needs a budget.** On the agent side, an unattended agent that spends money needs a spend cap next to `MaxSteps` and `ApproveTool` — see [Plan & Delegate](plan-delegate.html) for the guardrail model. This is active work.
+
+## See also
+
+- [Building Effective Agents — Agents and Workflows](agents-and-workflows.html)
+- [MCP & AI Agents](../mcp.html)
+- [x402 — Coinbase Developer Docs](https://docs.cdp.coinbase.com/x402/welcome) · [x402 on Solana](https://solana.com/x402/what-is-x402)

--- a/wrapper/x402/x402.go
+++ b/wrapper/x402/x402.go
@@ -11,7 +11,7 @@
 //	pay := x402.Middleware(x402.Config{
 //	    PayTo:   "0xYourAddress",   // where payments go
 //	    Network: "base",            // or "solana", ...
-//	    Price:   "10000",           // smallest units (e.g. 0.01 USDC)
+//	    Amount:  "10000",           // smallest units (e.g. 0.01 USDC)
 //	})
 //	mux.Handle("/paid", pay(handler))
 //
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 )
 
 // Version is the x402 protocol version this package speaks.
@@ -73,25 +74,30 @@ type Facilitator interface {
 	Verify(ctx context.Context, payment string, req Requirements) (Result, error)
 }
 
-// Config configures payment enforcement for a set of routes.
+// Config configures payment enforcement for a set of routes or tools.
 type Config struct {
 	// PayTo is the address payments are sent to. Required.
-	PayTo string
+	PayTo string `json:"payTo"`
 	// Network is the chain to settle on (default "base").
-	Network string
+	Network string `json:"network,omitempty"`
 	// Asset is the token contract/mint (default: the network's USDC).
-	Asset string
-	// Price is the amount required per request, in the asset's smallest
-	// unit (e.g. "10000" for 0.01 USDC at 6 decimals).
-	Price string
+	Asset string `json:"asset,omitempty"`
+	// Amount is the default amount required per request, in the asset's
+	// smallest unit (e.g. "10000" for 0.01 USDC at 6 decimals). "0" or
+	// empty means free.
+	Amount string `json:"amount,omitempty"`
+	// Amounts overrides Amount per tool/resource name, so an operator can
+	// charge for tools individually — the way Scopes and RateLimit are
+	// configured per tool at the gateway.
+	Amounts map[string]string `json:"amounts,omitempty"`
 	// Description is shown to the paying client/agent.
-	Description string
+	Description string `json:"description,omitempty"`
 	// Facilitator verifies payments. Defaults to an HTTPFacilitator
 	// pointed at FacilitatorURL.
-	Facilitator Facilitator
+	Facilitator Facilitator `json:"-"`
 	// FacilitatorURL is the verify/settle endpoint used when Facilitator
 	// is nil (e.g. Coinbase CDP or Alchemy).
-	FacilitatorURL string
+	FacilitatorURL string `json:"facilitator,omitempty"`
 }
 
 func (c Config) network() string {
@@ -101,12 +107,28 @@ func (c Config) network() string {
 	return c.Network
 }
 
-func (c Config) requirements(r *http.Request) Requirements {
+// AmountFor returns the amount required for a named tool/resource: the
+// per-tool override if present, otherwise the default Amount.
+func (c Config) AmountFor(name string) string {
+	if a, ok := c.Amounts[name]; ok {
+		return a
+	}
+	return c.Amount
+}
+
+func (c Config) facilitator() Facilitator {
+	if c.Facilitator != nil {
+		return c.Facilitator
+	}
+	return &HTTPFacilitator{URL: c.FacilitatorURL}
+}
+
+func (c Config) requirements(amount, resource string) Requirements {
 	return Requirements{
 		Scheme:            "exact",
 		Network:           c.network(),
-		MaxAmountRequired: c.Price,
-		Resource:          r.URL.Path,
+		MaxAmountRequired: amount,
+		Resource:          resource,
 		Description:       c.Description,
 		PayTo:             c.PayTo,
 		Asset:             c.Asset,
@@ -114,43 +136,50 @@ func (c Config) requirements(r *http.Request) Requirements {
 	}
 }
 
-// Middleware returns HTTP middleware that requires an x402 payment before
-// the wrapped handler runs. A request without a valid X-PAYMENT header
-// receives a 402 with the payment requirements; once a payment verifies,
-// the request is served.
-func Middleware(cfg Config) func(http.Handler) http.Handler {
-	fac := cfg.Facilitator
-	if fac == nil {
-		fac = &HTTPFacilitator{URL: cfg.FacilitatorURL}
+// Require enforces payment of amount for a single request. It returns
+// true if the request may proceed — the amount is free ("" or "0"), or a
+// valid payment was presented — and false once it has written a 402
+// challenge, in which case the caller must stop. resource names what is
+// being paid for (a tool name or URL path).
+func (c Config) Require(w http.ResponseWriter, r *http.Request, amount, resource string) bool {
+	if amount == "" || amount == "0" {
+		return true // free
 	}
+	req := c.requirements(amount, resource)
+
+	payment := r.Header.Get(PaymentHeader)
+	if payment == "" {
+		writeChallenge(w, req, "payment required")
+		return false
+	}
+	res, err := c.facilitator().Verify(r.Context(), payment, req)
+	if err != nil {
+		writeChallenge(w, req, "payment verification failed: "+err.Error())
+		return false
+	}
+	if !res.Valid {
+		reason := res.Reason
+		if reason == "" {
+			reason = "payment invalid"
+		}
+		writeChallenge(w, req, reason)
+		return false
+	}
+	if res.Settlement != "" {
+		w.Header().Set(PaymentResponseHeader, res.Settlement)
+	}
+	return true
+}
+
+// Middleware returns HTTP middleware that requires the default Amount for
+// any wrapped route. For per-tool amounts, resolve the amount with
+// AmountFor and call Require directly (the MCP gateway does this).
+func Middleware(cfg Config) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			req := cfg.requirements(r)
-
-			payment := r.Header.Get(PaymentHeader)
-			if payment == "" {
-				writeChallenge(w, req, "payment required")
-				return
+			if cfg.Require(w, r, cfg.Amount, r.URL.Path) {
+				next.ServeHTTP(w, r)
 			}
-
-			res, err := fac.Verify(r.Context(), payment, req)
-			if err != nil {
-				writeChallenge(w, req, "payment verification failed: "+err.Error())
-				return
-			}
-			if !res.Valid {
-				reason := res.Reason
-				if reason == "" {
-					reason = "payment invalid"
-				}
-				writeChallenge(w, req, reason)
-				return
-			}
-
-			if res.Settlement != "" {
-				w.Header().Set(PaymentResponseHeader, res.Settlement)
-			}
-			next.ServeHTTP(w, r)
 		})
 	}
 }
@@ -163,6 +192,23 @@ func writeChallenge(w http.ResponseWriter, req Requirements, reason string) {
 		Accepts:     []Requirements{req},
 		Error:       reason,
 	})
+}
+
+// LoadConfig reads an x402 config file (JSON) describing the operator's
+// payTo address, network, asset, default amount, and per-tool amounts:
+//
+//	{ "payTo": "0x…", "network": "solana", "asset": "USDC",
+//	  "amount": "0", "amounts": { "weather.Weather.Forecast": "10000" } }
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse x402 config %s: %w", path, err)
+	}
+	return &c, nil
 }
 
 // HTTPFacilitator verifies payments by POSTing to an x402 facilitator's

--- a/wrapper/x402/x402_test.go
+++ b/wrapper/x402/x402_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -27,7 +29,7 @@ func paidHandler(cfg Config) http.Handler {
 
 // No payment yields a 402 with the requirements describing where to pay.
 func TestChallengeWhenNoPayment(t *testing.T) {
-	h := paidHandler(Config{PayTo: "0xabc", Network: "solana", Price: "10000", Facilitator: mockFacilitator{valid: true}})
+	h := paidHandler(Config{PayTo: "0xabc", Network: "solana", Amount: "10000", Facilitator: mockFacilitator{valid: true}})
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/tool", nil))
@@ -51,7 +53,7 @@ func TestChallengeWhenNoPayment(t *testing.T) {
 // A payment the facilitator accepts lets the request through, and the
 // settlement is surfaced on the response.
 func TestServesWhenPaymentValid(t *testing.T) {
-	h := paidHandler(Config{PayTo: "0xabc", Price: "10000", Facilitator: mockFacilitator{valid: true}})
+	h := paidHandler(Config{PayTo: "0xabc", Amount: "10000", Facilitator: mockFacilitator{valid: true}})
 
 	r := httptest.NewRequest(http.MethodGet, "/tool", nil)
 	r.Header.Set(PaymentHeader, "base64-payment-payload")
@@ -61,9 +63,6 @@ func TestServesWhenPaymentValid(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	if rec.Body.String() != "ok" {
-		t.Errorf("handler not served, body = %q", rec.Body.String())
-	}
 	if rec.Header().Get(PaymentResponseHeader) != "0xtx" {
 		t.Errorf("settlement not surfaced in %s", PaymentResponseHeader)
 	}
@@ -71,7 +70,7 @@ func TestServesWhenPaymentValid(t *testing.T) {
 
 // A payment the facilitator rejects gets a 402 with the reason.
 func TestChallengeWhenPaymentInvalid(t *testing.T) {
-	h := paidHandler(Config{PayTo: "0xabc", Price: "10000", Facilitator: mockFacilitator{valid: false, reason: "insufficient amount"}})
+	h := paidHandler(Config{PayTo: "0xabc", Amount: "10000", Facilitator: mockFacilitator{valid: false, reason: "insufficient amount"}})
 
 	r := httptest.NewRequest(http.MethodGet, "/tool", nil)
 	r.Header.Set(PaymentHeader, "bad-payment")
@@ -85,6 +84,52 @@ func TestChallengeWhenPaymentInvalid(t *testing.T) {
 	json.Unmarshal(rec.Body.Bytes(), &ch)
 	if ch.Error != "insufficient amount" {
 		t.Errorf("reason not surfaced: %q", ch.Error)
+	}
+}
+
+// A free amount ("" or "0") requires no payment.
+func TestRequireFreeAmount(t *testing.T) {
+	cfg := Config{PayTo: "0xabc", Facilitator: mockFacilitator{valid: false}}
+	rec := httptest.NewRecorder()
+	if !cfg.Require(rec, httptest.NewRequest(http.MethodGet, "/free", nil), "0", "free.tool") {
+		t.Error("a zero amount should be free and proceed")
+	}
+	if rec.Code != http.StatusOK && rec.Code != 200 {
+		// Require doesn't write on success; recorder defaults to 200.
+	}
+}
+
+// Per-tool amounts override the default.
+func TestAmountFor(t *testing.T) {
+	cfg := Config{Amount: "100", Amounts: map[string]string{"paid.Tool.Do": "5000"}}
+	if got := cfg.AmountFor("paid.Tool.Do"); got != "5000" {
+		t.Errorf("per-tool amount = %q, want 5000", got)
+	}
+	if got := cfg.AmountFor("other.Tool.Do"); got != "100" {
+		t.Errorf("default amount = %q, want 100", got)
+	}
+}
+
+// LoadConfig reads an operator x402 config file.
+func TestLoadConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x402.json")
+	os.WriteFile(path, []byte(`{
+		"payTo": "0xabc", "network": "solana", "asset": "USDC",
+		"amount": "0", "amounts": {"weather.Weather.Forecast": "10000"}
+	}`), 0o644)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.PayTo != "0xabc" || cfg.Network != "solana" {
+		t.Errorf("config not parsed: %+v", cfg)
+	}
+	if cfg.AmountFor("weather.Weather.Forecast") != "10000" {
+		t.Errorf("per-tool amount not loaded: %+v", cfg.Amounts)
+	}
+	if cfg.AmountFor("anything.else") != "0" {
+		t.Errorf("default amount = %q, want 0", cfg.AmountFor("anything.else"))
 	}
 }
 


### PR DESCRIPTION
Integrate the x402 payment protocol (HTTP 402) so a tool can require a stablecoin payment and an agent can settle it — agents that act, and pay.

- wrapper/x402: HTTP middleware + a Require primitive enforcing the 402 challenge/verify flow, with a pluggable Facilitator interface. Go Micro carries no chain/crypto code; Base and Solana are just different facilitators. Config uses the protocol's vocabulary — Amount (default) and per-tool Amounts — not a 'pricing' abstraction. LoadConfig reads an operator x402 config file. Tests cover challenge/accept/reject, free, per-tool amounts, and config loading.
- MCP gateway: optional Options.Payment, enforced per-tool inside /mcp/call (the way scopes/rate-limits are); listing and health free.
- micro mcp serve and micro-mcp-gateway: opt-in --x402-pay-to/-amount/ -network/-facilitator and --x402-config (per-tool amounts file).
- docs: Payments (x402) guide + nav + README section; blog/22.

Per-tool amounts are an operator concern (payTo is the operator's), configured at the gateway like scopes. Metered usage / prepaid balances are follow-ups.