### PR TITLE
docs: add docstring to getHTTP2BufPool function

### DIFF
--- a/transport/http2_buf_pool.go
+++ b/transport/http2_buf_pool.go
@@ -8,6 +8,7 @@ var http2BufPool = sync.Pool{
 	},
 }
 
+// getHTTP2BufPool returns the HTTP2 buffer pool.
 func getHTTP2BufPool() *sync.Pool {
 	return &http2BufPool
 }


### PR DESCRIPTION
### 问题背景
公共函数 `getHTTP2BufPool` 缺少文档注释，这降低了代码的可读性和可维护性。添加文档注释有助于其他开发者理解函数的用途和返回值，符合 Go 语言的最佳实践。

### 修改内容
- **修改了什么**：为 `getHTTP2BufPool` 函数添加了一行文档注释，说明它返回 HTTP2 缓冲池。
- **为什么这样改**：提升代码自文档化，便于新贡献者快速理解函数功能，并遵循开源项目的文档标准。
- **对代码质量的提升**：增强了代码的可读性和维护性，无性能或安全性影响。

### 验证方式
- 由于修改仅涉及添加注释，不影响代码功能，因此所有现有测试应通过。
- 运行了仓库的测试套件（如 `go test ./transport/...`），确认没有引入回归。
- 手动检查了注释的准确性和与代码上下文的一致性。

### 其他信息
- **Breaking changes**: 无。此修改仅为文档增强，不改变任何 API 或行为。
- **文档更新**: 不需要额外更新，因为修改本身就是文档改进。
- **已知限制**: 无。