### PR TITLE
docs: install the CLI with @v6 instead of @latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The AI-native major release. Breaking changes are listed first; everything
 else is additive. See the [v5 → v6 migration guide](internal/website/docs/guides/migration/v5-to-v6.md) — it's a small upgrade.
 
 ### Changed (breaking)
-- **Module path is now `go-micro.dev/v6`.** Update imports (`go-micro.dev/v5/...` → `go-micro.dev/v6/...`) and `go install go-micro.dev/v6/cmd/micro@latest`.
+- **Module path is now `go-micro.dev/v6`.** Update imports (`go-micro.dev/v5/...` → `go-micro.dev/v6/...`) and `go install go-micro.dev/v6/cmd/micro@v6`.
 - **TLS verification is on by default.** v5 skipped verification unless `MICRO_TLS_SECURE=true`; v6 verifies by default. `MICRO_TLS_SECURE` is removed — set `MICRO_TLS_INSECURE=true` (or call `tls.InsecureConfig()`) for self-signed/dev certs.
 - **`micro.NewService(name, opts...)` is the service constructor**, symmetric with `NewAgent`/`NewFlow`. `micro.New(name, opts...)` remains as a deprecated alias; the old name-less `micro.NewService(opts...)` form is removed (pass the name positionally). Generators emit the new form.
 - **JWT auth ported in-module.** The external `github.com/micro/plugins/v5/auth/jwt` (pinned to v5) is replaced by `go-micro.dev/v6/auth/jwt/token`, now on the maintained `golang-jwt/jwt/v5`; the deprecated `dgrijalva/jwt-go` dependency is dropped.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Install the CLI:
 curl -fsSL https://go-micro.dev/install.sh | sh
 
 # Or with Go
-go install go-micro.dev/v6/cmd/micro@latest
+go install go-micro.dev/v6/cmd/micro@v6
 ```
 
 ### Fastest start — no API key

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -26,10 +26,10 @@ Go Micro has three core abstractions:
 curl -fsSL https://go-micro.dev/install.sh | sh
 
 # Or with Go
-go install go-micro.dev/v6/cmd/micro@latest
+go install go-micro.dev/v6/cmd/micro@v6
 ```
 
-> If `@latest` reports a version constraint conflict, pin the current major version explicitly, e.g. `go install go-micro.dev/v6/cmd/micro@v6.1.0` (see [releases](https://github.com/micro/go-micro/releases)).
+> Use `@v6` (not `@latest`). It selects the newest `v6.x.x` release. Plain `@latest` can currently resolve to a stale pre-rename tag through the public module proxy and fail with a "version constraints conflict"; `@v6` avoids that. To pin an exact version use e.g. `@v6.2.0` (see [releases](https://github.com/micro/go-micro/releases)).
 
 ## Quick Start: Generate from a Prompt
 

--- a/internal/website/docs/guides/ai-native-services.md
+++ b/internal/website/docs/guides/ai-native-services.md
@@ -17,7 +17,7 @@ A **task management service** with full CRUD operations that:
 ## Prerequisites
 
 ```bash
-go install go-micro.dev/v6/cmd/micro@latest
+go install go-micro.dev/v6/cmd/micro@v6
 ```
 
 ## Step 1: Create the Service

--- a/internal/website/docs/guides/grpc-compatibility.md
+++ b/internal/website/docs/guides/grpc-compatibility.md
@@ -88,7 +88,7 @@ message Response {
 
 ```bash
 # Install protoc-gen-micro
-go install go-micro.dev/v6/cmd/protoc-gen-micro@latest
+go install go-micro.dev/v6/cmd/protoc-gen-micro@v6
 
 # Generate Go code
 protoc --proto_path=. \

--- a/internal/website/docs/guides/migration/from-grpc.md
+++ b/internal/website/docs/guides/migration/from-grpc.md
@@ -90,7 +90,7 @@ Update your proto generation:
 
 ```bash
 # Install protoc-gen-micro
-go install go-micro.dev/v6/cmd/protoc-gen-micro@latest
+go install go-micro.dev/v6/cmd/protoc-gen-micro@v6
 
 # Generate both gRPC and Go Micro code
 protoc --proto_path=. \

--- a/internal/website/docs/guides/migration/v5-to-v6.md
+++ b/internal/website/docs/guides/migration/v5-to-v6.md
@@ -32,7 +32,7 @@ go mod tidy
 Update the CLI too:
 
 ```bash
-go install go-micro.dev/v6/cmd/micro@latest
+go install go-micro.dev/v6/cmd/micro@v6
 ```
 
 ## 2. TLS is verified by default

--- a/internal/website/docs/quickstart.md
+++ b/internal/website/docs/quickstart.md
@@ -13,10 +13,10 @@ curl -fsSL https://go-micro.dev/install.sh | sh
 Or, if you have Go and prefer to build from source:
 
 ```bash
-go install go-micro.dev/v6/cmd/micro@latest
+go install go-micro.dev/v6/cmd/micro@v6
 ```
 
-> **Note:** If `go install ...@latest` reports a version constraint conflict, pin the major version explicitly, e.g. `go install go-micro.dev/v6/cmd/micro@v6.1.0` (see [releases](https://github.com/micro/go-micro/releases)).
+> **Note:** Use `@v6` (not `@latest`) — it resolves to the newest `v6.x.x` release. Plain `@latest` can currently resolve to a stale pre-rename tag through the public module proxy and fail with a "version constraints conflict"; `@v6` avoids that. To pin an exact version use e.g. `@v6.2.0` (see [releases](https://github.com/micro/go-micro/releases)).
 
 ## Create Your First Service
 

--- a/internal/website/docs/server.md
+++ b/internal/website/docs/server.md
@@ -28,7 +28,7 @@ For local development, use [`micro run`](guides/micro-run.html) instead.
 Install the CLI which includes the server command:
 
 ```bash
-go install go-micro.dev/v6/cmd/micro@latest
+go install go-micro.dev/v6/cmd/micro@v6
 ```
 
 > **Note:** Use a specific version instead of `@latest` to avoid module path conflicts. See [releases](https://github.com/micro/go-micro/releases) for the latest version.


### PR DESCRIPTION
Plain 'go install go-micro.dev/v6/cmd/micro@latest' fails on the public module proxy with a version-constraints conflict: the proxy has cached the sub-paths go-micro.dev/v6/cmd and .../cmd/micro as standalone v0/v1 modules (from old github.com/micro/go-micro tags, surfaced during an earlier vanity meta bug), so @latest resolves to v1.18.0 with a mismatched module path.

A version-prefix query (@v6) sidesteps it: those cached sub-path modules have no v6.x.x versions, so Go falls back to the go-micro.dev/v6 root module and builds correctly. Verified against proxy.golang.org.


Claude-Session: https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL