### PR TITLE
feat(agent): expose run metadata + structured guardrail reasons to to…

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/uuid"
 	pb "go-micro.dev/v6/agent/proto"
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/gateway/a2a"
@@ -72,6 +73,12 @@ type agentImpl struct {
 	// calls counts identical tool calls (name+args) in the current Ask,
 	// for LoopLimit.
 	calls map[string]int
+
+	// runID correlates the tool calls of the current Ask; parentRunID is
+	// the run that delegated to this one (set on ephemeral sub-agents).
+	// Both are surfaced to tool wrappers via ai.RunInfo on the context.
+	runID       string
+	parentRunID string
 }
 
 // New creates a new Agent.
@@ -167,6 +174,14 @@ func (a *agentImpl) Ask(ctx context.Context, message string) (*Response, error) 
 	a.mem.Add("user", message)
 	a.steps = 0
 	a.calls = map[string]int{}
+
+	// Correlate this run's tool calls and surface lineage to wrappers.
+	a.runID = uuid.New().String()
+	ctx = ai.WithRunInfo(ctx, ai.RunInfo{
+		RunID:    a.runID,
+		ParentID: a.parentRunID,
+		Agent:    a.opts.Name,
+	})
 
 	resp, err := a.model.Generate(ctx, &ai.Request{
 		Prompt:       message,

--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -152,7 +152,7 @@ func (a *agentImpl) stepWrap(next ai.ToolHandler) ai.ToolHandler {
 		if a.opts.MaxSteps > 0 {
 			a.steps++
 			if a.steps > a.opts.MaxSteps {
-				return errResult(call.ID, fmt.Sprintf(
+				return refused(call.ID, ai.RefusedMaxSteps, fmt.Sprintf(
 					"step limit reached (%d). Do not call any more tools; stop and summarize what you have so far.",
 					a.opts.MaxSteps))
 			}
@@ -173,7 +173,7 @@ func (a *agentImpl) loopWrap(next ai.ToolHandler) ai.ToolHandler {
 			fp := call.Name + ":" + string(args)
 			a.calls[fp]++
 			if a.calls[fp] > a.opts.LoopLimit {
-				return errResult(call.ID, fmt.Sprintf(
+				return refused(call.ID, ai.RefusedLoop, fmt.Sprintf(
 					"loop detected: you have already called %q with the same arguments %d times and the result will not change. Stop repeating it — try a different approach, or finish with what you have.",
 					call.Name, a.opts.LoopLimit))
 			}
@@ -191,7 +191,7 @@ func (a *agentImpl) approveWrap(next ai.ToolHandler) ai.ToolHandler {
 				if reason != "" {
 					msg += ": " + reason
 				}
-				return errResult(call.ID, msg)
+				return refused(call.ID, ai.RefusedApproval, msg)
 			}
 		}
 		return next(ctx, call)
@@ -261,6 +261,8 @@ func (a *agentImpl) handleDelegate(call ai.ToolCall) ai.ToolResult {
 		WithClient(a.opts.Client),
 		WithStore(a.opts.Store),
 	)
+	// Record lineage so the sub-agent's tool calls carry this run as parent.
+	sub.parentRunID = a.runID
 
 	resp, err := sub.Ask(context.Background(), task)
 	if err != nil {
@@ -326,4 +328,13 @@ func errResult(id, msg string) ai.ToolResult {
 	m := map[string]string{"error": msg}
 	b, _ := json.Marshal(m)
 	return ai.ToolResult{ID: id, Value: m, Content: string(b)}
+}
+
+// refused is an error result a guardrail returns, tagged with a structured
+// reason (ai.Refused*) so a tool wrapper can react to it without parsing
+// the message.
+func refused(id, reason, msg string) ai.ToolResult {
+	r := errResult(id, msg)
+	r.Refused = reason
+	return r
 }

--- a/agent/wrap_test.go
+++ b/agent/wrap_test.go
@@ -2,10 +2,13 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/registry"
+	"go-micro.dev/v6/store"
 )
 
 // A registered wrapper runs around every tool call and can observe and
@@ -79,6 +82,81 @@ func TestWrapToolSeesGuardrailRefusal(t *testing.T) {
 
 	if !strings.Contains(sawResult, "not approved") {
 		t.Errorf("wrapper should observe the guardrail refusal; got %q", sawResult)
+	}
+}
+
+// A guardrail refusal carries a structured reason a wrapper can switch on,
+// so reliability tooling (e.g. loop handling) needn't parse the message.
+func TestWrapToolSeesRefusedReason(t *testing.T) {
+	a := newTestAgent(Name("looper"), LoopLimit(2))
+	h := a.toolHandler()
+
+	var last ai.ToolResult
+	for i := 0; i < 3; i++ {
+		last = h(context.Background(), ai.ToolCall{ID: "x", Name: "demo_Svc_Do", Input: map[string]any{"q": "same"}})
+	}
+	if last.Refused != ai.RefusedLoop {
+		t.Errorf("Refused = %q, want %q", last.Refused, ai.RefusedLoop)
+	}
+}
+
+// ctxMock is a model that forwards the Generate context to the tool
+// handler (as real providers do), so a wrapper can read ai.RunInfo.
+type ctxMock struct{ opts ai.Options }
+
+func (m *ctxMock) Init(opts ...ai.Option) error {
+	for _, o := range opts {
+		o(&m.opts)
+	}
+	return nil
+}
+func (m *ctxMock) Options() ai.Options { return m.opts }
+func (m *ctxMock) String() string      { return "ctxmock" }
+func (m *ctxMock) Stream(context.Context, *ai.Request, ...ai.GenerateOption) (ai.Stream, error) {
+	return nil, fmt.Errorf("no stream")
+}
+func (m *ctxMock) Generate(ctx context.Context, _ *ai.Request, _ ...ai.GenerateOption) (*ai.Response, error) {
+	if m.opts.ToolHandler != nil {
+		m.opts.ToolHandler(ctx, ai.ToolCall{ID: "c1", Name: "demo_Svc_Do", Input: map[string]any{}})
+	}
+	return &ai.Response{Answer: "done"}, nil
+}
+
+// During an Ask, a wrapper sees RunInfo on the context: a correlation id
+// for the run and the agent's name.
+func TestWrapToolSeesRunInfo(t *testing.T) {
+	ai.Register("ctxmock", func(opts ...ai.Option) ai.Model {
+		m := &ctxMock{}
+		_ = m.Init(opts...)
+		return m
+	})
+
+	var got ai.RunInfo
+	var ok bool
+	a := New(
+		Name("runner"),
+		Provider("ctxmock"),
+		WithRegistry(registry.NewMemoryRegistry()),
+		WithStore(store.NewMemoryStore()),
+		WrapTool(func(next ai.ToolHandler) ai.ToolHandler {
+			return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+				got, ok = ai.RunInfoFrom(ctx)
+				return next(ctx, call)
+			}
+		}),
+	)
+
+	if _, err := a.Ask(context.Background(), "go"); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !ok {
+		t.Fatal("wrapper did not see RunInfo on the context")
+	}
+	if got.Agent != "runner" {
+		t.Errorf("RunInfo.Agent = %q, want runner", got.Agent)
+	}
+	if got.RunID == "" {
+		t.Error("RunInfo.RunID is empty")
 	}
 }
 

--- a/ai/model.go
+++ b/ai/model.go
@@ -86,6 +86,42 @@ type ToolResult struct {
 	ID      string // Tool call ID (for correlation)
 	Value   any    // Structured result (optional)
 	Content string // Tool execution result (JSON string), shown to the model
+	// Refused names the reason a guardrail blocked the call before it ran
+	// ("max_steps", "loop", "approval"); empty when the call executed. A
+	// tool wrapper can switch on it to build reliability tooling — react to
+	// a detected loop, audit refusals — without parsing the message.
+	Refused string `json:"refused,omitempty"`
+}
+
+// Refusal reason codes set on ToolResult.Refused by the agent's guardrails.
+const (
+	RefusedMaxSteps = "max_steps"
+	RefusedLoop     = "loop"
+	RefusedApproval = "approval"
+)
+
+// RunInfo describes the agent run a tool call belongs to. The agent
+// attaches it to the context passed to a ToolHandler, so a wrapper can
+// correlate calls within a run and across delegation without coupling to
+// the agent package. Per-call detail (tool name, id) is on the ToolCall;
+// step and attempt counts are naturally counted by the wrapper itself.
+type RunInfo struct {
+	RunID    string // correlation id for this agent run (one per Ask)
+	ParentID string // the run that delegated to this one, if any
+	Agent    string // the agent's name
+}
+
+type runInfoKey struct{}
+
+// WithRunInfo attaches run info to ctx.
+func WithRunInfo(ctx context.Context, r RunInfo) context.Context {
+	return context.WithValue(ctx, runInfoKey{}, r)
+}
+
+// RunInfoFrom returns the run info attached to ctx, and whether it was set.
+func RunInfoFrom(ctx context.Context) (RunInfo, bool) {
+	r, ok := ctx.Value(runInfoKey{}).(RunInfo)
+	return r, ok
 }
 
 // Stream is the interface for streaming responses (future implementation)

--- a/internal/website/docs/guides/agent-guardrails.md
+++ b/internal/website/docs/guides/agent-guardrails.md
@@ -78,6 +78,31 @@ type ToolWrapper func(ToolHandler) ToolHandler
 
 Wrappers run **outside** the built-in guardrails, so they observe every call and its result — including a guardrail's refusal. Multiple wrappers compose outermost-first (the first registered is the outer layer). A "before/after" hook is just the two halves of one wrapper, and retry is calling `next` again — so the wrapper is the single, composable seam for everything around execution, while `MaxSteps`, `LoopLimit`, and `ApproveTool` remain the named guardrails on top of it.
 
+### Reliability metadata
+
+A wrapper has what it needs to build reliability tooling — loop handling, retry policies, auditing — without coupling to the agent:
+
+- **What happened** — a guardrail refusal is tagged with a structured reason on the result, so you switch on it rather than parse a message:
+
+  ```go
+  res := next(ctx, call)
+  switch res.Refused {
+  case ai.RefusedLoop:     // the agent repeated an identical call
+  case ai.RefusedMaxSteps: // the step budget was exhausted
+  case ai.RefusedApproval: // ApproveTool blocked it
+  }
+  ```
+
+- **Which run** — `ai.RunInfoFrom(ctx)` returns a correlation id for the run, the agent's name, and the parent run when the call came from a delegated sub-agent:
+
+  ```go
+  if run, ok := ai.RunInfoFrom(ctx); ok {
+      log.Printf("run=%s parent=%s agent=%s tool=%s", run.RunID, run.ParentID, run.Agent, call.Name)
+  }
+  ```
+
+- **Per-call detail** — `call.ID` (correlation), `call.Name`; duration is `time.Since(start)` around `next`, and step/attempt counts are naturally counted by the wrapper itself (it sees every call).
+
 ## Execution safety at the gateway
 
 When agents reach tools **through the MCP gateway**, the gateway adds its own per-tool policies, independent of the agent:


### PR DESCRIPTION
…ol wrappers

Closes the remaining ask in #2980 without adding a parallel callback API. ToolResult.Refused tags a guardrail block with a reason (ai.RefusedLoop / RefusedMaxSteps / RefusedApproval) so a wrapper can switch on it instead of parsing the message. ai.RunInfo (RunID, ParentID, Agent) rides on the context passed to the tool handler, giving wrappers run correlation and delegation lineage. Before/after/retry/failure were already covered by AgentWrapTool; this adds the metadata. Docs + tests included.