### PR TITLE
sponsors: add OpenAI (Codex for Open Source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Build an agent and it gets a model, memory, and tools, manages your services, an
 
 <a href="https://go-micro.dev/blog/3"><img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Anthropic_logo.svg" height="26" /></a>
 &nbsp;&nbsp;
+<a href="https://openai.com"><img src="https://upload.wikimedia.org/wikipedia/commons/4/4d/OpenAI_Logo.svg" height="26" /></a>
+&nbsp;&nbsp;
 <a href="https://go-micro.dev/blog/8"><img src="https://www.atlascloud.ai/logo.svg" height="26" /></a>
 
 **Want to support Go Micro and see your logo here?** [Become a sponsor](https://discord.gg/WeMU5AGxD) — reach out on Discord.

--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -262,6 +262,9 @@
         <a href="/blog/3" style="text-decoration: none;">
           <img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Anthropic_logo.svg" alt="Anthropic" style="height: 28px; opacity: 0.7; transition: opacity 0.2s; box-shadow: none;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'" />
         </a>
+        <a href="https://openai.com" style="text-decoration: none;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/4/4d/OpenAI_Logo.svg" alt="OpenAI" style="height: 28px; opacity: 0.7; transition: opacity 0.2s; box-shadow: none;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'" />
+        </a>
         <a href="/blog/8" style="text-decoration: none;">
           <img src="https://www.atlascloud.ai/logo.svg" alt="Atlas Cloud" style="height: 28px; opacity: 0.7; transition: opacity 0.2s; box-shadow: none;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'" />
         </a>


### PR DESCRIPTION
Go Micro received an **OpenAI Codex for Open Source** grant. This adds the OpenAI logo to the sponsors/supporters in both places it's shown:

- **README** `## Sponsors` — between Anthropic and Atlas Cloud
- **Landing page** (`index.html`) sponsors strip — same styling (28px, hover opacity)

Logo: `OpenAI_Logo.svg` from Wikimedia (verified it resolves, `image/svg+xml`). Linked to `https://openai.com`.

Note: the existing sponsor logos link to go-micro blog posts explaining the relationship (`/blog/3` Anthropic, `/blog/8` Atlas Cloud). OpenAI links straight to `openai.com` for now — happy to write a short blog post to match the pattern if you'd like, and repoint it.

Verified with a local Jekyll build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_