### PR TITLE
examples: support desk agent + blog walkthrough

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -79,6 +79,12 @@ A workflow as ordered, checkpointed steps that survives a crash and resumes wher
 - **steps** — a flow is a task with stages (`reserve → charge → confirm`), not just one LLM turn
 - **Checkpoint** — each step is persisted; on `Resume`, completed steps are not re-run (no duplicate side effects)
 
+### [support](./support/)
+A real-world support desk — the "zero to hero" shape in one runnable file:
+- **services** (`customers`, `tickets`, `notify`) become the agent's tools automatically
+- **flow** turns a `ticket.created` event into work for the agent (the event is the prompt)
+- **guardrail** — the agent triages freely but can't email a customer without passing the approval gate
+
 ## Coming Soon
 
 - **pubsub-events** - Event-driven architecture with NATS

--- a/examples/support/README.md
+++ b/examples/support/README.md
@@ -1,0 +1,62 @@
+# Support desk
+
+A real-world agent built the Go Micro way: a few services, an agent that
+manages them, an event that triggers it, and a human-in-the-loop gate on the
+one action that touches a customer. It's the "zero to hero" shape in one
+runnable file.
+
+## The scenario
+
+A customer files a ticket. A `ticket.created` event triggers the support
+agent, which:
+
+1. looks the customer up (`customers` service),
+2. sets the ticket's priority (`tickets` service),
+3. drafts a reply and emails it (`notify` service) — **but only after passing
+   the approval gate.**
+
+```
+> event: events.ticket.created {"id":"ticket-1","customer":"alice@acme.com",...}
+
+    [customers] looked up Alice (pro plan)
+    [tickets]   ticket-1 → priority=high status=in_progress
+    ▣ approval gate notify_NotifyService_Send(alice@acme.com) — approved
+    [notify]    📨 to=alice@acme.com: "Hi Alice — thanks for reaching out..."
+
+✓ ticket triaged and the customer was replied to — triggered by an event
+```
+
+## The pieces
+
+- **Services** (`customers`, `tickets`, `notify`) — plain Go Micro services. The
+  agent discovers their endpoints as tools automatically.
+- **Agent** (`support`) — `micro.NewAgent` with those three services. It reasons
+  over the ticket and calls the tools.
+- **Flow** (`intake`) — triggers on `events.ticket.created` and hands the event to
+  the agent: *the event is the prompt*. No human types anything.
+- **Guardrail** (`ApproveTool`) — the agent can read and triage freely, but
+  emailing a customer (`notify.Send`) passes through the gate first. Return
+  `false` to hold it for a person or a policy; the example approves and logs.
+
+## Run
+
+```bash
+go run main.go            # mock model — deterministic, no API key
+```
+
+Against a live model, the agent reasons about the ticket itself instead of
+following the script:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY, GEMINI_API_KEY, ...
+go run main.go -provider anthropic
+```
+
+## What to change next
+
+- Make the gate real: return `false` from `ApproveTool` for billing actions, or
+  route the decision to a human.
+- Expose the agent over A2A so another team's agent can file tickets — add
+  `agent.WithA2A(":4000")`.
+- Add a `kb` (knowledge base) service and watch the agent search it before
+  replying.

--- a/examples/support/main.go
+++ b/examples/support/main.go
@@ -1,0 +1,311 @@
+// Support desk — a real-world agent built from services, a flow, and a
+// guardrail. It's the "zero to hero" shape: a few services, an agent that
+// manages them, an event that triggers the agent, and a human-in-the-loop
+// gate on the one action that touches a customer.
+//
+// The scenario: a customer files a ticket. A ticket.created event triggers
+// the support agent, which looks the customer up, sets the ticket's
+// priority, and drafts a reply — but it can't actually email the customer
+// without passing the approval gate.
+//
+// Everything is real — services, registry, RPC, broker, the agent loop,
+// the store. Only the LLM is mocked, so it runs with no API key. Pass
+// -provider anthropic (with a key) to run it against a live model; then the
+// agent reasons about the ticket itself instead of following the script.
+//
+// Run:
+//
+//	go run ./examples/support
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"go-micro.dev/v6/agent"
+	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/broker"
+	"go-micro.dev/v6/client"
+	"go-micro.dev/v6/flow"
+	"go-micro.dev/v6/registry"
+	"go-micro.dev/v6/selector"
+	"go-micro.dev/v6/service"
+	"go-micro.dev/v6/store"
+)
+
+// ---------------------------------------------------------------------------
+// services — the support desk's capabilities
+// ---------------------------------------------------------------------------
+
+type Customer struct {
+	Email string `json:"email"`
+	Name  string `json:"name"`
+	Plan  string `json:"plan"`
+}
+
+type LookupRequest struct {
+	Email string `json:"email" description:"Customer email to look up (required)"`
+}
+
+// CustomerService is a tiny seeded customer directory.
+type CustomerService struct{}
+
+// Lookup returns the customer with the given email.
+// @example {"email": "alice@acme.com"}
+func (s *CustomerService) Lookup(_ context.Context, req *LookupRequest, rsp *Customer) error {
+	known := map[string]Customer{
+		"alice@acme.com": {Email: "alice@acme.com", Name: "Alice", Plan: "pro"},
+	}
+	c, ok := known[req.Email]
+	if !ok {
+		return fmt.Errorf("customer %s not found", req.Email)
+	}
+	*rsp = c
+	fmt.Printf("    \033[32m[customers]\033[0m looked up %s (%s plan)\n", c.Name, c.Plan)
+	return nil
+}
+
+type Ticket struct {
+	ID       string `json:"id"`
+	Customer string `json:"customer"`
+	Subject  string `json:"subject"`
+	Body     string `json:"body"`
+	Priority string `json:"priority,omitempty"`
+	Status   string `json:"status"`
+}
+
+type UpdateRequest struct {
+	ID       string `json:"id" description:"Ticket id (required)"`
+	Priority string `json:"priority" description:"Priority: low, normal, high"`
+	Status   string `json:"status" description:"Status: open, in_progress, resolved"`
+}
+
+// TicketService stores support tickets in memory.
+type TicketService struct {
+	mu      sync.Mutex
+	tickets map[string]*Ticket
+}
+
+func (s *TicketService) seed(t *Ticket) {
+	s.mu.Lock()
+	if s.tickets == nil {
+		s.tickets = map[string]*Ticket{}
+	}
+	s.tickets[t.ID] = t
+	s.mu.Unlock()
+}
+
+// Update changes a ticket's priority and/or status.
+// @example {"id": "ticket-1", "priority": "high", "status": "in_progress"}
+func (s *TicketService) Update(_ context.Context, req *UpdateRequest, rsp *Ticket) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.tickets[req.ID]
+	if !ok {
+		return fmt.Errorf("ticket %s not found", req.ID)
+	}
+	if req.Priority != "" {
+		t.Priority = req.Priority
+	}
+	if req.Status != "" {
+		t.Status = req.Status
+	}
+	*rsp = *t
+	fmt.Printf("    \033[32m[tickets]\033[0m %s → priority=%s status=%s\n", t.ID, t.Priority, t.Status)
+	return nil
+}
+
+type SendRequest struct {
+	To      string `json:"to" description:"Recipient email (required)"`
+	Message string `json:"message" description:"Reply body (required)"`
+}
+type SendResponse struct {
+	Sent bool `json:"sent"`
+}
+
+// NotifyService emails the customer. This is the action we gate.
+type NotifyService struct{ sent int }
+
+// Send emails a reply to a customer.
+// @example {"to": "alice@acme.com", "message": "We're on it."}
+func (s *NotifyService) Send(_ context.Context, req *SendRequest, rsp *SendResponse) error {
+	s.sent++
+	fmt.Printf("    \033[35m[notify]\033[0m 📨 to=%s: %q\n", req.To, req.Message)
+	rsp.Sent = true
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// mock LLM — the only fake. It scripts the triage from the offered tools.
+// ---------------------------------------------------------------------------
+
+type mockModel struct{ opts ai.Options }
+
+func newMock(opts ...ai.Option) ai.Model {
+	m := &mockModel{}
+	_ = m.Init(opts...)
+	return m
+}
+func (m *mockModel) Init(opts ...ai.Option) error {
+	for _, o := range opts {
+		o(&m.opts)
+	}
+	return nil
+}
+func (m *mockModel) Options() ai.Options { return m.opts }
+func (m *mockModel) String() string      { return "mock" }
+func (m *mockModel) Stream(context.Context, *ai.Request, ...ai.GenerateOption) (ai.Stream, error) {
+	return nil, fmt.Errorf("stream not supported by mock")
+}
+
+func (m *mockModel) call(ctx context.Context, tools []ai.Tool, sub string, input map[string]any) {
+	for _, t := range tools {
+		if strings.Contains(t.Name, sub) && m.opts.ToolHandler != nil {
+			m.opts.ToolHandler(ctx, ai.ToolCall{ID: sub, Name: t.Name, Input: input})
+			return
+		}
+	}
+}
+
+func (m *mockModel) Generate(ctx context.Context, req *ai.Request, _ ...ai.GenerateOption) (*ai.Response, error) {
+	// A real model would read the ticket from the prompt and decide. The
+	// mock follows a fixed, sensible triage so the demo is deterministic.
+	m.call(ctx, req.Tools, "Lookup", map[string]any{"email": "alice@acme.com"})
+	m.call(ctx, req.Tools, "Update", map[string]any{"id": "ticket-1", "priority": "high", "status": "in_progress"})
+	m.call(ctx, req.Tools, "Send", map[string]any{
+		"to":      "alice@acme.com",
+		"message": "Hi Alice — thanks for reaching out. We've bumped this to high priority and are on it.",
+	})
+	return &ai.Response{Answer: "Triaged ticket-1 for Alice and sent a reply."}, nil
+}
+
+// ---------------------------------------------------------------------------
+// wiring
+// ---------------------------------------------------------------------------
+
+func providerKey(provider string) string {
+	if v := os.Getenv("MICRO_AI_API_KEY"); v != "" {
+		return v
+	}
+	return os.Getenv(map[string]string{
+		"anthropic": "ANTHROPIC_API_KEY", "openai": "OPENAI_API_KEY",
+		"gemini": "GEMINI_API_KEY", "groq": "GROQ_API_KEY", "mistral": "MISTRAL_API_KEY",
+		"together": "TOGETHER_API_KEY", "atlascloud": "ATLASCLOUD_API_KEY",
+	}[provider])
+}
+
+func waitFor(reg registry.Registry, names ...string) {
+	deadline := time.Now().Add(5 * time.Second)
+	for _, name := range names {
+		for time.Now().Before(deadline) {
+			if svcs, err := reg.GetService(name); err == nil && len(svcs) > 0 && len(svcs[0].Nodes) > 0 {
+				break
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+}
+
+func main() {
+	provider := flag.String("provider", "mock", "LLM provider: mock (default), anthropic, openai, ...")
+	flag.Parse()
+
+	apiKey := ""
+	if *provider == "mock" {
+		ai.Register("mock", newMock)
+	} else if apiKey = providerKey(*provider); apiKey == "" {
+		fmt.Printf("no API key for provider %q — set MICRO_AI_API_KEY or the provider's key env\n", *provider)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\n\033[1mSupport desk (provider: %s)\033[0m\n\n", *provider)
+
+	// Shared in-memory infrastructure so the demo runs in one process.
+	reg := registry.NewMemoryRegistry()
+	br := broker.NewMemoryBroker()
+	if err := br.Connect(); err != nil {
+		fmt.Println("broker connect:", err)
+		os.Exit(1)
+	}
+	cl := client.NewClient(client.Registry(reg), client.Selector(selector.NewSelector(selector.Registry(reg))))
+
+	// Services.
+	tickets := new(TicketService)
+	notify := new(NotifyService)
+	for name, h := range map[string]any{"customers": new(CustomerService), "tickets": tickets, "notify": notify} {
+		svc := service.New(service.Name(name), service.Registry(reg), service.Client(cl))
+		_ = svc.Handle(h)
+		go svc.Run()
+	}
+
+	// The support agent manages the three services. The approval gate is
+	// the human-in-the-loop: it can read and triage freely, but emailing a
+	// customer (notify.Send) passes through here first. Return false to hold
+	// it for a person or a policy; here we approve and log.
+	support := agent.New(
+		agent.Name("support"),
+		agent.Services("customers", "tickets", "notify"),
+		agent.Prompt("You are a support agent. For each ticket, look up the customer, set an "+
+			"appropriate priority, and reply to them. Escalate billing issues."),
+		agent.Provider(*provider), agent.APIKey(apiKey),
+		agent.ApproveTool(func(tool string, input map[string]any) (bool, string) {
+			if strings.Contains(tool, "Send") {
+				fmt.Printf("  \033[33m▣ approval gate\033[0m %s(%v) — approved\n", tool, input["to"])
+			}
+			return true, ""
+		}),
+		agent.WithRegistry(reg), agent.WithClient(cl), agent.WithStore(store.NewMemoryStore()),
+	)
+	go support.Run()
+	defer support.Stop()
+
+	waitFor(reg, "customers", "tickets", "notify", "support")
+
+	// A new ticket arrives, and a flow turns the event into work for the
+	// agent: the event is the prompt.
+	intake := flow.New("intake",
+		flow.Trigger("events.ticket.created"),
+		flow.Agent("support"),
+		flow.Prompt("A new support ticket arrived: {{.Data}}. Handle it."),
+	)
+	if err := intake.Register(reg, br, cl); err != nil {
+		fmt.Println("flow register:", err)
+		os.Exit(1)
+	}
+	defer intake.Stop()
+
+	// The customer files a ticket (it exists before the event fires).
+	tickets.seed(&Ticket{ID: "ticket-1", Customer: "alice@acme.com", Subject: "Can't log in", Body: "I'm locked out.", Status: "open"})
+	body, _ := json.Marshal(map[string]string{"id": "ticket-1", "customer": "alice@acme.com", "subject": "Can't log in"})
+
+	fmt.Println("\033[1m> event:\033[0m events.ticket.created", string(body))
+	fmt.Println()
+	if err := br.Publish("events.ticket.created", &broker.Message{Body: body}); err != nil {
+		fmt.Println("publish:", err)
+		os.Exit(1)
+	}
+
+	// Wait for the agent to act.
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if notify.sent >= 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if rs := intake.Results(); len(rs) > 0 {
+		fmt.Printf("\n\033[1msupport agent:\033[0m %s\n", rs[len(rs)-1].Reply)
+	}
+	if notify.sent >= 1 {
+		fmt.Println("\n\033[32m✓ ticket triaged and the customer was replied to — triggered by an event\033[0m")
+	} else {
+		fmt.Println("\n\033[31m✗ the agent did not complete the triage\033[0m")
+	}
+}

--- a/internal/website/blog/28.md
+++ b/internal/website/blog/28.md
@@ -1,0 +1,95 @@
+---
+layout: blog
+title: "Building a Support Agent in Go"
+permalink: /blog/28
+description: "A real thing you can build with Go Micro: a support desk where a customer ticket triggers an agent that looks up the customer, sets priority, and replies — with a human-in-the-loop gate on the one action that touches a customer."
+---
+
+# Building a Support Agent in Go
+
+*June 19, 2026 &bull; Asim Aslam*
+
+Most agent demos are a chat box wired to one tool. Real systems aren't that — they're a handful of services, an agent that operates them, something that triggers the agent without a human typing, and a gate on the actions you don't want it taking on its own. Here's that, built end to end. The full code is in [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support); it runs with no API key.
+
+The scenario: a customer files a ticket. That should trigger an agent to look the customer up, set a priority, and reply — but it must not email anyone without passing an approval gate.
+
+## 1. Services are the tools
+
+Start with plain services. The agent will discover their endpoints as tools automatically — you don't describe them twice.
+
+```go
+type CustomerService struct{}
+
+// Lookup returns the customer with the given email.
+// @example {"email": "alice@acme.com"}
+func (s *CustomerService) Lookup(ctx context.Context, req *LookupRequest, rsp *Customer) error {
+    // ...
+}
+```
+
+A `tickets` service (with `Update`) and a `notify` service (with `Send`, the action we'll gate) round it out. Three ordinary Go Micro services — nothing AI-specific about them.
+
+## 2. The agent
+
+An agent is a service with a model inside. Give it the services it manages and it turns their endpoints into tools:
+
+```go
+support := micro.NewAgent("support",
+    micro.AgentServices("customers", "tickets", "notify"),
+    micro.AgentPrompt("You are a support agent. For each ticket, look up the "+
+        "customer, set a priority, and reply. Escalate billing issues."),
+)
+```
+
+That's the whole agent. It discovers `customers.Lookup`, `tickets.Update`, and `notify.Send`, and the model decides which to call.
+
+## 3. The event is the prompt
+
+A support agent that waits for someone to type into a chat box is useless. The trigger is a *ticket*, so a flow turns that event into the agent's work:
+
+```go
+intake := micro.NewFlow("intake",
+    micro.FlowTrigger("events.ticket.created"),
+    micro.FlowAgent("support"),
+    micro.FlowPrompt("A new support ticket arrived: {{.Data}}. Handle it."),
+)
+```
+
+Now a `ticket.created` event on the broker is enough to set the agent going — no human in the loop to start it. ([When the event is the prompt](/blog/21) is the idea in full.)
+
+## 4. The guardrail is the point
+
+The agent can read and triage all it likes. The action you actually care about is the one that reaches a customer — sending the email. That goes through a gate:
+
+```go
+micro.AgentApproveTool(func(tool string, input map[string]any) (bool, string) {
+    if strings.Contains(tool, "Send") {
+        // return false to hold it for a human or a policy
+        log.Printf("approval gate: emailing %v", input["to"])
+    }
+    return true, ""
+})
+```
+
+Return `false` and the send is refused with a reason the model sees — that's your human-in-the-loop, your spend cap, your billing sign-off. The agent never gets to email a customer on its own unless you let it. ([Agent guardrails](/blog/23) covers the rest.)
+
+## Run it
+
+```
+> event: events.ticket.created {"id":"ticket-1","customer":"alice@acme.com",...}
+
+    [customers] looked up Alice (pro plan)
+    [tickets]   ticket-1 → priority=high status=in_progress
+    ▣ approval gate notify_NotifyService_Send(alice@acme.com) — approved
+    [notify]    📨 to=alice@acme.com: "Hi Alice — thanks for reaching out..."
+
+✓ ticket triaged and the customer was replied to — triggered by an event
+```
+
+With the mock model it follows a fixed triage so it runs anywhere. Point it at a real model — `go run main.go -provider anthropic` — and the agent reasons about the ticket itself, choosing what to look up and how to reply.
+
+## What you actually built
+
+Count what's AI-specific: the prompt, and one model option. Everything else is services, a flow, the broker, and a guardrail — the things Go Micro has always done. The agent didn't need a framework of its own; it's a service that calls other services, triggered by an event, with a gate on the dangerous action.
+
+That's the shape of a real agent system, and it's the same shape as a real service system. From here you'd make the gate enforce a real policy, add a knowledge-base service for the agent to search, or expose the agent over [A2A](/blog/26) so another team's agent can file tickets. The code is in [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support) — clone it and change one thing.

--- a/internal/website/blog/index.html
+++ b/internal/website/blog/index.html
@@ -12,6 +12,13 @@ permalink: /blog/
 <div class="posts">
 
   <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
+    <h2 style="margin: 0 0 0.5rem;"><a href="/blog/28">Building a Support Agent in Go</a></h2>
+    <p class="meta" style="color: #666; font-size: 0.85rem;">June 19, 2026</p>
+    <p>A real thing you can build with Go Micro: a support desk where a customer ticket triggers an agent that looks up the customer, sets priority, and replies — with a human-in-the-loop gate on the one action that touches a customer.</p>
+    <a href="/blog/28">Read more &rarr;</a>
+  </article>
+
+  <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
     <h2 style="margin: 0 0 0.5rem;"><a href="/blog/27">Bringing an Open Source Project Back from the Dead</a></h2>
     <p class="meta" style="color: #666; font-size: 0.85rem;">June 18, 2026</p>
     <p>Go Micro started in January 2015, went through a VC-funded company and a platform pivot, and then went quiet. This is how it came back — and how agents, services, and flows brought it to v6.</p>


### PR DESCRIPTION
A real-world, runnable example (examples/support): customers/tickets/notify services become the agent's tools, a flow turns a ticket.created event into the agent's work, and an approval gate guards the one action that touches a customer. Runs with no API key (mock model) or against a live provider.

Adds blog/28 'Building a Support Agent in Go' and indexes both.


Claude-Session: https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL