### PR TITLE
test(harness): read agent plan from the scoped store

### DIFF
--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -102,8 +102,8 @@ func TestPlanDelegateEndToEnd(t *testing.T) {
 		t.Errorf("task service has %d tasks, want 3", n)
 	}
 
-	// The plan was persisted to the real store.
-	if recs, err := mem.Read("agent/conductor/plan"); err != nil || len(recs) == 0 {
+	// The plan was persisted to the real store, in the agent's scoped table.
+	if recs, err := store.Scope(mem, "agent", "conductor").Read("plan"); err != nil || len(recs) == 0 {
 		t.Errorf("plan not persisted to store: err=%v recs=%d", err, len(recs))
 	}
 
@@ -195,7 +195,7 @@ func TestFlowDispatchesToAgentEndToEnd(t *testing.T) {
 	if n := taskSvc.count(); n != 3 {
 		t.Errorf("task service has %d tasks, want 3", n)
 	}
-	if recs, err := mem.Read("agent/conductor/plan"); err != nil || len(recs) == 0 {
+	if recs, err := store.Scope(mem, "agent", "conductor").Read("plan"); err != nil || len(recs) == 0 {
 		t.Errorf("plan not persisted: err=%v recs=%d", err, len(recs))
 	}
 	if n := notifySvc.count(); n != 1 {


### PR DESCRIPTION
The store-scoping change moved an agent's plan from the default table key agent/{name}/plan to its own table (database "agent", table {name}, key "plan"). The plan-delegate harness tests still read the old key and failed with 'not found'; read through store.Scope(mem, "agent", name) like the agent does.