### PR TITLE
Add provider-conformance harness, contract test, and reframe docs to 'agent harness'

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -1,10 +1,9 @@
-name: Universe (E2E)
+name: Harness (E2E)
 
-# Spins up a mini go-micro world end-to-end — services, a durable flow
-# that crashes and resumes, and an agent — then shuts it down. Everything
-# is real except the LLM, which is mocked, so the default job is
-# deterministic and needs no secrets. A second job runs the same scenario
-# against a live model when an API key secret is configured.
+# Runs the end-to-end harnesses for agents, services, flows, and provider
+# conformance. The default job uses deterministic mock LLMs and needs no
+# secrets. A second job runs the same harnesses against any live providers
+# whose API key secrets are configured.
 
 on:
   push:
@@ -16,8 +15,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  universe:
-    name: Mini universe (mock LLM)
+  harness:
+    name: Harnesses (mock LLM)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,12 +33,12 @@ jobs:
       - name: Plan-delegate harness
         run: go run ./internal/harness/plan-delegate
 
-  universe-live:
-    name: Mini universe (live LLM, if key present)
+  harness-live:
+    name: Provider harnesses (live LLM, if keys present)
     runs-on: ubuntu-latest
     # Only on the daily schedule or a manual run — never automatically on
     # every push/PR, so changes don't quietly burn API credits. Trigger it
-    # by hand (Actions → Universe → Run workflow) when changing the agent,
+    # by hand (Actions → Harness → Run workflow) when changing the agent,
     # flow, or AI internals and you want a real-model check.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:

--- a/.github/workflows/universe.yml
+++ b/.github/workflows/universe.yml
@@ -48,12 +48,13 @@ jobs:
         with:
           go-version: stable
           cache: true
-      - name: Universe against a live model (AtlasCloud)
+      - name: Provider conformance against configured live models
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           ATLASCLOUD_API_KEY: ${{ secrets.ATLASCLOUD_API_KEY }}
-        run: |
-          if [ -z "$ATLASCLOUD_API_KEY" ]; then
-            echo "No ATLASCLOUD_API_KEY secret configured — skipping the live run."
-            exit 0
-          fi
-          go run ./internal/harness/universe -provider atlascloud
+        run: go run ./internal/harness/provider-conformance

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -X $(GIT_IMPORT).BuildDate=$(BUILD_DATE) -X $(GIT_IMPORT).GitCommit=$(
 # GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser-cross:v1.25.7
 GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser:latest
 
-.PHONY: test test-race test-coverage harness lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
+.PHONY: test test-race test-coverage harness provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
 
 # Default target
 help:
@@ -18,6 +18,8 @@ help:
 	@echo "  make test-race     - Run tests with race detector"
 	@echo "  make test-coverage - Run tests with coverage"
 	@echo "  make lint          - Run linter"
+	@echo "  make harness       - Run deterministic end-to-end harnesses"
+	@echo "  make provider-conformance - Run harnesses against configured live providers"
 	@echo "  make fmt           - Format code"
 	@echo "  make install-tools - Install development tools"
 	@echo "  make proto         - Generate protobuf code"
@@ -46,6 +48,11 @@ harness:
 	go run ./internal/harness/universe
 	go run ./internal/harness/agent-flow
 	go run ./internal/harness/plan-delegate
+
+# Run the same harnesses against every configured live provider. Providers
+# without API keys are skipped; configured providers must pass.
+provider-conformance:
+	go run ./internal/harness/provider-conformance
 
 # Run linter
 lint:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Go Micro [![Go.Dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/go-micro.dev/v6?tab=doc) [![Go Report Card](https://goreportcard.com/badge/github.com/go-micro/go-micro)](https://goreportcard.com/report/github.com/go-micro/go-micro)
 
-Go Micro is a framework for building agents and services in Go.
+Go Micro is an **agent harness** and service framework for Go.
 
-Build an agent and it gets a model, memory, and tools, manages your services, and is reachable over [MCP](https://modelcontextprotocol.io/) and [A2A](https://a2a-protocol.org). Write services and they register, discover each other, and every endpoint is automatically an AI-callable tool. Orchestrate the deterministic parts with flows. Agents, services, and flows are all Go code — the same primitives, the same deployment — because an agent is a distributed system, and building one is building a service.
+A harness is the runtime around an agent: the tools it can call, the memory it keeps, the guardrails that bound it, the workflows that trigger it, the services it depends on, and the protocols other agents use to reach it. Go Micro gives you that harness as Go code. Build an agent and it gets a model, memory, tools, planning, delegation, guardrails, and service discovery; it is reachable over [MCP](https://modelcontextprotocol.io/) and [A2A](https://a2a-protocol.org). Write services and every endpoint becomes an AI-callable tool. Orchestrate the deterministic parts with durable flows. Agents, services, and flows share one runtime because an agent is a distributed system, and building one is building a service.
 
 ## Sponsors
 
@@ -21,6 +21,7 @@ Running Go Micro in production, or building on it and want help? Paid **support,
 ## Contents
 
 - [Quick Start](#quick-start)
+- [Why an Agent Harness](#why-an-agent-harness)
 - [Writing Services](#writing-services)
 - [Building Agents](#building-agents) — [Plan & Delegate](#plan--delegate), [Pluggable](#batteries-included-pluggable), [Paid tools (x402)](#paid-tools-x402), [A2A](#reachable-by-other-agents-a2a)
 - [Features](#features)
@@ -116,6 +117,20 @@ When you need a capability that doesn't exist, the agent generates a new service
 
 Edit the generated code by hand at any time — re-running preserves your changes. [Read more](https://go-micro.dev/blog/13).
 
+## Why an Agent Harness
+
+The first wave of agent frameworks helped developers put a model in a loop. The next problem is operating that loop: connecting it to real tools, scoping what it can touch, preserving state, routing work to specialists, recovering from failures, observing what happened, and letting other agents call it. That is harness work.
+
+Go Micro's answer is to make the harness the same thing you already deploy:
+
+- **Tools are services** — endpoint metadata becomes tool schema; RPC executes the call.
+- **Agents are services** — they register, discover, load-balance, and expose `Agent.Chat`.
+- **Workflows are durable code paths** — use flows when the path is known; dispatch to agents when it is not.
+- **Safety lives at execution** — `MaxSteps`, `LoopLimit`, `ApproveTool`, and tool wrappers run where actions happen.
+- **Interop is built in** — MCP for tools, A2A for agents, x402 for paid tools.
+
+Use Go Micro when the agent has to operate a system, not just answer a prompt.
+
 ## Writing Services
 
 Under the hood, a service is a struct with methods. Doc comments and `@example` tags become tool descriptions for AI agents automatically.
@@ -200,7 +215,7 @@ micro call task-mgr Agent.Chat '{"message": "What tasks are overdue?"}'
 
 ### Plan & Delegate
 
-Every agent gets two built-in capabilities, exposed as tools — no extra setup, no harness:
+Every agent gets two built-in harness capabilities, exposed as tools — no extra setup or separate graph runtime:
 
 - **`plan`** — for multi-step work, the agent records an ordered plan in its store-backed memory and stays oriented across turns.
 - **`delegate`** — the agent hands a self-contained subtask to another agent. If a registered agent already owns the relevant services, the hand-off goes over RPC to that agent; otherwise a focused, short-lived sub-agent is created for the subtask with its own isolated context.

--- a/cmd/micro/cli/new/contract_test.go
+++ b/cmd/micro/cli/new/contract_test.go
@@ -1,0 +1,68 @@
+package new
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+// TestZeroToOneContract locks the documented getting-started path:
+// `micro new helloworld` must produce an ordinary Go service that can be
+// tested by the Go toolchain. The generated module is pointed back at this
+// checkout so the contract stays local and deterministic in CI.
+func TestZeroToOneContract(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmp := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldwd)
+
+	set := flag.NewFlagSet("micro-new", flag.ContinueOnError)
+	if err := set.Parse([]string{"helloworld"}); err != nil {
+		t.Fatal(err)
+	}
+	ctx := cli.NewContext(cli.NewApp(), set, nil)
+
+	if err := Run(ctx); err != nil {
+		t.Fatalf("micro new helloworld: %v", err)
+	}
+
+	serviceDir := filepath.Join(tmp, "helloworld")
+	for _, rel := range []string{"go.mod", "main.go", "handler/helloworld.go", "README.md", "Makefile"} {
+		if _, err := os.Stat(filepath.Join(serviceDir, rel)); err != nil {
+			t.Fatalf("generated file %s: %v", rel, err)
+		}
+	}
+
+	modPath := filepath.Join(serviceDir, "go.mod")
+	mod, err := os.ReadFile(modPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modText := strings.Replace(string(mod), "go-micro.dev/v6 latest", "go-micro.dev/v6 v6.0.0", 1)
+	modText += "\nreplace go-micro.dev/v6 => " + filepath.ToSlash(repoRoot) + "\n"
+	if err := os.WriteFile(modPath, []byte(modText), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("go", "test", "./...")
+	cmd.Dir = serviceDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated service go test ./... failed: %v\n%s", err, out)
+	}
+}

--- a/internal/docs/DEVELOPMENT_STRATEGY_ASSESSMENT.md
+++ b/internal/docs/DEVELOPMENT_STRATEGY_ASSESSMENT.md
@@ -1,0 +1,194 @@
+# Development Strategy Assessment
+
+**Date:** 2026-06-24  
+**Scope:** README, roadmap, website docs, internal design notes, examples, harnesses, and blog narrative around agents, services, and workflows.
+
+## Executive summary
+
+Go Micro has a coherent v6 thesis: **agents are distributed systems**, so the framework should make agents, services, and workflows one set of Go-native primitives rather than a separate orchestration product. The repository already has the right foundation: services are self-describing tools, agents add model + memory + tools with `plan`/`delegate`, flows provide deterministic event-driven execution, and MCP/A2A/x402 make the system interoperable with external agents and paid tools.
+
+The next phase should not be another broad feature push. The best strategic move is to make the current promise consistently true under real usage:
+
+1. **Harden the core agent loop across providers and failures.**
+2. **Make the getting-started contract impossible to break.**
+3. **Close the loop on durable, observable, streaming agent runs.**
+4. **Turn one maintained real-world build into the canonical 0→hero path.**
+5. **Keep the product shape narrow: framework + CLI + docs, not a hosted platform.**
+
+## What the project is now
+
+### Positioning
+
+The public README positions Go Micro as “a framework for building agents and services in Go.” The important distinction is that an agent is not treated as an external chatbot wrapper; it is a service with an LLM, memory, discovered tools, registry presence, and RPC reachability. That makes the messaging clear and differentiated from graph-first agent frameworks.
+
+### Core primitives
+
+- **Services** are the durable base abstraction: ordinary Go handlers register, discover each other, and become AI-callable tools through their endpoint metadata and comments.
+- **Agents** are services with a model, memory, and tools. They expose `Agent.Chat`, can be called over RPC, can be reached from `micro chat`, and get built-in `plan` and `delegate` tools.
+- **Flows** cover the deterministic side: predefined event or step paths that checkpoint and resume. This complements agents rather than competing with them.
+- **Gateways** make the primitives externally useful: MCP exposes services as tools, A2A exposes agents as agents, HTTP/gRPC gateways preserve conventional service access, and x402 opens the path to paid tools.
+
+### Narrative and adoption surface
+
+The blog has progressed from “microservices become AI tools” through first-class agents, planning/delegation, workflows, guardrails, durability, A2A, and sponsorship. That narrative is strong because it tells a product story: Go Micro did not bolt agents onto a framework; it reframed microservices as the runtime substrate for agentic systems.
+
+## Strengths to preserve
+
+1. **One abstraction stack.** Services, agents, and flows all use registry, client, broker, store, and gateway primitives. This lowers conceptual load and reinforces the “distributed systems for agents” thesis.
+2. **CLI-first developer experience.** The README and roadmap make the CLI the product surface: scaffold, run, chat, inspect, deploy.
+3. **Interop from the registry.** MCP and A2A generated from existing registry metadata avoid hand-maintained tool/agent catalogs.
+4. **Pluggable but opinionated.** Model, store, registry, broker, transport, memory, and tool middleware are swappable, but defaults exist.
+5. **Good taxonomy.** The docs cleanly map augmented LLMs, workflows, and agents to Go Micro primitives without introducing a graph DSL.
+
+## Key risks
+
+### 1. Breadth outruns reliability
+
+The project already spans services, agents, flows, MCP, A2A, x402, multiple model providers, code generation, CLI, dashboard, examples, and deployment. The roadmap correctly identifies hardening as the current priority. More surface area before conformance and resilience would increase support burden and weaken trust.
+
+### 2. Provider behavior can fragment the experience
+
+The AI package presents one model interface, but each provider has different tool-call semantics, streaming APIs, errors, rate limits, and refusal behavior. If `micro chat`, `NewAgent`, and flows behave differently by provider, users will perceive the framework as unreliable even when the service layer is solid.
+
+### 3. Agent promises require production semantics
+
+Agents that plan, delegate, pay, or run unattended need deadlines, cancellation, retries, resumability, tracing, audit history, and human-intervention states. Without these, agent features remain demos rather than production workflows.
+
+### 4. Docs can become aspirational
+
+Some internal design/status documents are intentionally obsolete or historical. The public roadmap and changelog are now the canonical sources. Future docs should make current/shipped/proposed status explicit to avoid confusion.
+
+### 5. The example portfolio is broad but not yet a single proof
+
+There are many targeted examples, but the strategy needs one polished real-world build that exercises services, agents, flows, guardrails, history/runs, MCP/A2A, and deployment as a continuous path.
+
+## Recommended next steps
+
+### Phase 1: hardening and contracts
+
+**Goal:** make the existing v6 promise repeatable.
+
+1. **Cross-provider conformance matrix**
+   - Run the same scenario against every supported provider when keys are present.
+   - Cover simple generation, service tool calls, multi-step tool use, `plan`, `delegate`, guardrails, refusal/stop behavior, and structured errors.
+   - Publish the support matrix in docs so users know which capabilities are verified.
+
+2. **Getting-started contract in CI**
+   - Define two golden paths:
+     - **0→1:** `micro new` → `micro run` → HTTP/RPC call succeeds.
+     - **0→hero:** services + agent + flow + plan/delegate + inspection path.
+   - Make the contract a small harness or scripted example that runs on every relevant change.
+
+3. **Failure semantics in the agent loop**
+   - Ensure `context.Context` deadlines propagate through model calls, tool execution, delegation, flows, and gateway calls.
+   - Add consistent timeout, retry/backoff, and rate-limit handling at model-provider boundaries.
+   - Make cancellation visible in run metadata and user-facing CLI output.
+
+4. **Docs status cleanup**
+   - Keep `README.md`, `ROADMAP.md`, and website roadmap aligned.
+   - Add or maintain “current vs proposed” banners on internal docs that remain as design history.
+
+### Phase 2: agentic depth
+
+**Goal:** make long-running agent work production-grade.
+
+1. **Durable agent loop**
+   - Reuse the existing `Checkpoint` model from flows.
+   - Persist model turn, tool call, step count, plan state, delegation context, and terminal status.
+   - Resume without duplicating completed side effects.
+
+2. **Agent observability**
+   - Convert `RunInfo` into OpenTelemetry spans/events.
+   - Include model provider, latency, token usage where available, tool calls, delegate boundaries, refusals, guardrail blocks, and errors.
+   - Expose `micro runs` / `micro history` as first-class inspection commands if not already complete.
+
+3. **Streaming end to end**
+   - Implement `ai.Stream` uniformly where provider support exists.
+   - Carry streaming through `micro chat`, agent `Ask`/`Chat`, A2A `message/stream`, and any UI surface that remains.
+
+4. **Human-in-the-loop state**
+   - Extend beyond binary `ApproveTool` into pause/resume or `input-required` states for long runs.
+   - Make this compatible with durable checkpoints so approval can happen after process restart.
+
+### Phase 3: canonical real-world build
+
+**Goal:** turn the thesis into one maintained proof path.
+
+Build and maintain one example application that demonstrates:
+
+- A few domain services with real state.
+- One conductor agent and at least one specialist agent.
+- A flow triggered by an event that dispatches to an agent.
+- Guardrails on risky tools.
+- Durable run inspection and resume.
+- MCP exposure for external agents.
+- Optional A2A interop.
+- Deployment instructions.
+
+The support-agent example is a strong candidate because it naturally includes service lookups, prioritization, customer communication, human approval, and event-triggered automation.
+
+## Strategic priorities
+
+### Product
+
+- Keep Go Micro as an **open-source framework**, not a hosted platform.
+- Make commercial support, training, and retainers the sustainability path.
+- Treat CLI quality as the primary adoption lever.
+
+### Developer experience
+
+- Optimize the loop: `new` → `run` → `chat` → `inspect` → `deploy`.
+- Prefer fewer, excellent commands over a broad command surface.
+- Ensure generated code is ordinary Go that users can edit and keep.
+
+### Technical architecture
+
+- Use registry metadata as the source of truth for tools and agents.
+- Keep workflows deterministic and agents dynamic; do not introduce a graph DSL unless the current primitives cannot express a real user need.
+- Make all autonomous behavior bounded, observable, cancellable, and resumable.
+
+### Documentation
+
+- Lead with runnable paths and production caveats.
+- Keep the taxonomy page because it explains when to use augmented LLMs, flows, and agents.
+- Promote one real-world example over many disconnected mini examples.
+
+## Agent harness positioning
+
+The language should move from “framework for services” to “agent harness on top of services.” A service framework helps teams build callable capabilities. An agent harness is the runtime that makes a model safe and useful around those capabilities: discovery, tool schema, execution, state, guardrails, workflows, delegation, observability, and interop.
+
+Recommended public language:
+
+- **Primary line:** “Go Micro is an agent harness and service framework for Go.”
+- **Short explanation:** “The harness is the runtime around an agent: tools, memory, guardrails, workflows, state, discovery, and protocols.”
+- **Positioning contrast:** “Agent frameworks put a model in a loop; Go Micro operates that loop against real services.”
+- **Developer promise:** “If your agent has to operate a system, not just answer a prompt, use Go Micro.”
+
+This keeps the original microservices heritage but reframes it for the agent market. The service layer is not old positioning; it is the reason the harness is credible. Agents need real capabilities, and Go Micro services are typed, discoverable, callable capabilities.
+
+## Relevance in the agent-harness world
+
+To be relevant as agent infrastructure, Go Micro should make the following product bets visible and real:
+
+1. **Harness, not chatbot.** Lead with execution: tools, memory, guardrails, workflows, and interop. Avoid copy that sounds like “another agent framework.”
+2. **Services as tools.** Make existing Go services immediately useful to agents through MCP, A2A, and generated tool descriptions.
+3. **Runtime safety.** Prioritize MaxSteps, loop detection, approval gates, scoped state, timeouts, cancellation, audit trails, and policy hooks.
+4. **Durability and observability.** Agents doing real work need resumable runs, traces, run history, tool-call timelines, and explainable failures.
+5. **Interop-first.** Be the Go runtime that any MCP or A2A agent can plug into, rather than a closed agent ecosystem.
+6. **Evaluation and conformance.** Harnesses are trusted by tests. Cross-provider conformance, scenario harnesses, and eventually first-class evaluation should become a visible part of the project.
+7. **Canonical proof.** Maintain one real-world example that demonstrates services, agents, flows, guardrails, durable runs, MCP/A2A, and deployment end to end.
+
+## Suggested immediate backlog
+
+1. Add cross-provider conformance harness and docs matrix.
+2. Script and CI-test the 0→1 and 0→hero getting-started contracts.
+3. Audit agent loop context propagation, timeouts, and cancellation.
+4. Wire `RunInfo` to tracing and CLI inspection.
+5. Implement durable agent checkpoint/resume.
+6. Complete streaming through model providers, chat, agent RPC, and A2A.
+7. Promote support-agent or another scenario into the canonical real-world example.
+8. Normalize docs status banners and remove/redirect stale internal status pages where appropriate.
+
+## Bottom line
+
+Go Micro has a strong, timely strategic position: **the service framework for building agentic systems in Go**. The current opportunity is to make that position trustworthy. Development should bias toward conformance, resilience, durable execution, observability, and a polished end-to-end developer path before expanding the feature surface.

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -1,0 +1,120 @@
+// Provider conformance runs the same end-to-end harnesses across model
+// providers whose API keys are configured. Missing keys are skipped so the
+// command is safe in local development and scheduled CI; a configured provider
+// that fails any harness makes the command fail.
+//
+// Run all live providers with configured keys:
+//
+//	go run ./internal/harness/provider-conformance
+//
+// Run the deterministic mock path only:
+//
+//	go run ./internal/harness/provider-conformance -providers mock
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var providerEnv = map[string]string{
+	"anthropic":  "ANTHROPIC_API_KEY",
+	"openai":     "OPENAI_API_KEY",
+	"gemini":     "GEMINI_API_KEY",
+	"groq":       "GROQ_API_KEY",
+	"mistral":    "MISTRAL_API_KEY",
+	"together":   "TOGETHER_API_KEY",
+	"atlascloud": "ATLASCLOUD_API_KEY",
+}
+
+func main() {
+	providersFlag := flag.String("providers", "anthropic,openai,gemini,groq,mistral,together,atlascloud", "comma-separated providers to check; use mock for deterministic local checks")
+	harnessesFlag := flag.String("harnesses", "universe,agent-flow,plan-delegate", "comma-separated harness names under internal/harness")
+	timeoutFlag := flag.Duration("timeout", 10*time.Minute, "timeout per provider/harness run")
+	flag.Parse()
+
+	providers := splitCSV(*providersFlag)
+	harnesses := splitCSV(*harnessesFlag)
+
+	var ran, skipped, failed int
+	for _, provider := range providers {
+		if provider != "mock" && providerKey(provider) == "" {
+			fmt.Printf("- %s: skipped (set MICRO_AI_API_KEY or %s)\n", provider, providerEnv[provider])
+			skipped++
+			continue
+		}
+
+		for _, harness := range harnesses {
+			fmt.Printf("\n==> %s / %s\n", provider, harness)
+			if err := runHarness(provider, harness, *timeoutFlag); err != nil {
+				fmt.Printf("FAIL %s / %s: %v\n", provider, harness, err)
+				failed++
+				continue
+			}
+			ran++
+		}
+	}
+
+	fmt.Printf("\nprovider conformance: %d passed, %d skipped providers, %d failed\n", ran, skipped, failed)
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func providerKey(provider string) string {
+	if v := os.Getenv("MICRO_AI_API_KEY"); v != "" {
+		return v
+	}
+	return os.Getenv(providerEnv[provider])
+}
+
+func localRPCEnv(env []string) []string {
+	filtered := env[:0]
+	for _, kv := range env {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			filtered = append(filtered, kv)
+			continue
+		}
+		switch strings.ToUpper(key) {
+		case "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY":
+			continue
+		default:
+			filtered = append(filtered, kv)
+		}
+	}
+	return append(filtered, "HTTP_PROXY=", "HTTPS_PROXY=", "NO_PROXY=*")
+}
+
+func runHarness(provider, harness string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "run", "./internal/harness/"+harness, "-provider", provider)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = localRPCEnv(os.Environ())
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("timed out after %s", timeout)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/website/docs/guides/agent-patterns.md
+++ b/internal/website/docs/guides/agent-patterns.md
@@ -396,7 +396,7 @@ docker run -p 3000:3000 ghcr.io/micro/micro-mcp-gateway \
 
 ## Pattern 9: Planning and Delegation
 
-Built into the `Agent` abstraction. Every agent gets two tools — `plan` and `delegate` — with no extra setup. They are plain tools, not a separate harness or graph.
+Built into the `Agent` abstraction. Every agent gets two harness tools — `plan` and `delegate` — with no extra setup. They are plain tools, not a separate graph runtime.
 
 ```
 Conductor ──plan──→ (records ordered steps in memory)
@@ -467,7 +467,7 @@ If agents don't know what errors are possible, they can't handle them gracefully
 
 ### Don't: Build Agent Logic into Services
 
-Keep services as pure business logic. Let the agent (or the agent framework) handle orchestration, retries, and decision-making. Your service should just do one thing well.
+Keep services as pure business logic. Let the agent harness handle orchestration, retries, and decision-making. Your service should just do one thing well.
 
 ## Next Steps
 

--- a/internal/website/docs/guides/agents-and-workflows.md
+++ b/internal/website/docs/guides/agents-and-workflows.md
@@ -9,7 +9,7 @@ Go Micro's AI primitives map directly onto the taxonomy in Anthropic's [Building
 - **Workflows** — "LLMs and tools orchestrated through **predefined code paths**." Deterministic.
 - **Agents** — "LLMs **dynamically direct their own processes** and tool usage." Model-driven.
 
-Go Micro has both, plus the building block they're made of — and expresses them as plain services and tools, with no graph DSL. That's deliberate: the same post advises finding "the simplest solution possible" and being "cautious with frameworks… they obscure the underlying mechanics."
+Go Micro has both, plus the harness they run inside — and expresses them as plain services and tools, with no graph DSL. That's deliberate: the same post advises finding "the simplest solution possible" and being "cautious with frameworks… they obscure the underlying mechanics."
 
 ## The building block: the augmented LLM
 
@@ -132,11 +132,11 @@ micro.NewAgent("conductor",
 )
 ```
 
-These are guardrails, not a framework — a counter and a callback on the path every tool call already takes. For anything that must be predictable, still prefer a **workflow**, and test agents against the [integration harness](https://github.com/micro/go-micro/tree/master/internal/harness/plan-delegate).
+These are harness guardrails, not a separate policy engine — a counter and a callback on the path every tool call already takes. For anything that must be predictable, still prefer a **workflow**, and test agents against the [integration harness](https://github.com/micro/go-micro/tree/master/internal/harness/plan-delegate).
 
 ## Why no graph DSL
 
-Anthropic: "be cautious with frameworks… understand the underlying code." Go Micro's answer is that there is no separate framework to understand — workflows and agents are services, and tool use is RPC. `plan` and `delegate` are tools, not a harness. The patterns above are code you can read, not a DSL you have to learn. That's the [direction we took going all in on AI](/blog/14).
+Anthropic: "be cautious with frameworks… understand the underlying code." Go Micro's answer is that there is no separate framework to understand — the harness is the service runtime. Workflows and agents are services, and tool use is RPC. `plan` and `delegate` are tools, not a graph DSL. The patterns above are code you can read, not a DSL you have to learn. That's the [direction we took going all in on AI](/blog/14).
 
 ## See also
 

--- a/internal/website/docs/guides/comparison.md
+++ b/internal/website/docs/guides/comparison.md
@@ -184,8 +184,9 @@ and supports multi-agent systems, evaluation, and deployment to Cloud Run / GKE.
 
 They overlap on agents but solve different problems. ADK is a library for building
 an agent process — you define an agent, its tools, and a model, then run and deploy
-it. It does not provide service discovery, inter-service RPC, or pub/sub; that's out
-of scope, and you bring your own.
+it. Go Micro is the harness around agents once they operate real systems: service
+discovery, inter-service RPC, pub/sub, durable flows, tool execution, and deployment.
+Those pieces are out of scope for ADK, and you bring your own.
 
 In Go Micro an agent is built as an ordinary service: it registers in the registry,
 is callable by RPC (`Agent.Chat`) and over A2A, and other services and agents
@@ -195,14 +196,14 @@ also gives you the discovery, RPC, pub/sub, config, and deployment around them.
 
 | | Go Micro | Google ADK |
 |---|----------|------------|
-| **Primary unit** | A service (an agent is a service with an LLM inside) | An agent |
+| **Primary unit** | A harnessed service (an agent is a service with an LLM inside) | An agent |
 | **Service discovery / registry** | Built-in (mDNS, Consul, etcd) | Not in scope |
 | **Inter-service RPC, load balancing, pub/sub** | Built-in | Not in scope |
 | **MCP** | Every service endpoint is automatically an MCP tool (no extra code) | MCP tools, wired explicitly |
 | **A2A** | Agents are A2A-reachable services | Supported |
 | **Deterministic orchestration** | Flows | Graph workflows |
 | **Multi-agent** | Agents discover & call each other via the registry; `plan`/`delegate` built in | Composition, routing, workflow patterns |
-| **Evaluation suite** | Not built in | Yes (criteria, user/env simulation, metrics) |
+| **Evaluation suite** | Harnesses/conformance today; first-class evaluation is a gap | Yes (criteria, user/env simulation, metrics) |
 | **Context engineering** | Store-backed memory | "Context as source code" (auto filter/summarize/token tracking) |
 | **Languages** | Go | Python, TypeScript, Go, Java, Kotlin |
 | **Backing** | Community | Google |
@@ -213,8 +214,8 @@ also gives you the discovery, RPC, pub/sub, config, and deployment around them.
 - You want a cross-language A2A ecosystem with Google's backing
 
 ### When to choose Go Micro
-- Your agents and services should be **the same thing** — registered, discoverable,
-  load-balanced, and deployed the same way
+- You want an **agent harness** where agents and services are the same thing —
+  registered, discoverable, load-balanced, and deployed the same way
 - You want your existing services to become agent tools with **zero extra code**
   (every endpoint is an MCP tool automatically)
 - You're building in Go and want one set of primitives for services, agents, and flows

--- a/internal/website/docs/guides/plan-delegate.md
+++ b/internal/website/docs/guides/plan-delegate.md
@@ -9,7 +9,7 @@ Every Go Micro agent has two built-in capabilities, on top of the service tools 
 - **`plan`** — record an ordered plan in memory before doing multi-step work.
 - **`delegate`** — hand a self-contained subtask to another agent.
 
-They are exposed to the model as ordinary tools. There is no harness, graph, or workflow engine to configure — the agent calls them the same way it calls a service endpoint. They are added automatically to every agent, so you don't wire anything up. `micro chat` exposes them too, so you get planning and delegation even when talking to your services directly.
+They are exposed to the model as ordinary tools. There is no separate graph runtime to configure — these harness capabilities are tools, and the agent calls them the same way it calls a service endpoint. They are added automatically to every agent, so you don't wire anything up. `micro chat` exposes them too, so you get planning and delegation even when talking to your services directly.
 
 ## Prerequisites
 

--- a/internal/website/docs/index.md
+++ b/internal/website/docs/index.md
@@ -4,13 +4,13 @@ layout: default
 
 # Docs
 
-Documentation for the Go Micro framework.
+Documentation for the Go Micro agent harness and service framework.
 
 ## Overview
 
 <img src="/images/generated/architecture.jpg" alt="Go Micro architecture" style="width: 100%; border-radius: 8px; margin-bottom: 1.5rem;" />
 
-Go Micro is a framework for building agents and services in Go. Build an agent and it gets a model, memory, and tools, manages your services, and is reachable over [MCP](https://modelcontextprotocol.io/) and [A2A](https://a2a-protocol.org). Write services and they register, discover each other, and every endpoint is automatically an AI-callable tool. Orchestrate the deterministic parts with flows. Agents, services, and flows come from the same primitives — because an agent is a distributed system, and building one is building a service.
+Go Micro is an agent harness and service framework for Go. A harness is the runtime around an agent: tools, memory, guardrails, workflows, state, discovery, and interop. Build an agent and it gets a model, memory, tools, planning, delegation, and service discovery; it is reachable over [MCP](https://modelcontextprotocol.io/) and [A2A](https://a2a-protocol.org). Write services and every endpoint becomes an AI-callable tool. Orchestrate the deterministic parts with durable flows. Agents, services, and flows come from the same primitives because an agent is a distributed system, and building one is building a service.
 
 It's built on a pluggable architecture of Go interfaces: service discovery, client/server RPC, pub/sub, plus auth, caching, and storage. Sane defaults out of the box, everything swappable.
 
@@ -47,7 +47,7 @@ about the framework.
 - [Building AI-Native Services](guides/ai-native-services.html) - End-to-end tutorial for MCP-enabled services
 - [MCP Security Guide](guides/mcp-security.html) - Auth, scopes, rate limiting, and audit logging
 - [Tool Description Best Practices](guides/tool-descriptions.html) - Writing docs that make agents effective
-- [Agent Integration Patterns](guides/agent-patterns.html) - Multi-agent workflows and architectures
+- [Agent Integration Patterns](guides/agent-patterns.html) - Multi-agent harness patterns and architectures
 
 ## Advanced
 

--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -5,11 +5,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Go Micro - An AI-native framework for building agents, services, and flows in Go." />
+    <meta name="description" content="Go Micro - An agent harness and service framework for Go." />
     <meta name="go-import" content="go-micro.dev/v6 git https://github.com/micro/go-micro">
     <meta name="go-import" content="go-micro.dev/v5 git https://github.com/micro/go-micro">
     <meta name="go-source" content="go-micro.dev/v6 https://github.com/micro/go-micro https://github.com/micro/go-micro/tree/master{/dir} https://github.com/micro/go-micro/blob/master{/dir}/{file}#L{line}">
-    <title>Go Micro - Build Agents and Services in Go</title>
+    <title>Go Micro - Agent Harness for Go</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
       html { overflow-x: hidden; }
@@ -167,8 +167,8 @@
 
     <section class="hero">
       <div class="hero-inner">
-        <h1>Build Agents and Services in Go</h1>
-        <p class="tagline">An AI-native framework for agents, services, and workflows.</p>
+        <h1>An Agent Harness for Go</h1>
+        <p class="tagline">Tools, memory, guardrails, workflows, and services — one runtime for agents that do real work.</p>
         <pre>curl -fsSL https://go-micro.dev/install.sh | sh</pre>
         <div class="hero-buttons">
           <a href="/docs/getting-started.html" class="btn btn-primary">Get Started</a>
@@ -183,20 +183,20 @@
 
     <section class="section-alt">
       <div class="section">
-        <h2>Everything You Need</h2>
-        <p class="subtitle">AI generation and orchestration on top of a production microservices framework.</p>
+        <h2>The Runtime Around the Agent</h2>
+        <p class="subtitle">Go Micro moved from a service framework to an agent harness: the production pieces agents need once they leave the demo.</p>
         <div class="features">
           <div class="feature">
-            <strong>Agents</strong>
-            <p>A model, memory, and tools that manage your services. Plan, delegate, guardrails — built in, no harness.</p>
+            <strong>Agent Harness</strong>
+            <p>A model, memory, tools, plan/delegate, guardrails, and execution middleware around every agent.</p>
           </div>
           <div class="feature">
-            <strong>Services</strong>
-            <p>Build services in Go or generate them from a prompt. They register and discover each other automatically.</p>
+            <strong>Services as Tools</strong>
+            <p>Build services in Go or generate them from a prompt. Their endpoints become typed tools automatically.</p>
           </div>
           <div class="feature">
-            <strong>Flows</strong>
-            <p>Event-driven, durable workflows. Ordered steps that checkpoint and resume after a crash.</p>
+            <strong>Durable Workflows</strong>
+            <p>Use fixed, checkpointed code paths for deterministic work; hand off to agents when the path is dynamic.</p>
           </div>
           <div class="feature">
             <strong>MCP Gateway</strong>
@@ -220,8 +220,8 @@
           <img src="/images/generated/mcp-agent.jpg" alt="AI agent calling microservices via MCP" />
         </div>
         <div class="two-col-text">
-          <h2>Describe, Run, Chat</h2>
-          <p>Tell it what you need. The AI designs services, generates an agent, and drops you into an interactive console. Talk to the agent — it orchestrates across services automatically.</p>
+          <h2>From Prompt Loop to Operating Harness</h2>
+          <p>Tell it what you need. The AI designs services, generates an agent, and drops you into an interactive console. The harness gives that agent tools, memory, guardrails, and workflows so it can operate across services.</p>
           <pre><span class="kw">$</span> <span class="fn">micro run</span> <span class="str">--prompt "task management system"</span>
 <span class="kw">&gt;</span> Create a project called Launch, add tasks, assign to Alice</pre>
           <p><a href="/blog/16" class="btn btn-primary" style="margin-top: 0.75rem; display: inline-block;">Learn About Agents</a></p>
@@ -233,8 +233,8 @@
       <div class="section">
         <div class="two-col">
           <div class="two-col-text">
-            <h2>Pluggable Architecture</h2>
-            <p>Services connect through a registry for discovery and a broker for events. Swap any component without changing your service code — go from mDNS to Consul, or HTTP to gRPC, with a single option.</p>
+            <h2>Distributed Systems for Agents</h2>
+            <p>Agents need the same substrate services do: discovery, RPC, events, state, auth, observability, and deployment. Swap any component without changing your code — go from mDNS to Consul, or HTTP to gRPC, with a single option.</p>
           </div>
           <div>
             <img src="/images/generated/architecture.jpg" alt="Go Micro architecture diagram" />


### PR DESCRIPTION
### Motivation

- Provide a repeatable cross-provider conformance check so the same end-to-end harnesses can be exercised against every configured live model provider without silently burning API credits. 
- Make the documented 0→1 getting-started path impossible to accidentally break by locking the `micro new` output with an automated contract test. 
- Clarify product messaging and internal strategy by repositioning the project as an "agent harness" and capturing the roadmap/assessment in docs.

### Description

- Add a new provider conformance harness at `internal/harness/provider-conformance/main.go` that runs specified harnesses (`universe`, `agent-flow`, `plan-delegate`) across a configurable list of providers and skips providers without API keys. 
- Update CI workflow `.github/workflows/universe.yml` to call `internal/harness/provider-conformance` for scheduled/manual runs and export common provider env vars so configured providers are checked; the previous Atlas-only live check was replaced. 
- Add a `provider-conformance` target to the `Makefile` and document `harness`/`provider-conformance` usage, and wire the deterministic harness targets to `make harness`. 
- Add an automated contract test `cmd/micro/cli/new/contract_test.go` to validate `micro new helloworld` produces a buildable Go service and update many docs/website files and `internal/docs/DEVELOPMENT_STRATEGY_ASSESSMENT.md` to adopt the "agent harness" framing and guidance.

### Testing

- Ran unit tests with `go test ./...`, including the new `TestZeroToOneContract`, and they completed successfully. 
- Executed the deterministic harnesses with `make harness` (which runs `go run ./internal/harness/universe`, `agent-flow`, and `plan-delegate`) and observed they passed locally. 
- Verified the provider conformance command runs deterministically against the `mock` provider via `go run ./internal/harness/provider-conformance -providers mock` and succeeds, while live provider runs are skipped in environments lacking API keys (CI scheduled runs will skip missing keys and fail if a configured provider fails).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b8b661588833088e906687ec394b5)