### PR TITLE
harness/new: honest conformance timeout + cheaper contract test (fixes for #3006)

### DIFF
--- a/cmd/micro/cli/new/contract_test.go
+++ b/cmd/micro/cli/new/contract_test.go
@@ -12,10 +12,17 @@ import (
 )
 
 // TestZeroToOneContract locks the documented getting-started path:
-// `micro new helloworld` must produce an ordinary Go service that can be
-// tested by the Go toolchain. The generated module is pointed back at this
-// checkout so the contract stays local and deterministic in CI.
+// `micro new helloworld` must produce an ordinary Go service that the Go
+// toolchain can build. The generated module is pointed back at this checkout
+// so the contract stays local and deterministic in CI.
+//
+// It shells out to `micro new` (which runs `go mod tidy`) and `go build`, so
+// it needs the Go toolchain and module access; it is skipped under `-short`.
 func TestZeroToOneContract(t *testing.T) {
+	if testing.Short() {
+		t.Skip("contract test shells out to the Go toolchain; skipped with -short")
+	}
+
 	repoRoot, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
 	if err != nil {
 		t.Fatal(err)
@@ -59,10 +66,10 @@ func TestZeroToOneContract(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command("go", "test", "./...")
+	cmd := exec.Command("go", "build", "./...")
 	cmd.Dir = serviceDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("generated service go test ./... failed: %v\n%s", err, out)
+		t.Fatalf("generated service go build ./... failed: %v\n%s", err, out)
 	}
 }

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -106,7 +107,26 @@ func runHarness(provider, harness string, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "go", "run", "./internal/harness/"+harness, "-provider", provider)
+	// Build the harness to a temp binary and run that, rather than `go run`:
+	// `go run` launches the compiled binary as a child it does not kill on
+	// context cancellation, so a harness that starts local services could
+	// outlive the timeout. Running the binary ourselves keeps the timeout
+	// honest — canceling the context kills the process that does the work.
+	binDir, err := os.MkdirTemp("", "harness-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(binDir)
+	binPath := filepath.Join(binDir, harness)
+
+	build := exec.CommandContext(ctx, "go", "build", "-o", binPath, "./internal/harness/"+harness)
+	build.Stdout = os.Stdout
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		return fmt.Errorf("build: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, binPath, "-provider", provider)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = localRPCEnv(os.Environ())


### PR DESCRIPTION
Mechanical hardening on top of #3006 (stacked — base is the #3006 branch so the diff is just these two fixes). Pairs with the review on #3006.

**`internal/harness/provider-conformance`** — build each harness to a temp binary and run that instead of `go run`. `go run` launches the compiled harness as a child it doesn't kill on context cancellation, so a timed-out harness (which starts local services/listeners) could be orphaned and outlive the run. Building + exec'ing the binary makes the per-run timeout actually terminate the work.

**`cmd/micro/cli/new/contract_test.go`** — two changes:
- Skip under `-short`, so the default unit-test suite doesn't shell out to the Go toolchain + network on every run (the contract test runs `go mod tidy` via `Run` and then compiles a generated service).
- Use `go build ./...` instead of `go test ./...` — the contract is that the generated service *builds*, and `go build` is sufficient and lighter.

Verified: `go build ./...`, `golangci-lint run` (0 issues, incl. the now-blocking lint), `go test -short ./cmd/micro/cli/new/` skips fast, and `go run ./internal/harness/provider-conformance -providers mock` still passes.

Merge order: either merge this into the #3006 branch first, or merge #3006 to master and I'll re-target this to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_