### PR TITLE
feat(agent): tool-execution wrappers via WrapTool

### DIFF
--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -74,108 +74,150 @@ func Builtins(opts ...Option) (tools []ai.Tool, handle func(name string, input m
 	handle = func(name string, input map[string]any) (any, string, bool) {
 		switch name {
 		case toolPlan:
-			r, c := a.handlePlan(input)
-			return r, c, true
+			r := a.handlePlan(ai.ToolCall{Name: name, Input: input})
+			return r.Value, r.Content, true
 		case toolDelegate:
-			r, c := a.handleDelegate(input)
-			return r, c, true
+			r := a.handleDelegate(ai.ToolCall{Name: name, Input: input})
+			return r.Value, r.Content, true
 		}
 		return nil, "", false
 	}
 	return builtinTools(), handle
 }
 
-// toolHandler returns the agent's tool-call handler. It intercepts the
-// built-in tools and falls through to RPC service execution for the
-// rest. Ephemeral sub-agents get the bare service handler so they can
-// neither plan nor re-delegate (which prevents runaway recursion).
+// toolHandler returns the agent's tool-call handler, composed as a stack
+// of wrappers around a base handler — the same middleware shape as
+// client/server wrappers. The base executes the call (custom tools,
+// delegate, or RPC); the built-in guardrails wrap it; developer wrappers
+// (WrapTool) wrap those, outermost, so they observe every call and its
+// result including guardrail refusals. Ephemeral sub-agents get the bare
+// service handler so they can neither plan nor re-delegate (which
+// prevents runaway recursion).
 func (a *agentImpl) toolHandler() ai.ToolHandler {
-	base := a.tools.Handler()
 	if a.ephemeral {
-		return base
+		return a.tools.Handler()
 	}
-	return func(name string, input map[string]any) (any, string) {
-		// plan is internal bookkeeping, not an action — never gated.
-		if name == toolPlan {
-			return a.handlePlan(input)
-		}
 
-		// Stopping condition: bound the number of actions per Ask.
+	// Innermost first: base, then guardrails (approve → loop → step →
+	// plan), then developer wrappers outermost. Wrapping reverses order,
+	// so the result runs plan → step → loop → approve → base.
+	h := a.baseHandler()
+	h = a.approveWrap(h)
+	h = a.loopWrap(h)
+	h = a.stepWrap(h)
+	h = a.planWrap(h)
+	for i := len(a.opts.wrappers) - 1; i >= 0; i-- {
+		h = a.opts.wrappers[i](h)
+	}
+	return h
+}
+
+// baseHandler executes a tool call: a developer custom tool, the built-in
+// delegate, or an RPC to the service. It is the innermost handler.
+func (a *agentImpl) baseHandler() ai.ToolHandler {
+	rpc := a.tools.Handler()
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		for i := range a.opts.tools {
+			if a.opts.tools[i].def.Name == call.Name {
+				out, err := a.opts.tools[i].handler(ctx, call.Input)
+				if err != nil {
+					return errResult(call.ID, err.Error())
+				}
+				return ai.ToolResult{ID: call.ID, Value: out, Content: out}
+			}
+		}
+		if call.Name == toolDelegate {
+			return a.handleDelegate(call)
+		}
+		return rpc(ctx, call)
+	}
+}
+
+// planWrap handles the plan tool inline. plan is internal bookkeeping,
+// not an action — it is never counted, loop-checked, or gated.
+func (a *agentImpl) planWrap(next ai.ToolHandler) ai.ToolHandler {
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		if call.Name == toolPlan {
+			return a.handlePlan(call)
+		}
+		return next(ctx, call)
+	}
+}
+
+// stepWrap bounds the number of actions per Ask (MaxSteps).
+func (a *agentImpl) stepWrap(next ai.ToolHandler) ai.ToolHandler {
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
 		if a.opts.MaxSteps > 0 {
 			a.steps++
 			if a.steps > a.opts.MaxSteps {
-				return errResult(fmt.Sprintf(
+				return errResult(call.ID, fmt.Sprintf(
 					"step limit reached (%d). Do not call any more tools; stop and summarize what you have so far.",
 					a.opts.MaxSteps))
 			}
 		}
+		return next(ctx, call)
+	}
+}
 
-		// Loop detection: stop the agent repeating an identical action
-		// that makes no progress (which the step count alone won't catch).
+// loopWrap stops the agent repeating an identical action that makes no
+// progress (which the step count alone won't catch).
+func (a *agentImpl) loopWrap(next ai.ToolHandler) ai.ToolHandler {
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
 		if a.opts.LoopLimit > 0 {
 			if a.calls == nil {
 				a.calls = map[string]int{}
 			}
-			args, _ := json.Marshal(input)
-			fp := name + ":" + string(args)
+			args, _ := json.Marshal(call.Input)
+			fp := call.Name + ":" + string(args)
 			a.calls[fp]++
 			if a.calls[fp] > a.opts.LoopLimit {
-				return errResult(fmt.Sprintf(
+				return errResult(call.ID, fmt.Sprintf(
 					"loop detected: you have already called %q with the same arguments %d times and the result will not change. Stop repeating it — try a different approach, or finish with what you have.",
-					name, a.opts.LoopLimit))
+					call.Name, a.opts.LoopLimit))
 			}
 		}
+		return next(ctx, call)
+	}
+}
 
-		// Human-in-the-loop / policy: gate the action before it runs.
+// approveWrap gates each action before it runs (ApproveTool).
+func (a *agentImpl) approveWrap(next ai.ToolHandler) ai.ToolHandler {
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
 		if a.opts.Approve != nil {
-			if ok, reason := a.opts.Approve(name, input); !ok {
+			if ok, reason := a.opts.Approve(call.Name, call.Input); !ok {
 				msg := "tool call was not approved"
 				if reason != "" {
 					msg += ": " + reason
 				}
-				return errResult(msg)
+				return errResult(call.ID, msg)
 			}
 		}
-
-		// Developer-registered custom tools (WithTool).
-		for i := range a.opts.tools {
-			if a.opts.tools[i].def.Name == name {
-				out, err := a.opts.tools[i].handler(context.Background(), input)
-				if err != nil {
-					return errResult(err.Error())
-				}
-				return out, out
-			}
-		}
-
-		if name == toolDelegate {
-			return a.handleDelegate(input)
-		}
-		return base(name, input)
+		return next(ctx, call)
 	}
 }
 
 // handlePlan persists the supplied plan to the agent's memory and
 // echoes it back so the model can see the stored state.
-func (a *agentImpl) handlePlan(input map[string]any) (any, string) {
-	data, err := json.Marshal(input)
+func (a *agentImpl) handlePlan(call ai.ToolCall) ai.ToolResult {
+	data, err := json.Marshal(call.Input)
 	if err != nil {
-		return errResult("invalid plan: " + err.Error())
+		return errResult(call.ID, "invalid plan: "+err.Error())
 	}
 	if a.opts.Store != nil {
 		a.opts.Store.Write(&store.Record{Key: a.planKey(), Value: data})
 	}
-	return input, string(data)
+	return ai.ToolResult{ID: call.ID, Value: call.Input, Content: string(data)}
 }
 
 // handleDelegate hands a subtask to another agent. Delegate-first:
 // if 'to' names a registered agent, it is called via RPC. Otherwise an
 // ephemeral sub-agent is created with a fresh, isolated context, asked
 // the subtask, and its reply returned.
-func (a *agentImpl) handleDelegate(input map[string]any) (any, string) {
+func (a *agentImpl) handleDelegate(call ai.ToolCall) ai.ToolResult {
+	input := call.Input
 	task, _ := input["task"].(string)
 	if task == "" {
-		return errResult("task is required")
+		return errResult(call.ID, "task is required")
 	}
 	to, _ := input["to"].(string)
 
@@ -183,11 +225,11 @@ func (a *agentImpl) handleDelegate(input map[string]any) (any, string) {
 	if to != "" && a.isAgent(to) {
 		reply, err := a.callAgentRPC(context.Background(), to, task)
 		if err != nil {
-			return errResult("delegate to agent " + to + ": " + err.Error())
+			return errResult(call.ID, "delegate to agent "+to+": "+err.Error())
 		}
 		out := map[string]any{"agent": to, "reply": reply}
 		b, _ := json.Marshal(out)
-		return out, string(b)
+		return ai.ToolResult{ID: call.ID, Value: out, Content: string(b)}
 	}
 
 	// Otherwise create a focused, ephemeral sub-agent. Fresh context:
@@ -211,11 +253,11 @@ func (a *agentImpl) handleDelegate(input map[string]any) (any, string) {
 
 	resp, err := sub.Ask(context.Background(), task)
 	if err != nil {
-		return errResult("sub-agent: " + err.Error())
+		return errResult(call.ID, "sub-agent: "+err.Error())
 	}
 	out := map[string]any{"reply": resp.Reply}
 	b, _ := json.Marshal(out)
-	return out, string(b)
+	return ai.ToolResult{ID: call.ID, Value: out, Content: string(b)}
 }
 
 // isAgent reports whether name resolves to a registered agent (a
@@ -273,8 +315,8 @@ func (a *agentImpl) loadPlan() string {
 	return string(recs[0].Value)
 }
 
-func errResult(msg string) (any, string) {
+func errResult(id, msg string) ai.ToolResult {
 	m := map[string]string{"error": msg}
 	b, _ := json.Marshal(m)
-	return m, string(b)
+	return ai.ToolResult{ID: id, Value: m, Content: string(b)}
 }

--- a/agent/builtin_test.go
+++ b/agent/builtin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"go-micro.dev/v5/ai"
 	"go-micro.dev/v5/registry"
 	"go-micro.dev/v5/store"
 )
@@ -32,7 +33,7 @@ func TestHandlePlanPersists(t *testing.T) {
 			map[string]any{"task": "write code", "status": "in_progress"},
 		},
 	}
-	_, content := a.handlePlan(steps)
+	content := a.handlePlan(ai.ToolCall{Name: "plan", Input: steps}).Content
 	if content == "" {
 		t.Fatal("handlePlan returned empty content")
 	}
@@ -59,7 +60,7 @@ func TestPlanShowsInPrompt(t *testing.T) {
 		t.Errorf("buildPrompt() with no plan = %q, want %q", got, "base prompt")
 	}
 
-	a.handlePlan(map[string]any{"steps": []any{map[string]any{"task": "do it", "status": "pending"}}})
+	a.handlePlan(ai.ToolCall{Name: "plan", Input: map[string]any{"steps": []any{map[string]any{"task": "do it", "status": "pending"}}}})
 
 	got := a.buildPrompt()
 	if got == "base prompt" {

--- a/agent/guardrails_test.go
+++ b/agent/guardrails_test.go
@@ -1,12 +1,20 @@
 package agent
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"go-micro.dev/v5/ai"
 	"go-micro.dev/v5/registry"
 	"go-micro.dev/v5/store"
 )
+
+// toolContent runs a tool call through a handler and returns the content
+// shown to the model — the part these tests assert on.
+func toolContent(h ai.ToolHandler, name string, input map[string]any) string {
+	return h(context.Background(), ai.ToolCall{Name: name, Input: input}).Content
+}
 
 // MaxSteps refuses tool calls once the per-Ask limit is exceeded; plan
 // is bookkeeping and is never counted.
@@ -17,7 +25,7 @@ func TestMaxStepsStopsActions(t *testing.T) {
 
 	// plan must not consume a step.
 	a.steps = 0
-	h(toolPlan, map[string]any{"steps": []any{}})
+	toolContent(h, toolPlan, map[string]any{"steps": []any{}})
 	if a.steps != 0 {
 		t.Fatalf("plan consumed a step: steps=%d", a.steps)
 	}
@@ -25,14 +33,14 @@ func TestMaxStepsStopsActions(t *testing.T) {
 	// First two actions are allowed (they fall through to RPC, which
 	// fails harmlessly — we only care they weren't refused by the limit).
 	for i := 1; i <= 2; i++ {
-		_, content := h("demo_Svc_Do", map[string]any{})
+		content := toolContent(h, "demo_Svc_Do", map[string]any{})
 		if strings.Contains(content, "step limit") {
 			t.Fatalf("action %d wrongly hit the step limit", i)
 		}
 	}
 
 	// Third action exceeds MaxSteps(2) and must be refused.
-	_, content := h("demo_Svc_Do", map[string]any{})
+	content := toolContent(h, "demo_Svc_Do", map[string]any{})
 	if !strings.Contains(content, "step limit") {
 		t.Errorf("third action should hit the step limit; got %q", content)
 	}
@@ -49,7 +57,7 @@ func TestApproveToolBlocks(t *testing.T) {
 		}),
 	)
 
-	_, content := a.toolHandler()("demo_Svc_Do", map[string]any{})
+	content := toolContent(a.toolHandler(), "demo_Svc_Do", map[string]any{})
 	if sawTool != "demo_Svc_Do" {
 		t.Errorf("approver saw %q, want demo_Svc_Do", sawTool)
 	}
@@ -72,7 +80,7 @@ func TestApproveToolDoesNotGatePlan(t *testing.T) {
 	).(*agentImpl)
 	a.setup()
 
-	_, content := a.toolHandler()(toolPlan, map[string]any{
+	content := toolContent(a.toolHandler(), toolPlan, map[string]any{
 		"steps": []any{map[string]any{"task": "x", "status": "pending"}},
 	})
 	if strings.Contains(content, "not approved") {

--- a/agent/integration_test.go
+++ b/agent/integration_test.go
@@ -82,8 +82,11 @@ func TestAskExposesAndRunsPlan(t *testing.T) {
 		}
 		// Simulate the model recording a plan.
 		if opts.ToolHandler != nil {
-			opts.ToolHandler(toolPlan, map[string]any{
-				"steps": []any{map[string]any{"task": "step one", "status": "pending"}},
+			opts.ToolHandler(context.Background(), ai.ToolCall{
+				Name: toolPlan,
+				Input: map[string]any{
+					"steps": []any{map[string]any{"task": "step one", "status": "pending"}},
+				},
 			})
 		}
 		return &ai.Response{Answer: "done"}, nil
@@ -123,7 +126,7 @@ func TestDelegateEphemeral(t *testing.T) {
 	defer func() { fakeGen = nil }()
 
 	a := newTestAgent(Name("root"))
-	_, content := a.handleDelegate(map[string]any{"task": "summarize the report"})
+	content := a.handleDelegate(ai.ToolCall{Name: "delegate", Input: map[string]any{"task": "summarize the report"}}).Content
 	if !strings.Contains(content, "subtask complete") {
 		t.Errorf("delegate should return the sub-agent's reply; got %q", content)
 	}
@@ -158,7 +161,7 @@ func TestDelegateToRegisteredAgent(t *testing.T) {
 	defer func() { fakeGen = nil }()
 
 	a := newTestAgent(Name("root"), WithRegistry(reg), WithClient(fc))
-	_, content := a.handleDelegate(map[string]any{"task": "notify alice", "to": "comms"})
+	content := a.handleDelegate(ai.ToolCall{Name: "delegate", Input: map[string]any{"task": "notify alice", "to": "comms"}}).Content
 
 	if calledService != "comms" || calledEndpoint != "Agent.Chat" {
 		t.Errorf("expected RPC to comms Agent.Chat, got %s %s", calledService, calledEndpoint)
@@ -171,7 +174,7 @@ func TestDelegateToRegisteredAgent(t *testing.T) {
 // Delegate requires a task.
 func TestDelegateRequiresTask(t *testing.T) {
 	a := newTestAgent(Name("root"))
-	_, content := a.handleDelegate(map[string]any{})
+	content := a.handleDelegate(ai.ToolCall{Name: "delegate", Input: map[string]any{}}).Content
 	if !strings.Contains(content, "error") {
 		t.Errorf("delegate with no task should error; got %q", content)
 	}

--- a/agent/loop_test.go
+++ b/agent/loop_test.go
@@ -14,14 +14,14 @@ func TestLoopDetectionStopsRepeats(t *testing.T) {
 	// First 3 identical calls are allowed (they fall through to RPC,
 	// which fails harmlessly — we only care they weren't refused as loops).
 	for i := 1; i <= 3; i++ {
-		_, content := h("demo_Svc_Do", map[string]any{"q": "x"})
+		content := toolContent(h, "demo_Svc_Do", map[string]any{"q": "x"})
 		if strings.Contains(content, "loop detected") {
 			t.Fatalf("call %d wrongly flagged as a loop", i)
 		}
 	}
 
 	// The 4th identical call is refused as a loop.
-	_, content := h("demo_Svc_Do", map[string]any{"q": "x"})
+	content := toolContent(h, "demo_Svc_Do", map[string]any{"q": "x"})
 	if !strings.Contains(content, "loop detected") {
 		t.Errorf("4th identical call should be refused as a loop; got %q", content)
 	}
@@ -33,7 +33,7 @@ func TestLoopDetectionAllowsDistinctCalls(t *testing.T) {
 	h := a.toolHandler()
 
 	for i := 0; i < 5; i++ {
-		_, content := h("demo_Svc_Do", map[string]any{"q": i}) // distinct args each time
+		content := toolContent(h, "demo_Svc_Do", map[string]any{"q": i}) // distinct args each time
 		if strings.Contains(content, "loop detected") {
 			t.Fatalf("distinct call %d wrongly flagged as a loop", i)
 		}
@@ -45,7 +45,7 @@ func TestLoopDetectionDisabled(t *testing.T) {
 	a := newTestAgent(Name("noloop"), LoopLimit(0))
 	h := a.toolHandler()
 	for i := 0; i < 6; i++ {
-		_, content := h("demo_Svc_Do", map[string]any{"q": "same"})
+		content := toolContent(h, "demo_Svc_Do", map[string]any{"q": "same"})
 		if strings.Contains(content, "loop detected") {
 			t.Fatalf("loop detection should be disabled with LoopLimit(0)")
 		}
@@ -63,7 +63,7 @@ func TestLoopDetectionDefaultOn(t *testing.T) {
 	h := a.toolHandler()
 	var lastContent string
 	for i := 0; i < a.opts.LoopLimit+1; i++ {
-		_, lastContent = h("demo_Svc_Do", map[string]any{})
+		lastContent = toolContent(h, "demo_Svc_Do", map[string]any{})
 	}
 	if !strings.Contains(lastContent, "loop detected") {
 		t.Errorf("default loop detection should catch repeated calls; got %q", lastContent)

--- a/agent/memory_test.go
+++ b/agent/memory_test.go
@@ -90,7 +90,7 @@ func TestWithToolExposedAndDispatched(t *testing.T) {
 		t.Fatal("custom tool 'calc' was not offered to the model")
 	}
 
-	_, content := a.toolHandler()("calc", map[string]any{"a": 1.0, "b": 2.0})
+	content := toolContent(a.toolHandler(), "calc", map[string]any{"a": 1.0, "b": 2.0})
 	if got == nil {
 		t.Fatal("custom tool handler was not called")
 	}
@@ -107,7 +107,7 @@ func TestWithToolError(t *testing.T) {
 				return "", errors.New("kaboom")
 			}))
 
-	_, content := a.toolHandler()("boom", nil)
+	content := toolContent(a.toolHandler(), "boom", nil)
 	if !strings.Contains(content, "kaboom") {
 		t.Errorf("tool error not surfaced: %q", content)
 	}

--- a/agent/options.go
+++ b/agent/options.go
@@ -60,6 +60,9 @@ type Options struct {
 
 	// tools are developer-registered custom tools (see WithTool).
 	tools []customTool
+	// wrappers are developer-registered tool-execution wrappers
+	// (see WrapTool), applied outside the built-in guardrails.
+	wrappers []ai.ToolWrapper
 }
 
 func newOptions(opts ...Option) Options {
@@ -153,6 +156,28 @@ func LoopLimit(n int) Option {
 // in-process, database, or semantic store.
 func WithMemory(m Memory) Option {
 	return func(o *Options) { o.Memory = m }
+}
+
+// WrapTool registers a tool-execution wrapper, the tool-side analogue of
+// a client/server middleware wrapper. Each wrapper takes the next handler
+// and returns a new one; code before the next(...) call runs before the
+// tool executes, code after runs after. Use it for logging, metrics,
+// retries, or custom policy. Wrappers run outside the built-in guardrails
+// (MaxSteps, LoopLimit, ApproveTool), so they observe every call and its
+// result, including refusals. Multiple wrappers compose outermost-first.
+//
+//	micro.NewAgent("worker", micro.AgentWrapTool(
+//	    func(next ai.ToolHandler) ai.ToolHandler {
+//	        return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+//	            res := next(ctx, call)
+//	            log.Printf("id=%s tool=%s", call.ID, call.Name)
+//	            return res
+//	        }
+//	    }))
+func WrapTool(w ...ai.ToolWrapper) Option {
+	return func(o *Options) {
+		o.wrappers = append(o.wrappers, w...)
+	}
 }
 
 // WithTool registers a custom tool the agent can call, beyond the

--- a/agent/wrap_test.go
+++ b/agent/wrap_test.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go-micro.dev/v5/ai"
+)
+
+// A registered wrapper runs around every tool call and can observe and
+// modify the result.
+func TestWrapToolWraps(t *testing.T) {
+	var saw string
+	wrap := func(next ai.ToolHandler) ai.ToolHandler {
+		return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+			saw = call.Name
+			res := next(ctx, call)
+			res.Content = "wrapped:" + res.Content
+			return res
+		}
+	}
+
+	a := newTestAgent(Name("wrapped"), WrapTool(wrap))
+	content := toolContent(a.toolHandler(), "demo_Svc_Do", map[string]any{})
+
+	if saw != "demo_Svc_Do" {
+		t.Errorf("wrapper saw %q, want demo_Svc_Do", saw)
+	}
+	if !strings.HasPrefix(content, "wrapped:") {
+		t.Errorf("wrapper did not modify the result; got %q", content)
+	}
+}
+
+// Multiple wrappers compose outermost-first: the first registered wrapper
+// is the outer layer, so it runs first on the way in and last on the way
+// out.
+func TestWrapToolOrder(t *testing.T) {
+	var order []string
+	mk := func(tag string) ai.ToolWrapper {
+		return func(next ai.ToolHandler) ai.ToolHandler {
+			return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+				order = append(order, "in:"+tag)
+				res := next(ctx, call)
+				order = append(order, "out:"+tag)
+				return res
+			}
+		}
+	}
+
+	a := newTestAgent(Name("ordered"), WrapTool(mk("a"), mk("b")))
+	toolContent(a.toolHandler(), "demo_Svc_Do", map[string]any{})
+
+	want := "in:a in:b out:b out:a"
+	if got := strings.Join(order, " "); got != want {
+		t.Errorf("wrapper order = %q, want %q", got, want)
+	}
+}
+
+// Wrappers run outside the built-in guardrails, so they observe a refused
+// call and its refusal result rather than being short-circuited.
+func TestWrapToolSeesGuardrailRefusal(t *testing.T) {
+	var sawResult string
+	wrap := func(next ai.ToolHandler) ai.ToolHandler {
+		return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+			res := next(ctx, call)
+			sawResult = res.Content
+			return res
+		}
+	}
+
+	a := newTestAgent(Name("gated-wrap"),
+		ApproveTool(func(tool string, input map[string]any) (bool, string) {
+			return false, "denied"
+		}),
+		WrapTool(wrap),
+	)
+	toolContent(a.toolHandler(), "demo_Svc_Do", map[string]any{})
+
+	if !strings.Contains(sawResult, "not approved") {
+		t.Errorf("wrapper should observe the guardrail refusal; got %q", sawResult)
+	}
+}
+
+// call.Scan decodes a tool call's input into a typed struct.
+func TestToolCallScan(t *testing.T) {
+	call := ai.ToolCall{Input: map[string]any{"query": "hello", "limit": 5}}
+	var args struct {
+		Query string `json:"query"`
+		Limit int    `json:"limit"`
+	}
+	if err := call.Scan(&args); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if args.Query != "hello" || args.Limit != 5 {
+		t.Errorf("Scan decoded %+v, want {hello 5}", args)
+	}
+}

--- a/ai/README.md
+++ b/ai/README.md
@@ -133,14 +133,15 @@ m.Init(
 The model can automatically execute tool calls when provided with a tool handler:
 
 ```go
-// Define a tool handler
-toolHandler := func(name string, input map[string]any) (result any, content string) {
+// Define a tool handler. It mirrors a go-micro RPC handler: context
+// first, the call in, a result out.
+toolHandler := func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
     // Execute the tool and return results
-    switch name {
+    switch call.Name {
     case "get_weather":
-        return map[string]string{"temp": "72F"}, `{"temp": "72F"}`
+        return ai.ToolResult{ID: call.ID, Value: map[string]string{"temp": "72F"}, Content: `{"temp": "72F"}`}
     default:
-        return nil, `{"error": "unknown tool"}`
+        return ai.ToolResult{ID: call.ID, Content: `{"error": "unknown tool"}`}
     }
 }
 

--- a/ai/anthropic/anthropic.go
+++ b/ai/anthropic/anthropic.go
@@ -111,7 +111,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 	for rounds := 0; rounds < 10; rounds++ {
 		var toolResultBlocks []map[string]any
 		for i := range pendingCalls {
-			_, content := p.opts.ToolHandler(pendingCalls[i].Name, pendingCalls[i].Input)
+			content := p.opts.ToolHandler(ctx, pendingCalls[i]).Content
 			pendingCalls[i].Result = content
 			toolResultBlocks = append(toolResultBlocks, map[string]any{
 				"type":        "tool_result",

--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -120,7 +120,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		})
 
 		for _, tc := range resp.ToolCalls {
-			_, content := p.opts.ToolHandler(tc.Name, tc.Input)
+			content := p.opts.ToolHandler(ctx, tc).Content
 			followUpMessages = append(followUpMessages, map[string]any{
 				"role":         "tool",
 				"tool_call_id": tc.ID,

--- a/ai/gemini/gemini.go
+++ b/ai/gemini/gemini.go
@@ -101,7 +101,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 	if p.opts.ToolHandler != nil {
 		var resultParts []map[string]any
 		for _, tc := range resp.ToolCalls {
-			result, _ := p.opts.ToolHandler(tc.Name, tc.Input)
+			result := p.opts.ToolHandler(ctx, tc).Value
 			resultParts = append(resultParts, map[string]any{
 				"functionResponse": map[string]any{
 					"name":     tc.Name,

--- a/ai/groq/groq.go
+++ b/ai/groq/groq.go
@@ -99,7 +99,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 			"tool_calls": rawMessage["tool_calls"],
 		})
 		for _, tc := range resp.ToolCalls {
-			_, content := p.opts.ToolHandler(tc.Name, tc.Input)
+			content := p.opts.ToolHandler(ctx, tc).Content
 			followUpMessages = append(followUpMessages, map[string]any{
 				"role":         "tool",
 				"tool_call_id": tc.ID,

--- a/ai/mistral/mistral.go
+++ b/ai/mistral/mistral.go
@@ -99,7 +99,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 			"tool_calls": rawMessage["tool_calls"],
 		})
 		for _, tc := range resp.ToolCalls {
-			_, content := p.opts.ToolHandler(tc.Name, tc.Input)
+			content := p.opts.ToolHandler(ctx, tc).Content
 			followUpMessages = append(followUpMessages, map[string]any{
 				"role":         "tool",
 				"tool_call_id": tc.ID,

--- a/ai/model.go
+++ b/ai/model.go
@@ -3,6 +3,7 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 )
 
@@ -66,10 +67,25 @@ type ToolCall struct {
 	Error  string         // Tool execution error (populated after execution)
 }
 
+// Scan decodes the call's Input into v (a pointer to a struct or map),
+// the same way a codec decodes an RPC request body. Use it when a tool
+// wants typed arguments instead of the raw map:
+//
+//	var args struct{ Query string `json:"query"` }
+//	if err := call.Scan(&args); err != nil { ... }
+func (c ToolCall) Scan(v any) error {
+	b, err := json.Marshal(c.Input)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}
+
 // ToolResult represents the result of a tool execution
 type ToolResult struct {
 	ID      string // Tool call ID (for correlation)
-	Content string // Tool execution result (JSON string)
+	Value   any    // Structured result (optional)
+	Content string // Tool execution result (JSON string), shown to the model
 }
 
 // Stream is the interface for streaming responses (future implementation)
@@ -80,8 +96,17 @@ type Stream interface {
 	Close() error
 }
 
-// ToolHandler is a function that handles tool calls
-type ToolHandler func(name string, input map[string]any) (result any, content string)
+// ToolHandler executes a tool call and returns its result. It mirrors a
+// go-micro RPC handler — context first, a request in, a result out — so
+// the same mental model carries over from services to tools.
+type ToolHandler func(ctx context.Context, call ToolCall) ToolResult
+
+// ToolWrapper wraps a ToolHandler to add behaviour around execution —
+// logging, metrics, retries, guardrails. It is the tool-side analogue of
+// client.CallWrapper and server.HandlerWrapper: a wrapper takes the next
+// handler and returns a new one, and code before the next(...) call runs
+// before the tool, code after runs after.
+type ToolWrapper func(ToolHandler) ToolHandler
 
 // NewFunc creates a new Model instance
 type NewFunc func(...Option) Model

--- a/ai/openai/openai.go
+++ b/ai/openai/openai.go
@@ -117,7 +117,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		})
 
 		for _, tc := range resp.ToolCalls {
-			_, content := p.opts.ToolHandler(tc.Name, tc.Input)
+			content := p.opts.ToolHandler(ctx, tc).Content
 			followUpMessages = append(followUpMessages, map[string]any{
 				"role":         "tool",
 				"tool_call_id": tc.ID,

--- a/ai/together/together.go
+++ b/ai/together/together.go
@@ -99,7 +99,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 			"tool_calls": rawMessage["tool_calls"],
 		})
 		for _, tc := range resp.ToolCalls {
-			_, content := p.opts.ToolHandler(tc.Name, tc.Input)
+			content := p.opts.ToolHandler(ctx, tc).Content
 			followUpMessages = append(followUpMessages, map[string]any{
 				"role":         "tool",
 				"tool_call_id": tc.ID,

--- a/ai/tools.go
+++ b/ai/tools.go
@@ -128,31 +128,32 @@ func (t *Tools) Handler() ToolHandler {
 	if c == nil {
 		c = client.DefaultClient
 	}
-	return func(name string, input map[string]any) (any, string) {
+	return func(ctx context.Context, call ToolCall) ToolResult {
+		name := call.Name
 		if orig, ok := t.names.get(name); ok {
 			name = orig
 		}
 		parts := strings.SplitN(name, ".", 2)
 		if len(parts) != 2 {
-			return toolErrResult("invalid tool name: " + name)
+			return toolErrResult(call.ID, "invalid tool name: "+name)
 		}
 
-		inputBytes, err := json.Marshal(input)
+		inputBytes, err := json.Marshal(call.Input)
 		if err != nil {
-			return toolErrResult("failed to marshal input: " + err.Error())
+			return toolErrResult(call.ID, "failed to marshal input: "+err.Error())
 		}
 
 		req := c.NewRequest(parts[0], parts[1], &codecBytes.Frame{Data: inputBytes})
 		var rsp codecBytes.Frame
-		if err := c.Call(context.Background(), req, &rsp); err != nil {
-			return toolErrResult(err.Error())
+		if err := c.Call(ctx, req, &rsp); err != nil {
+			return toolErrResult(call.ID, err.Error())
 		}
 
 		var result any
 		if err := json.Unmarshal(rsp.Data, &result); err != nil {
 			result = string(rsp.Data)
 		}
-		return result, string(rsp.Data)
+		return ToolResult{ID: call.ID, Value: result, Content: string(rsp.Data)}
 	}
 }
 
@@ -163,9 +164,9 @@ func DiscoverTools(reg registry.Registry) ([]Tool, error) {
 	return NewTools(reg).Discover()
 }
 
-func toolErrResult(msg string) (any, string) {
+func toolErrResult(id, msg string) ToolResult {
 	encoded, _ := json.Marshal(map[string]string{"error": msg})
-	return map[string]string{"error": msg}, string(encoded)
+	return ToolResult{ID: id, Value: map[string]string{"error": msg}, Content: string(encoded)}
 }
 
 func toolJSONType(goType string) string {

--- a/ai/tools_test.go
+++ b/ai/tools_test.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"context"
 	"testing"
 
 	"go-micro.dev/v5/registry"
@@ -97,11 +98,11 @@ func TestTools_HandlerInvalidName(t *testing.T) {
 	tools := NewTools(registry.NewMemoryRegistry())
 	h := tools.Handler()
 
-	result, content := h("foo", map[string]any{})
-	if result == nil {
+	res := h(context.Background(), ToolCall{Name: "foo", Input: map[string]any{}})
+	if res.Value == nil {
 		t.Fatal("expected error result")
 	}
-	if content == "" {
+	if res.Content == "" {
 		t.Error("expected non-empty content")
 	}
 }

--- a/cmd/micro/chat/chat.go
+++ b/cmd/micro/chat/chat.go
@@ -352,14 +352,15 @@ func run(c *cli.Context) error {
 
 	// Wrap the tool handler to intercept generate calls
 	baseHandler := tools.Handler()
-	wrappedHandler := func(name string, input map[string]any) (any, string) {
-		if name == "micro_generate_service" {
-			return s.handleGenerate(input)
+	wrappedHandler := func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		if call.Name == "micro_generate_service" {
+			r, c := s.handleGenerate(call.Input)
+			return ai.ToolResult{ID: call.ID, Value: r, Content: c}
 		}
-		if result, content, ok := s.builtinHandle(name, input); ok {
-			return result, content
+		if result, content, ok := s.builtinHandle(call.Name, call.Input); ok {
+			return ai.ToolResult{ID: call.ID, Value: result, Content: content}
 		}
-		return baseHandler(name, input)
+		return baseHandler(ctx, call)
 	}
 
 	opts := []ai.Option{
@@ -522,28 +523,28 @@ func (s *session) routeToAgent(ctx context.Context, prompt string) error {
 		},
 	}
 
-	routerHandler := func(name string, input map[string]any) (any, string) {
-		agentName, _ := input["agent"].(string)
-		message, _ := input["message"].(string)
+	routerHandler := func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		agentName, _ := call.Input["agent"].(string)
+		message, _ := call.Input["message"].(string)
 		if message == "" {
 			message = prompt
 		}
 
 		if _, ok := s.agents[agentName]; !ok {
-			return map[string]string{"error": "unknown agent: " + agentName}, `{"error":"unknown agent"}`
+			return ai.ToolResult{ID: call.ID, Value: map[string]string{"error": "unknown agent: " + agentName}, Content: `{"error":"unknown agent"}`}
 		}
 
 		fmt.Printf("  \033[35m◆\033[0m \033[2m%s\033[0m\n", agentName)
 		resp, err := s.callAgent(ctx, agentName, message)
 		if err != nil {
-			return map[string]string{"error": err.Error()}, `{"error":"` + err.Error() + `"}`
+			return ai.ToolResult{ID: call.ID, Value: map[string]string{"error": err.Error()}, Content: `{"error":"` + err.Error() + `"}`}
 		}
 
 		s.printAgentResponse(resp)
 
 		result := map[string]any{"agent": agentName, "reply": resp.Reply}
 		b, _ := json.Marshal(result)
-		return result, string(b)
+		return ai.ToolResult{ID: call.ID, Value: result, Content: string(b)}
 	}
 
 	routerModel := ai.New(s.provider,

--- a/cmd/micro/server/server.go
+++ b/cmd/micro/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -24,10 +25,6 @@ import (
 	"time"
 
 	"github.com/urfave/cli/v2"
-	"go-micro.dev/v5/auth"
-	"go-micro.dev/v5/client"
-	"go-micro.dev/v5/cmd"
-	codecBytes "go-micro.dev/v5/codec/bytes"
 	"go-micro.dev/v5/ai"
 	_ "go-micro.dev/v5/ai/anthropic"
 	_ "go-micro.dev/v5/ai/atlascloud"
@@ -36,6 +33,10 @@ import (
 	_ "go-micro.dev/v5/ai/mistral"
 	_ "go-micro.dev/v5/ai/openai"
 	_ "go-micro.dev/v5/ai/together"
+	"go-micro.dev/v5/auth"
+	"go-micro.dev/v5/client"
+	"go-micro.dev/v5/cmd"
+	codecBytes "go-micro.dev/v5/codec/bytes"
 	"go-micro.dev/v5/registry"
 	"go-micro.dev/v5/store"
 	"golang.org/x/crypto/bcrypt"
@@ -683,7 +684,9 @@ func registerHandlers(mux *http.ServeMux, tmpls *templates, storeInst store.Stor
 		// toolName can be either the original dotted name or the LLM-safe
 		// underscored name; the safe name is resolved first.
 		// Checks endpoint scopes against the caller's token before executing.
-		executeToolCall := func(toolName string, input map[string]any) (any, string) {
+		executeToolCall := func(_ context.Context, call ai.ToolCall) ai.ToolResult {
+			toolName := call.Name
+			input := call.Input
 			if orig, ok := safeNameMap[toolName]; ok {
 				toolName = orig
 			}
@@ -733,7 +736,7 @@ func registerHandlers(mux *http.ServeMux, tmpls *templates, storeInst store.Stor
 						}
 						if !allowed {
 							errMsg := fmt.Sprintf(`{"error":"insufficient scopes","required_scopes":"%s"}`, strings.Join(requiredScopes, ","))
-							return map[string]string{"error": "insufficient scopes", "required_scopes": strings.Join(requiredScopes, ",")}, errMsg
+							return ai.ToolResult{ID: call.ID, Value: map[string]string{"error": "insufficient scopes", "required_scopes": strings.Join(requiredScopes, ",")}, Content: errMsg}
 						}
 					}
 				}
@@ -741,20 +744,20 @@ func registerHandlers(mux *http.ServeMux, tmpls *templates, storeInst store.Stor
 			parts := strings.SplitN(toolName, ".", 2)
 			if len(parts) != 2 {
 				errMsg := `{"error":"invalid tool name"}`
-				return map[string]string{"error": "invalid tool name"}, errMsg
+				return ai.ToolResult{ID: call.ID, Value: map[string]string{"error": "invalid tool name"}, Content: errMsg}
 			}
 			inputBytes, _ := json.Marshal(input)
 			rpcReq := client.DefaultClient.NewRequest(parts[0], parts[1], &codecBytes.Frame{Data: inputBytes})
 			var rsp codecBytes.Frame
 			if err := client.DefaultClient.Call(r.Context(), rpcReq, &rsp); err != nil {
 				errMsg := fmt.Sprintf(`{"error":"%s"}`, err.Error())
-				return map[string]string{"error": err.Error()}, errMsg
+				return ai.ToolResult{ID: call.ID, Value: map[string]string{"error": err.Error()}, Content: errMsg}
 			}
 			var rpcResult any
 			if err := json.Unmarshal(rsp.Data, &rpcResult); err != nil {
 				rpcResult = string(rsp.Data)
 			}
-			return rpcResult, string(rsp.Data)
+			return ai.ToolResult{ID: call.ID, Value: rpcResult, Content: string(rsp.Data)}
 		}
 
 		// Create model with options
@@ -797,8 +800,8 @@ func registerHandlers(mux *http.ServeMux, tmpls *templates, storeInst store.Stor
 			var toolCalls []map[string]any
 			for _, tc := range response.ToolCalls {
 				toolCalls = append(toolCalls, map[string]any{
-					"tool":   tc.Name,
-					"input":  tc.Input,
+					"tool":  tc.Name,
+					"input": tc.Input,
 				})
 			}
 			result["tool_calls"] = toolCalls

--- a/internal/docs/AGENT_DESIGN.md
+++ b/internal/docs/AGENT_DESIGN.md
@@ -84,6 +84,7 @@ An agent composes the same way a service does — a small set of pluggable piece
 | **Memory** | store-backed, durable across restarts | `AgentMemory(m Memory)` |
 | **Tools** | the agent's services (RPC) + `plan`/`delegate` | `AgentTool(name, desc, schema, fn)` for any function |
 | **Guardrails** | loop detection on | `AgentMaxSteps`, `AgentLoopLimit`, `AgentApproveTool` |
+| **Tool middleware** | none | `AgentWrapTool(...ai.ToolWrapper)` — wrap tool execution (logging, metrics, retries) |
 
 ```go
 type Memory interface {

--- a/internal/harness/agent-flow/main.go
+++ b/internal/harness/agent-flow/main.go
@@ -138,7 +138,7 @@ func (m *mockModel) call(name string, input map[string]any) {
 	args, _ := json.Marshal(input)
 	fmt.Printf("  \033[33m[onboarder]\033[0m → %s(%s)\n", name, args)
 	if m.opts.ToolHandler != nil {
-		m.opts.ToolHandler(name, input)
+		m.opts.ToolHandler(context.Background(), ai.ToolCall{Name: name, Input: input})
 	}
 }
 

--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -151,7 +151,7 @@ func (m *mockModel) call(who, name string, input map[string]any) {
 	args, _ := json.Marshal(input)
 	fmt.Printf("  \033[33m[%s]\033[0m → %s(%s)\n", who, name, args)
 	if m.opts.ToolHandler != nil {
-		m.opts.ToolHandler(name, input)
+		m.opts.ToolHandler(context.Background(), ai.ToolCall{Name: name, Input: input})
 	}
 }
 

--- a/internal/website/docs/guides/agent-guardrails.md
+++ b/internal/website/docs/guides/agent-guardrails.md
@@ -48,6 +48,36 @@ micro.NewAgent("worker", micro.AgentApproveTool(
 
 `ApproveTool` is also where an **external policy engine** plugs in. It sees every tool call before execution and can veto, so you can route decisions to your own rules, a budget service, or a third-party runtime-safety layer — without go-micro depending on it. Orchestration stays in the agent; execution safety stays in the hook. That separation is the whole point: you can swap the safety layer without touching the agent.
 
+## Wrap the whole execution — `WrapTool`
+
+`ApproveTool` is a *before* gate. When you need the full lifecycle — timing, logging, metrics, retries, or inspecting the result — wrap the execution instead. `WrapTool` is the tool-side analogue of go-micro's `client.CallWrapper` and `server.HandlerWrapper`: a wrapper takes the next handler and returns a new one, so code before the `next(...)` call runs *before* the tool, and code after runs *after*.
+
+```go
+import "go-micro.dev/v5/ai"
+
+func logging(next ai.ToolHandler) ai.ToolHandler {
+    return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+        start := time.Now()
+        res := next(ctx, call)
+        log.Printf("id=%s tool=%s took=%s", call.ID, call.Name, time.Since(start))
+        return res
+    }
+}
+
+micro.NewAgent("worker", micro.AgentWrapTool(logging))
+```
+
+The handler signature is the same one every provider uses to execute a tool, and it mirrors a service handler — context first, the call in, a result out:
+
+```go
+type ToolHandler func(ctx context.Context, call ToolCall) ToolResult
+type ToolWrapper func(ToolHandler) ToolHandler
+```
+
+`call.ID` is a correlation ID carried through from the provider, so a wrapper can tie a tool call back to the request it came from. `call.Scan(&v)` decodes the arguments into a typed struct when you'd rather not work with the raw map.
+
+Wrappers run **outside** the built-in guardrails, so they observe every call and its result — including a guardrail's refusal. Multiple wrappers compose outermost-first (the first registered is the outer layer). A "before/after" hook is just the two halves of one wrapper, and retry is calling `next` again — so the wrapper is the single, composable seam for everything around execution, while `MaxSteps`, `LoopLimit`, and `ApproveTool` remain the named guardrails on top of it.
+
 ## Execution safety at the gateway
 
 When agents reach tools **through the MCP gateway**, the gateway adds its own per-tool policies, independent of the agent:

--- a/internal/website/docs/guides/agent-patterns.md
+++ b/internal/website/docs/guides/agent-patterns.md
@@ -173,27 +173,28 @@ tools := []ai.Tool{
     },
 }
 
-// Handle tool calls by routing to your services
-toolHandler := func(name string, input map[string]any) (any, string) {
-    switch name {
+// Handle tool calls by routing to your services. The handler mirrors a
+// go-micro RPC handler: context first, the call in, a result out.
+toolHandler := func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+    switch call.Name {
     case "create_task":
         var rsp CreateResponse
-        err := client.Call(ctx, "tasks", "TaskService.Create", input, &rsp)
+        err := client.Call(ctx, "tasks", "TaskService.Create", call.Input, &rsp)
         if err != nil {
-            return nil, fmt.Sprintf(`{"error": "%s"}`, err)
+            return ai.ToolResult{ID: call.ID, Content: fmt.Sprintf(`{"error": "%s"}`, err)}
         }
         b, _ := json.Marshal(rsp)
-        return rsp, string(b)
+        return ai.ToolResult{ID: call.ID, Value: rsp, Content: string(b)}
     case "list_tasks":
         var rsp ListResponse
-        err := client.Call(ctx, "tasks", "TaskService.List", input, &rsp)
+        err := client.Call(ctx, "tasks", "TaskService.List", call.Input, &rsp)
         if err != nil {
-            return nil, fmt.Sprintf(`{"error": "%s"}`, err)
+            return ai.ToolResult{ID: call.ID, Content: fmt.Sprintf(`{"error": "%s"}`, err)}
         }
         b, _ := json.Marshal(rsp)
-        return rsp, string(b)
+        return ai.ToolResult{ID: call.ID, Value: rsp, Content: string(b)}
     }
-    return nil, `{"error": "unknown tool"}`
+    return ai.ToolResult{ID: call.ID, Content: `{"error": "unknown tool"}`}
 }
 
 m := ai.New("anthropic",

--- a/micro.go
+++ b/micro.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"go-micro.dev/v5/agent"
+	"go-micro.dev/v5/ai"
 	"go-micro.dev/v5/client"
 	"go-micro.dev/v5/flow"
 	"go-micro.dev/v5/server"
@@ -120,6 +121,16 @@ func AgentMemory(m Memory) AgentOption { return agent.WithMemory(m) }
 // AgentTool registers a custom tool the agent can call, beyond its services.
 func AgentTool(name, description string, properties map[string]any, handler ToolFunc) AgentOption {
 	return agent.WithTool(name, description, properties, handler)
+}
+
+// AgentWrapTool registers a tool-execution wrapper — the tool-side
+// analogue of a client/server middleware wrapper. Each wrapper takes the
+// next handler and returns a new one; run code before next(...) for
+// "before", after it for "after". Use it for logging, metrics, retries,
+// or policy. Wrappers run outside the built-in guardrails, so they see
+// every call and result, including refusals.
+func AgentWrapTool(w ...ai.ToolWrapper) AgentOption {
+	return agent.WrapTool(w...)
 }
 
 // NewFlow creates an event-driven LLM orchestration unit.


### PR DESCRIPTION
Restructure ai.ToolHandler to the structured, ctx-carrying shape that mirrors a go-micro RPC handler:

    func(ctx context.Context, call ai.ToolCall) ai.ToolResult

This reuses the existing ToolCall (with its correlation ID) and ToolResult types instead of the flat (name, input)->(any, string) signature, and adds ToolCall.Scan for typed argument access.

Add ai.ToolWrapper and the agent option WrapTool / micro.AgentWrapTool — the tool-side analogue of client.CallWrapper and server.HandlerWrapper. Reframe the built-in guardrails (MaxSteps, LoopLimit, ApproveTool) as composed wrappers around a base handler; developer wrappers compose outermost, so they observe every call and result, including refusals.

Update all provider call sites, the MCP server and chat handlers, the integration harnesses, and docs to the new signature.