### PR TITLE
website: deduplicate header/footer via Jekyll includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ examples/mcp/hello/hello
 /plan-delegate
 /agent-plan-delegate
 /micro-mcp-gateway
+
+# Local Jekyll / Bundler artifacts
+internal/website/.bundle/
+internal/website/_site/
+internal/website/.jekyll-cache/

--- a/internal/website/_includes/footer-links.html
+++ b/internal/website/_includes/footer-links.html
@@ -1,0 +1,4 @@
+<a href="/docs/">Docs</a> &middot;
+<a href="/blog/">Blog</a> &middot;
+<a href="https://github.com/micro/go-micro">GitHub</a> &middot;
+<a href="/support">Support</a>

--- a/internal/website/_includes/marketing-footer.html
+++ b/internal/website/_includes/marketing-footer.html
@@ -1,0 +1,6 @@
+<footer class="footer">
+  <div>&copy; {{ site.time | date: '%Y' }} Go Micro. Apache 2.0 Licensed.</div>
+  <div>
+    {% include footer-links.html %}
+  </div>
+</footer>

--- a/internal/website/_includes/marketing-nav.html
+++ b/internal/website/_includes/marketing-nav.html
@@ -1,0 +1,9 @@
+<nav class="nav">
+  <a class="nav-brand" href="/">
+    <img src="https://raw.githubusercontent.com/micro/go-micro/master/logo.png" alt="Go Micro" style="border-radius: 8px;" />
+    Go Micro
+  </a>
+  <div class="nav-links">
+    {% include nav-links.html %}
+  </div>
+</nav>

--- a/internal/website/_includes/nav-links.html
+++ b/internal/website/_includes/nav-links.html
@@ -1,0 +1,4 @@
+<a href="/docs/">Docs</a>
+<a href="/blog/">Blog</a>
+<a href="/support"{% if page.nav_active == 'support' %} class="active"{% endif %}>Support</a>
+<a href="https://github.com/micro/go-micro">GitHub</a>

--- a/internal/website/_layouts/blog.html
+++ b/internal/website/_layouts/blog.html
@@ -74,9 +74,7 @@
       Go Micro
     </a>
     <div class="nav-links">
-      <a href="/docs/">Docs</a>
-      <a href="/blog/">Blog</a>
-      <a href="https://github.com/micro/go-micro">GitHub</a>
+      {% include nav-links.html %}
     </div>
   </nav>
   <div class="container">
@@ -85,10 +83,7 @@
   <footer class="site-footer">
     <div>&copy; {{ site.time | date: '%Y' }} Go Micro. Apache 2.0 Licensed.</div>
     <div>
-      <a href="/docs/">Docs</a> &middot;
-      <a href="/blog/">Blog</a> &middot;
-      <a href="https://github.com/micro/go-micro">GitHub</a> &middot;
-      <a href="https://github.com/micro/go-micro/issues/new?labels=question&template=question.md">Support</a>
+      {% include footer-links.html %}
     </div>
   </footer>
 </body>

--- a/internal/website/_layouts/default.html
+++ b/internal/website/_layouts/default.html
@@ -104,10 +104,7 @@
     </a>
     <button class="menu-toggle" id="menuToggle">Menu</button>
     <div class="nav-links">
-      <a href="/docs/">Docs</a>
-      <a href="/blog/">Blog</a>
-      <a href="/support">Support</a>
-      <a href="https://github.com/micro/go-micro">GitHub</a>
+      {% include nav-links.html %}
     </div>
   </nav>
   <div class="sidebar-overlay" id="sidebarOverlay"></div>
@@ -171,10 +168,7 @@
   <footer class="site-footer">
     <div>&copy; {{ site.time | date: '%Y' }} Go Micro. Apache 2.0 Licensed.</div>
     <div>
-      <a href="/docs/">Docs</a> &middot;
-      <a href="/blog/">Blog</a> &middot;
-      <a href="https://github.com/micro/go-micro">GitHub</a> &middot;
-      <a href="/support">Support</a>
+      {% include footer-links.html %}
     </div>
   </footer>
   <script>

--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -161,18 +163,7 @@
   </head>
   <body>
 
-    <nav class="nav">
-      <a class="nav-brand" href="/">
-        <img src="https://raw.githubusercontent.com/micro/go-micro/master/logo.png" alt="Go Micro" style="border-radius: 8px;" />
-        Go Micro
-      </a>
-      <div class="nav-links">
-        <a href="/docs/">Docs</a>
-        <a href="/blog/">Blog</a>
-        <a href="/support">Support</a>
-        <a href="https://github.com/micro/go-micro">GitHub</a>
-      </div>
-    </nav>
+    {% include marketing-nav.html %}
 
     <section class="hero">
       <div class="hero-inner">
@@ -294,15 +285,7 @@
       </div>
     </section>
 
-    <footer class="footer">
-      <div>&copy; 2026 Go Micro. Apache 2.0 Licensed.</div>
-      <div>
-        <a href="/docs/">Docs</a> &middot;
-        <a href="/blog/">Blog</a> &middot;
-        <a href="https://github.com/micro/go-micro">GitHub</a> &middot;
-        <a href="/support">Support</a>
-      </div>
-    </footer>
+    {% include marketing-footer.html %}
 
   </body>
 </html>

--- a/internal/website/support.html
+++ b/internal/website/support.html
@@ -1,5 +1,6 @@
 ---
 permalink: /support
+nav_active: support
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -85,18 +86,7 @@ permalink: /support
   </head>
   <body>
 
-    <nav class="nav">
-      <a class="nav-brand" href="/">
-        <img src="https://raw.githubusercontent.com/micro/go-micro/master/logo.png" alt="Go Micro" style="border-radius: 8px;" />
-        Go Micro
-      </a>
-      <div class="nav-links">
-        <a href="/docs/">Docs</a>
-        <a href="/blog/">Blog</a>
-        <a href="/support" class="active">Support</a>
-        <a href="https://github.com/micro/go-micro">GitHub</a>
-      </div>
-    </nav>
+    {% include marketing-nav.html %}
 
     <section class="hero">
       <div class="hero-inner">
@@ -186,15 +176,7 @@ permalink: /support
       </div>
     </section>
 
-    <footer class="footer">
-      <div>&copy; 2026 Go Micro. Apache 2.0 Licensed.</div>
-      <div>
-        <a href="/docs/">Docs</a> &middot;
-        <a href="/blog/">Blog</a> &middot;
-        <a href="https://github.com/micro/go-micro">GitHub</a> &middot;
-        <a href="/support">Support</a>
-      </div>
-    </footer>
+    {% include marketing-footer.html %}
 
   </body>
 </html>


### PR DESCRIPTION
## What

The site had the nav and footer copied across four files — `index.html`, `support.html`, `_layouts/default.html`, and `_layouts/blog.html` — so every nav/footer change had to be made in several places (and drifted: the blog nav was missing **Support**, and its footer still pointed at the question-issue template).

This extracts the shared bits into Jekyll includes:

- `_includes/nav-links.html` — the nav link list (Docs / Blog / Support / GitHub)
- `_includes/footer-links.html` — the footer link list
- `_includes/marketing-nav.html` / `_includes/marketing-footer.html` — the full marketing nav/footer (brand + links)

Then:

- **`index.html`** and **`support.html`** pull their nav/footer from the marketing includes (and gain Liquid front matter so includes resolve). A nav/footer link now lives in exactly one place.
- **`_layouts/default.html`** (docs) and **`_layouts/blog.html`** pull the same link lists, keeping their own wrappers/styles. This **adds the missing Support link to the blog nav** and **fixes the blog footer Support link**.
- Active nav state is driven by a per-page `nav_active` flag (set on the support page).
- `.gitignore`: ignore local Jekyll/Bundler artifacts (`.bundle/`, `_site/`, `.jekyll-cache/`).

## Verification

Built locally with Jekyll and confirmed the landing, support, docs, and blog pages all render the shared nav/footer correctly — including that the landing page's `go-source` meta survives Liquid processing and the support page keeps its active-link state.

Note: this is header/footer (markup) reuse. The marketing CSS is still duplicated between `index.html` and `support.html`; consolidating that behind a shared layout is a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_