### PR TITLE
blog: announce OpenAI Codex for Open Source grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build an agent and it gets a model, memory, and tools, manages your services, an
 
 <a href="https://go-micro.dev/blog/3"><img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Anthropic_logo.svg" height="26" /></a>
 &nbsp;&nbsp;
-<a href="https://openai.com"><img src="https://upload.wikimedia.org/wikipedia/commons/4/4d/OpenAI_Logo.svg" height="26" /></a>
+<a href="https://go-micro.dev/blog/29"><img src="https://upload.wikimedia.org/wikipedia/commons/4/4d/OpenAI_Logo.svg" height="26" /></a>
 &nbsp;&nbsp;
 <a href="https://go-micro.dev/blog/8"><img src="https://www.atlascloud.ai/logo.svg" height="26" /></a>
 

--- a/internal/website/blog/29.md
+++ b/internal/website/blog/29.md
@@ -1,0 +1,39 @@
+---
+layout: blog
+title: "Go Micro Joins OpenAI's Codex for Open Source"
+permalink: /blog/29
+description: "OpenAI is backing Go Micro through Codex for Open Source. What the grant is, and what it means for a framework built around agentic development."
+---
+
+# Go Micro Joins OpenAI's Codex for Open Source
+
+*June 23, 2026 • By the Go Micro Team*
+
+Go Micro has been accepted into **OpenAI's Codex for Open Source** program. OpenAI is covering six months of ChatGPT Pro — and with it, access to Codex — to support the day-to-day work of maintaining the project.
+
+## What the grant is
+
+Codex for Open Source backs maintainers directly: the constant, unglamorous work of reviewing changes, cutting releases, triaging issues, and keeping quality high. That's most of what maintaining a framework actually is, and it's the part that rarely gets funded. OpenAI putting Codex against it is a real, practical help.
+
+## Why it fits Go Micro
+
+There's a neat symmetry here. Go Micro is a framework for **agentic development** — agents that use tools, services that are automatically AI-callable, workflows that [loop until the job is done](/docs/guides/agent-loops.html). Building and maintaining it with an agentic coding tool is that same idea pointed back at itself: tools calling tools.
+
+It also lines up with what's already in the box. `openai` has been a first-class model provider in Go Micro since the AI-native rewrite — one of [several](/docs/guides/ai-provider-guide.html) behind the same `ai.Model` interface. So you can build *on* OpenAI models with Go Micro, and now we build Go Micro itself with OpenAI's tooling.
+
+## What we'll use it for
+
+Honestly: throughput. More reviewed PRs, faster releases, quicker issue triage, more examples and docs. The recent run of work — [agent loops](/docs/guides/agent-loops.html), [A2A](/blog/26), durable flows, a blocking lint gate in CI — is the pace we want to keep, and maintainer tooling is what sustains it.
+
+## Thanks
+
+Thanks to OpenAI for backing open source maintainers, and for supporting Go Micro specifically. It joins [Anthropic](/blog/3) and [Atlas Cloud](/blog/8) — the companies helping keep this project moving.
+
+---
+
+*Go Micro is an open source framework for building agents, services, and workflows in Go. [Star us on GitHub](https://github.com/micro/go-micro).*
+
+<div class="post-nav">
+  <div><a href="/blog/28">&larr; Building a Support Agent in Go</a></div>
+  <div><a href="/blog/">All Posts</a></div>
+</div>

--- a/internal/website/blog/index.html
+++ b/internal/website/blog/index.html
@@ -12,6 +12,13 @@ permalink: /blog/
 <div class="posts">
 
   <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
+    <h2 style="margin: 0 0 0.5rem;"><a href="/blog/29">Go Micro Joins OpenAI's Codex for Open Source</a></h2>
+    <p class="meta" style="color: #666; font-size: 0.85rem;">June 23, 2026</p>
+    <p>OpenAI is backing Go Micro through Codex for Open Source — six months of ChatGPT Pro to support the work of maintaining the project. A framework built around agentic development, maintained with agentic tooling.</p>
+    <a href="/blog/29">Read more &rarr;</a>
+  </article>
+
+  <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
     <h2 style="margin: 0 0 0.5rem;"><a href="/blog/28">Building a Support Agent in Go</a></h2>
     <p class="meta" style="color: #666; font-size: 0.85rem;">June 19, 2026</p>
     <p>A real thing you can build with Go Micro: a support desk where a customer ticket triggers an agent that looks up the customer, sets priority, and replies — with a human-in-the-loop gate on the one action that touches a customer.</p>

--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -262,7 +262,7 @@
         <a href="/blog/3" style="text-decoration: none;">
           <img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Anthropic_logo.svg" alt="Anthropic" style="height: 28px; opacity: 0.7; transition: opacity 0.2s; box-shadow: none;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'" />
         </a>
-        <a href="https://openai.com" style="text-decoration: none;">
+        <a href="/blog/29" style="text-decoration: none;">
           <img src="https://upload.wikimedia.org/wikipedia/commons/4/4d/OpenAI_Logo.svg" alt="OpenAI" style="height: 28px; opacity: 0.7; transition: opacity 0.2s; box-shadow: none;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'" />
         </a>
         <a href="/blog/8" style="text-decoration: none;">


### PR DESCRIPTION
Follow-up to #3002 (the OpenAI sponsor logo): adds a blog post for the **OpenAI Codex for Open Source** grant and links the logo to it, matching how the other sponsor logos work (Anthropic → `/blog/3`, Atlas Cloud → `/blog/8`).

- **`blog/29.md`** — "Go Micro Joins OpenAI's Codex for Open Source": what the grant is, why it fits a framework built around agentic development, the symmetry with `openai` already being a first-class model provider, and what it'll be used for. Kept honest (no over-claiming features built with it — it's a new grant).
- **Blog index** — listed at the top (June 23, 2026).
- **README + landing** — the OpenAI sponsor logo now links to `/blog/29` instead of `openai.com`.

Verified with a local Jekyll build (post renders, index lists it, logos repointed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_