### PR TITLE
website: add commercial support to the landing page

### DIFF
--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -274,8 +274,11 @@
           <img src="https://www.atlascloud.ai/logo.svg" alt="Atlas Cloud" style="height: 28px; opacity: 0.7; transition: opacity 0.2s; box-shadow: none;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'" />
         </a>
       </div>
-      <p class="subtitle" style="margin-top: 2.25rem;">Want to support Go Micro and put your logo here?</p>
-      <a href="https://discord.gg/WeMU5AGxD" class="btn btn-secondary">Become a sponsor</a>
+      <p class="subtitle" style="margin-top: 2.25rem;">Want to support Go Micro and put your logo here? Or running it in production and need a hand?</p>
+      <div class="hero-buttons">
+        <a href="https://discord.gg/WeMU5AGxD" class="btn btn-secondary">Become a sponsor</a>
+        <a href="/docs/support.html" class="btn btn-primary">Commercial support</a>
+      </div>
     </section>
 
     <section class="section-alt">
@@ -296,7 +299,7 @@
         <a href="/docs/">Docs</a> &middot;
         <a href="/blog/">Blog</a> &middot;
         <a href="https://github.com/micro/go-micro">GitHub</a> &middot;
-        <a href="https://github.com/micro/go-micro/issues/new?labels=question&template=question.md">Support</a>
+        <a href="/docs/support.html">Support</a>
       </div>
     </footer>
 


### PR DESCRIPTION
The Sponsors section now also points production users to commercial support & consulting, and the footer Support link routes to the support page (community + commercial) instead of the question issue template.


Claude-Session: https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL