### PR TITLE
feat(agent): loop detection guardrail + document/blog agent guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ See the [Payments (x402) guide](internal/website/docs/guides/x402-payments.md).
 | Plan & delegate | Built-in agent tools — plan multi-step work, delegate subtasks to other agents |
 | Pluggable memory | Durable store-backed conversation memory by default; swap with `AgentMemory` |
 | Custom tools | `AgentTool` — give an agent any function as a tool, beyond its services |
-| Guardrails | `MaxSteps` (stopping condition) and `ApproveTool` (human-in-the-loop) on every agent |
+| Guardrails | `MaxSteps` (stop on count), `LoopLimit` (stop repeated no-progress calls), `ApproveTool` (human-in-the-loop) |
 | Workflows | `micro.NewFlow()` — event-driven; runs a step or triggers an agent |
 | MCP gateway | Every endpoint is an AI tool automatically |
 | Payments (x402) | Opt-in per-call payments for tools via the x402 standard; pluggable facilitator (Base, Solana, …) |
@@ -357,6 +357,7 @@ See [all examples](examples/README.md).
 - [Agents and Workflows](internal/website/docs/guides/agents-and-workflows.md)
 - [Agent Design](internal/docs/AGENT_DESIGN.md)
 - [Plan & Delegate](internal/website/docs/guides/plan-delegate.md)
+- [Agent Guardrails](internal/website/docs/guides/agent-guardrails.md)
 - [Payments (x402)](internal/website/docs/guides/x402-payments.md)
 - [MCP & AI Agents](internal/website/docs/mcp.md)
 - [Data Model](internal/website/docs/model.md)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -66,6 +66,9 @@ type agentImpl struct {
 
 	// steps counts tool executions in the current Ask, for MaxSteps.
 	steps int
+	// calls counts identical tool calls (name+args) in the current Ask,
+	// for LoopLimit.
+	calls map[string]int
 }
 
 // New creates a new Agent.
@@ -148,6 +151,7 @@ func (a *agentImpl) Ask(ctx context.Context, message string) (*Response, error) 
 
 	a.mem.Add("user", message)
 	a.steps = 0
+	a.calls = map[string]int{}
 
 	resp, err := a.model.Generate(ctx, &ai.Request{
 		Prompt:       message,

--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -110,6 +110,22 @@ func (a *agentImpl) toolHandler() ai.ToolHandler {
 			}
 		}
 
+		// Loop detection: stop the agent repeating an identical action
+		// that makes no progress (which the step count alone won't catch).
+		if a.opts.LoopLimit > 0 {
+			if a.calls == nil {
+				a.calls = map[string]int{}
+			}
+			args, _ := json.Marshal(input)
+			fp := name + ":" + string(args)
+			a.calls[fp]++
+			if a.calls[fp] > a.opts.LoopLimit {
+				return errResult(fmt.Sprintf(
+					"loop detected: you have already called %q with the same arguments %d times and the result will not change. Stop repeating it — try a different approach, or finish with what you have.",
+					name, a.opts.LoopLimit))
+			}
+		}
+
 		// Human-in-the-loop / policy: gate the action before it runs.
 		if a.opts.Approve != nil {
 			if ok, reason := a.opts.Approve(name, input); !ok {

--- a/agent/loop_test.go
+++ b/agent/loop_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// Repeating the same tool call with the same arguments is refused once it
+// exceeds LoopLimit, and the model is told to change approach.
+func TestLoopDetectionStopsRepeats(t *testing.T) {
+	a := newTestAgent(Name("looper"), LoopLimit(3))
+	h := a.toolHandler()
+
+	// First 3 identical calls are allowed (they fall through to RPC,
+	// which fails harmlessly — we only care they weren't refused as loops).
+	for i := 1; i <= 3; i++ {
+		_, content := h("demo_Svc_Do", map[string]any{"q": "x"})
+		if strings.Contains(content, "loop detected") {
+			t.Fatalf("call %d wrongly flagged as a loop", i)
+		}
+	}
+
+	// The 4th identical call is refused as a loop.
+	_, content := h("demo_Svc_Do", map[string]any{"q": "x"})
+	if !strings.Contains(content, "loop detected") {
+		t.Errorf("4th identical call should be refused as a loop; got %q", content)
+	}
+}
+
+// Different arguments are not a loop, even past the limit.
+func TestLoopDetectionAllowsDistinctCalls(t *testing.T) {
+	a := newTestAgent(Name("distinct"), LoopLimit(2))
+	h := a.toolHandler()
+
+	for i := 0; i < 5; i++ {
+		_, content := h("demo_Svc_Do", map[string]any{"q": i}) // distinct args each time
+		if strings.Contains(content, "loop detected") {
+			t.Fatalf("distinct call %d wrongly flagged as a loop", i)
+		}
+	}
+}
+
+// LoopLimit(0) disables detection.
+func TestLoopDetectionDisabled(t *testing.T) {
+	a := newTestAgent(Name("noloop"), LoopLimit(0))
+	h := a.toolHandler()
+	for i := 0; i < 6; i++ {
+		_, content := h("demo_Svc_Do", map[string]any{"q": "same"})
+		if strings.Contains(content, "loop detected") {
+			t.Fatalf("loop detection should be disabled with LoopLimit(0)")
+		}
+	}
+}
+
+// It defaults on (lenient) so repeated identical calls are caught without
+// any configuration.
+func TestLoopDetectionDefaultOn(t *testing.T) {
+	a := New(Name("d"), Provider("fake")).(*agentImpl)
+	a.setup()
+	if a.opts.LoopLimit <= 0 {
+		t.Fatalf("LoopLimit should default on, got %d", a.opts.LoopLimit)
+	}
+	h := a.toolHandler()
+	var lastContent string
+	for i := 0; i < a.opts.LoopLimit+1; i++ {
+		_, lastContent = h("demo_Svc_Do", map[string]any{})
+	}
+	if !strings.Contains(lastContent, "loop detected") {
+		t.Errorf("default loop detection should catch repeated calls; got %q", lastContent)
+	}
+}

--- a/agent/options.go
+++ b/agent/options.go
@@ -50,6 +50,11 @@ type Options struct {
 	// unbounded). Once exceeded, further tool calls are refused and the
 	// model is told to stop and summarize. A stopping condition.
 	MaxSteps int
+	// LoopLimit bounds how many times the agent may call the same tool
+	// with the same arguments in one Ask before the call is refused as a
+	// no-progress loop (0 = disabled). Catches the agent repeating an
+	// identical action — which MaxSteps only bounds by total count.
+	LoopLimit int
 	// Approve gates each action before it runs. Nil = allow all.
 	Approve ApproveFunc
 
@@ -63,6 +68,9 @@ func newOptions(opts ...Option) Options {
 		Client:       client.DefaultClient,
 		Store:        store.DefaultStore,
 		HistoryLimit: 50,
+		// On by default and lenient: identical repeated calls are a
+		// no-progress loop, never useful. Set LoopLimit(0) to disable.
+		LoopLimit: 3,
 	}
 	for _, opt := range opts {
 		opt(&o)
@@ -131,6 +139,13 @@ func MaxSteps(n int) Option {
 // action (service tools and delegate). Returning false blocks the call.
 func ApproveTool(fn ApproveFunc) Option {
 	return func(o *Options) { o.Approve = fn }
+}
+
+// LoopLimit sets how many times the agent may repeat the same tool call
+// (same name and arguments) in one Ask before it is refused as a
+// no-progress loop. 0 disables loop detection.
+func LoopLimit(n int) Option {
+	return func(o *Options) { o.LoopLimit = n }
 }
 
 // WithMemory sets the agent's conversation memory. The default is

--- a/internal/docs/AGENT_DESIGN.md
+++ b/internal/docs/AGENT_DESIGN.md
@@ -69,6 +69,7 @@ type AgentOptions struct {
     HistoryLimit int               // max conversation turns to retain
     Memory       Memory            // pluggable conversation memory (default: store-backed)
     MaxSteps     int               // stopping condition: max tool calls per Ask
+    LoopLimit    int               // max identical repeated calls before refusal (default 3)
     Approve      ApproveFunc        // human-in-the-loop / policy gate on each action
 }
 ```
@@ -82,7 +83,7 @@ An agent composes the same way a service does — a small set of pluggable piece
 | **Model** | first registered provider | `AgentProvider` / `AgentModel` |
 | **Memory** | store-backed, durable across restarts | `AgentMemory(m Memory)` |
 | **Tools** | the agent's services (RPC) + `plan`/`delegate` | `AgentTool(name, desc, schema, fn)` for any function |
-| **Guardrails** | none | `AgentMaxSteps`, `AgentApproveTool` |
+| **Guardrails** | loop detection on | `AgentMaxSteps`, `AgentLoopLimit`, `AgentApproveTool` |
 
 ```go
 type Memory interface {

--- a/internal/website/_data/navigation.yml
+++ b/internal/website/_data/navigation.yml
@@ -36,6 +36,8 @@ guides:
     url: /docs/guides/agents-and-workflows.html
   - title: Plan & Delegate
     url: /docs/guides/plan-delegate.html
+  - title: Agent Guardrails
+    url: /docs/guides/agent-guardrails.html
   - title: Payments (x402)
     url: /docs/guides/x402-payments.html
   - title: Atlas Cloud Integration

--- a/internal/website/blog/23.md
+++ b/internal/website/blog/23.md
@@ -1,0 +1,66 @@
+---
+layout: blog
+title: "Agent Guardrails"
+permalink: /blog/23
+description: "An autonomous agent fails in mundane ways — it loops, it runs away, it takes an action it shouldn't. Go Micro separates orchestration from execution safety, and gives every agent three guardrails at the point where tools actually run."
+---
+
+# Agent Guardrails
+
+*June 16, 2026 &bull; Asim Aslam*
+
+The interesting failures of an autonomous agent aren't dramatic. It calls the same tool with the same arguments over and over, making no progress. It takes thirty steps on a task that needed three, quietly running up cost. It performs an action that a human, or a policy, should have stood in front of. When an agent [runs on its own](/blog/21), there's no one watching to catch any of it.
+
+A useful way to think about this — which came up in a community discussion recently — is to separate **orchestration** from **execution safety**. The model decides what to do; that's orchestration. Whether a decided action is actually allowed to run is a separate concern, and it shouldn't be tangled into the model or the services. Go Micro keeps them apart: every tool call an agent makes passes through one choke point, and that's where the guardrails live. They apply uniformly to service calls, custom tools, and `delegate`, and they touch neither the model nor your services.
+
+There are three.
+
+## Stop on count
+
+`MaxSteps` bounds the total tool executions in one request. Past the limit, calls are refused and the model is told to stop and summarize. It's the blunt backstop against runaway cost.
+
+```go
+micro.NewAgent("worker", micro.AgentMaxSteps(8))
+```
+
+## Stop on repeat
+
+This is the one the discussion was really about, and the one we didn't have. `MaxSteps` bounds *how many* calls, but not *whether they're the same call*. An agent can spend its entire budget calling one tool with identical arguments — each call succeeds, and none of them moves anything forward. A circuit breaker won't catch it either, because a circuit breaker reacts to *failures*, and a pointlessly repeated call isn't failing.
+
+`LoopLimit` catches it: it bounds how many times the agent may call the same tool with the same arguments in one request. When the limit is hit, the call is refused with a message that names the loop, so the model changes approach instead of spinning:
+
+> loop detected: you have already called "search.Search.Query" with the same arguments 3 times and the result will not change. Stop repeating it — try a different approach, or finish with what you have.
+
+That refusal-with-reason is what lets the agent recover on its own. It's **on by default** (a lenient 3), because identical repeated calls are never useful; `AgentLoopLimit(0)` disables it.
+
+```go
+micro.NewAgent("worker", micro.AgentLoopLimit(3))
+```
+
+## Gate the action
+
+`ApproveTool` is a hook called before each action runs. Return `false` to block it, with a reason the model sees — for human-in-the-loop approval, spend limits, allow/deny lists, or any policy:
+
+```go
+micro.NewAgent("worker", micro.AgentApproveTool(
+    func(tool string, input map[string]any) (bool, string) {
+        if strings.HasPrefix(tool, "billing_") {
+            return false, "billing actions require sign-off"
+        }
+        return true, ""
+    }))
+```
+
+## The hook is the seam
+
+`ApproveTool` is also where an **external safety layer** plugs in. It sees every tool call before execution and can veto, so you can route decisions to your own rules, a budget service, or a third-party runtime-policy engine — without Go Micro depending on any of them. That's the value of separating the two concerns: orchestration stays in the agent, execution safety stays in the hook, and you can replace the safety layer without touching the agent. Loop detection ships built in because it's near-universal; everything beyond it is a policy you supply.
+
+## At the edge, too
+
+When agents reach tools **through the MCP gateway**, the gateway adds its own per-tool policies, independent of the agent: `RateLimit` (requests per second) and `CircuitBreaker` (a tool that fails repeatedly is temporarily blocked, so a failing dependency doesn't cascade). With the agent-side guardrails that's a complete set — bound the count, stop the spin, gate the action, rate-limit and circuit-break at the edge.
+
+## Why it's the autonomy story
+
+None of this matters much when you're sitting in a chat watching the agent work — you are the guardrail. It matters when no one is. An agent triggered by an event, running unattended, needs to fail safely and recover by itself rather than burning resources in a loop nobody sees. Guardrails aren't a feature bolted onto agents; for an autonomous agent they're part of what makes it safe to run at all.
+
+See the [Agent Guardrails guide](/docs/guides/agent-guardrails) for the full reference.

--- a/internal/website/blog/index.html
+++ b/internal/website/blog/index.html
@@ -12,6 +12,13 @@ permalink: /blog/
 <div class="posts">
 
   <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
+    <h2 style="margin: 0 0 0.5rem;"><a href="/blog/23">Agent Guardrails</a></h2>
+    <p class="meta" style="color: #666; font-size: 0.85rem;">June 16, 2026</p>
+    <p>An autonomous agent fails in mundane ways — it loops, it runs away, it takes an action it shouldn't. Go Micro separates orchestration from execution safety, and gives every agent three guardrails at the point where tools actually run.</p>
+    <a href="/blog/23">Read more &rarr;</a>
+  </article>
+
+  <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
     <h2 style="margin: 0 0 0.5rem;"><a href="/blog/22">Integrating x402: Payments for Agents</a></h2>
     <p class="meta" style="color: #666; font-size: 0.85rem;">June 15, 2026</p>
     <p>Agents that act on their own eventually need to pay on their own. Go Micro now speaks x402 — the HTTP 402 payment standard — so a tool can require a stablecoin payment and an agent can settle it, with the chain pluggable behind a facilitator.</p>

--- a/internal/website/docs/guides/agent-guardrails.md
+++ b/internal/website/docs/guides/agent-guardrails.md
@@ -1,0 +1,67 @@
+---
+layout: default
+---
+
+# Agent Guardrails
+
+An autonomous agent decides its own actions at runtime, which is what makes it useful — and what makes it risky. The common failure modes are mundane: it loops, repeating the same call without making progress; it runs away, taking far more steps (and cost) than the task warrants; it takes an action that should have had a human or a policy in the way.
+
+Go Micro separates **orchestration** (the model deciding what to do) from **execution safety** (whether a decided action is allowed to run). Every tool call an agent makes passes through one choke point, and that's where the guardrails live — so they apply uniformly to service calls, custom tools, and `delegate`, without touching the model or your services.
+
+## The three agent guardrails
+
+### Stop on count — `MaxSteps`
+
+Bounds the total number of tool executions in a single `Ask`. Once exceeded, further calls are refused and the model is told to stop and summarize. The blunt backstop against runaway cost.
+
+```go
+micro.NewAgent("worker", micro.AgentMaxSteps(8))
+```
+
+### Stop on repeat — `LoopLimit`
+
+Bounds how many times the agent may call the **same tool with the same arguments** in one `Ask`. Identical repeated calls make no progress — `MaxSteps` only bounds them by total count, and a circuit breaker only catches *failures*, not a call that succeeds and is pointlessly repeated. When the limit is hit, the call is refused with a message that tells the model it's looping, so it changes approach instead of spinning:
+
+> loop detected: you have already called "search.Search.Query" with the same arguments 3 times and the result will not change. Stop repeating it — try a different approach, or finish with what you have.
+
+```go
+micro.NewAgent("worker", micro.AgentLoopLimit(3))
+```
+
+`LoopLimit` is **on by default** (a lenient 3) because identical repeated calls are never useful. Set `AgentLoopLimit(0)` to disable it.
+
+### Gate the action — `ApproveTool`
+
+A hook called before each action runs. Return `false` to block it, with a reason that's surfaced to the model. Use it for human-in-the-loop approval, spend limits, allow/deny lists, or any policy:
+
+```go
+micro.NewAgent("worker", micro.AgentApproveTool(
+    func(tool string, input map[string]any) (bool, string) {
+        if strings.HasPrefix(tool, "billing_") {
+            return false, "billing actions require sign-off"
+        }
+        return true, ""
+    }))
+```
+
+## ApproveTool is the integration seam
+
+`ApproveTool` is also where an **external policy engine** plugs in. It sees every tool call before execution and can veto, so you can route decisions to your own rules, a budget service, or a third-party runtime-safety layer — without go-micro depending on it. Orchestration stays in the agent; execution safety stays in the hook. That separation is the whole point: you can swap the safety layer without touching the agent.
+
+## Execution safety at the gateway
+
+When agents reach tools **through the MCP gateway**, the gateway adds its own per-tool policies, independent of the agent:
+
+- **`RateLimit`** — requests-per-second per tool.
+- **`CircuitBreaker`** — a tool that fails repeatedly is temporarily blocked, so a failing dependency doesn't cascade.
+
+Together with the agent-side guardrails, that's a full set: bound the count, stop the spin, gate the action, rate-limit and circuit-break at the edge.
+
+## Why it matters for autonomous agents
+
+These are most important when no human is in the loop. An agent [triggered by an event](/blog/21) runs unattended — there's no one to notice it looping or to approve a risky call. The guardrails are what let it fail safely and recover on its own rather than quietly burning resources.
+
+## See also
+
+- [Plan & Delegate](plan-delegate.html) — the agent's built-in tools
+- [Agents and Workflows](agents-and-workflows.html) — where agents fit

--- a/micro.go
+++ b/micro.go
@@ -93,6 +93,11 @@ type ApproveFunc = agent.ApproveFunc
 // stopping condition for autonomous agents.
 func AgentMaxSteps(n int) AgentOption { return agent.MaxSteps(n) }
 
+// AgentLoopLimit bounds how many times an agent may repeat the same tool
+// call (same arguments) in one Ask before it's refused as a no-progress
+// loop. 0 disables loop detection (defaults on).
+func AgentLoopLimit(n int) AgentOption { return agent.LoopLimit(n) }
+
 // AgentApproveTool sets a human-in-the-loop / policy hook called before
 // each action the agent takes.
 func AgentApproveTool(fn ApproveFunc) AgentOption { return agent.ApproveTool(fn) }


### PR DESCRIPTION
Add LoopLimit: refuse a tool call repeated with identical arguments in one Ask, with a self-heal message so the model changes approach. Catches the no-progress loop that MaxSteps (count) and the gateway circuit breaker (failures) miss. Enforced at the same tool-handler choke point as MaxSteps/ApproveTool; on by default (lenient 3); AgentLoopLimit(0) to disable. Tests cover repeats, distinct calls, disabled, and default-on.

Docs: new Agent Guardrails guide (MaxSteps/LoopLimit/ApproveTool, the ApproveTool integration seam for external policy engines, and the gateway's RateLimit/CircuitBreaker), nav + README + AGENT_DESIGN updates, and blog/23 'Agent Guardrails'.