### PR TITLE
Trim landing tagline to one-liner

### DIFF
--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -176,7 +176,7 @@
     <section class="hero">
       <div class="hero-inner">
         <h1>Build Agents and Services in Go</h1>
-        <p class="tagline">An AI-native framework for agents, services, and flows. Every service is an MCP tool; every agent speaks A2A.</p>
+        <p class="tagline">An AI-native framework for agents, services, and flows.</p>
         <pre>curl -fsSL https://go-micro.dev/install.sh | sh</pre>
         <div class="hero-buttons">
           <a href="/docs/getting-started.html" class="btn btn-primary">Get Started</a>


### PR DESCRIPTION
Drop the 'Every service is an MCP tool; every agent speaks A2A' sentence.