### PR TITLE
docs/blog: anchor the agent-harness positioning

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,11 @@
 # Go Micro Roadmap
 
-Go Micro is a framework for building **agents and services** in Go. An agent is a
-distributed system — it discovers services, calls them, holds state, and recovers
-from failure — so building an agent is building a service. The roadmap has two
+Go Micro is an **agent harness** and service framework for Go. A harness is the
+runtime around an agent — the tools, memory, guardrails, workflows, state,
+discovery, and protocols it needs to operate a system rather than just answer a
+prompt. An agent is a distributed system — it discovers services, calls them,
+holds state, and recovers from failure — so the harness is the runtime services
+already have, and building an agent is building a service. The roadmap has two
 jobs: make **agentic development** excellent, and make the **developer experience**
 around it excellent.
 

--- a/internal/website/_data/navigation.yml
+++ b/internal/website/_data/navigation.yml
@@ -32,6 +32,8 @@ examples:
   - title: Real-World Examples
     url: /docs/examples/realworld/
 guides:
+  - title: The Agent Harness
+    url: /docs/guides/agent-harness.html
   - title: Agents and Workflows
     url: /docs/guides/agents-and-workflows.html
   - title: Agent Loops

--- a/internal/website/blog/30.md
+++ b/internal/website/blog/30.md
@@ -1,0 +1,53 @@
+---
+layout: blog
+title: "Go Micro is an Agent Harness"
+permalink: /blog/30
+description: "The first wave of agent frameworks put a model in a loop. The harder problem is operating that loop — and that's what Go Micro is: the harness around the agent."
+---
+
+# Go Micro is an Agent Harness
+
+*June 24, 2026 • By the Go Micro Team*
+
+The first wave of agent frameworks solved one problem: put a model in a loop with some tools. That's the easy part now. The harder problem — the one that decides whether an agent makes it past a demo — is **operating** that loop.
+
+Operating a loop means connecting it to real tools, scoping what it can touch, keeping state when the process restarts, routing work to specialists, recovering from provider failures, seeing what it did, and letting other agents call it. That's harness work, and it's most of the actual job.
+
+## The harness is the stack you already deploy
+
+Go Micro's answer is that the harness isn't a new product to bolt on — it's the distributed-systems runtime services already have. An agent is a service with a model inside. So:
+
+- **Tools are services.** Every endpoint is an AI-callable tool from registry metadata; an RPC runs it. No catalog to hand-maintain.
+- **Agents are services.** They register, discover each other, load-balance, expose `Agent.Chat`, and are reachable over A2A.
+- **Workflows are code paths.** Use a durable flow when the path is known; hand off to an agent when it isn't.
+- **Safety lives at execution** — `MaxSteps`, `LoopLimit`, and `ApproveTool` run on the one path every tool call takes.
+- **Interop is built in** — MCP for tools, A2A for agents, x402 for paid tools.
+
+The service layer isn't old positioning we're walking away from. It's the reason the harness is credible: an agent that does real work needs typed, discoverable, callable capabilities, and that's exactly what a service is.
+
+## What's shipped, and what's next
+
+We'd rather be precise than aspirational. Today the harness gives you tools-from-services, store-backed memory, guardrails, durable flows (including run-until-done loops), built-in plan/delegate, and MCP/A2A/x402 interop.
+
+What we're building now is the part that turns "operates the loop" from a claim into a guarantee:
+
+- **Resilience** — deadlines, timeouts, and retry/backoff propagated through the whole loop.
+- **Durable agent runs** — checkpoint and resume a run after a restart, the way flows already do.
+- **Observability** — every run as OpenTelemetry spans, inspectable from the CLI.
+- **Streaming** — tokens end to end, through chat, the agent RPC, and A2A.
+
+That list is the roadmap's [Now and Next](/docs/roadmap.html), tracked as open issues. The work is happening in public.
+
+## Read more
+
+- [The Agent Harness](/docs/guides/agent-harness.html) — what the harness is, piece by piece, with status
+- [Roadmap](/docs/roadmap.html)
+
+---
+
+*Go Micro is an open source agent harness and service framework for Go. [Star us on GitHub](https://github.com/micro/go-micro).*
+
+<div class="post-nav">
+  <div><a href="/blog/29">&larr; OpenAI Codex for Open Source</a></div>
+  <div><a href="/blog/">All Posts</a></div>
+</div>

--- a/internal/website/blog/index.html
+++ b/internal/website/blog/index.html
@@ -12,6 +12,13 @@ permalink: /blog/
 <div class="posts">
 
   <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
+    <h2 style="margin: 0 0 0.5rem;"><a href="/blog/30">Go Micro is an Agent Harness</a></h2>
+    <p class="meta" style="color: #666; font-size: 0.85rem;">June 24, 2026</p>
+    <p>The first wave of agent frameworks put a model in a loop. The harder problem is operating that loop — tools, state, guardrails, recovery, observability, interop — and that's what Go Micro is: the harness around the agent, built from the stack you already deploy.</p>
+    <a href="/blog/30">Read more &rarr;</a>
+  </article>
+
+  <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
     <h2 style="margin: 0 0 0.5rem;"><a href="/blog/29">Go Micro Joins OpenAI's Codex for Open Source</a></h2>
     <p class="meta" style="color: #666; font-size: 0.85rem;">June 23, 2026</p>
     <p>OpenAI is backing Go Micro through Codex for Open Source — six months of ChatGPT Pro to support the work of maintaining the project. A framework built around agentic development, maintained with agentic tooling.</p>

--- a/internal/website/docs/guides/agent-harness.md
+++ b/internal/website/docs/guides/agent-harness.md
@@ -1,0 +1,74 @@
+---
+layout: default
+---
+
+# The Agent Harness
+
+The first wave of agent frameworks solved one problem: put a model in a loop with
+some tools. The harder problem is **operating** that loop — and that's what a
+harness is.
+
+A harness is the runtime around an agent:
+
+- the **tools** it can call,
+- the **memory** it keeps,
+- the **guardrails** that bound it,
+- the **workflows** that trigger and structure it,
+- the **state** that survives a restart,
+- the **observability** to see what it did,
+- the **services** it depends on,
+- and the **protocols** other agents use to reach it.
+
+Go Micro's bet is that this runtime is the one you already deploy. An agent is a
+service with a model inside; the harness is the distributed-systems machinery
+services already have. So you don't bolt a separate orchestration product onto
+your stack — the harness *is* the stack.
+
+## The pieces, and what they map to
+
+| Harness concern | In Go Micro | Status |
+|---|---|---|
+| Tools | Every service endpoint is an MCP-callable tool from registry metadata — no extra code | Shipped |
+| Memory | Store-backed agent memory (`AgentMemory`), durable across restarts | Shipped |
+| Guardrails | `MaxSteps`, `LoopLimit`, `ApproveTool`, tool wrappers — enforced at the call site | Shipped |
+| Workflows | Durable flows; `flow.Loop` for run-until-done | Shipped |
+| Planning / delegation | Built-in `plan` and `delegate` tools on every agent | Shipped |
+| Discovery & RPC | Registry + client; agents and services find and call each other | Shipped |
+| Interop | MCP (tools), A2A (agents), x402 (paid tools) | Shipped |
+| Resilience | Deadlines, timeouts, retry/backoff across the loop | In progress |
+| Durable runs | Checkpoint and resume an agent run (flows already do) | In progress |
+| Observability | `RunInfo` → OpenTelemetry spans; run history on the CLI | In progress |
+| Streaming | `ai.Stream` through chat, agent, and A2A | In progress |
+
+The "in progress" rows are exactly the roadmap's [Now and Next](/docs/roadmap.html),
+and the work is happening in the open.
+
+## Why services are the right substrate
+
+An agent that does real work needs typed, discoverable, callable capabilities —
+which is what a service is. The harness is credible *because* of the service
+layer, not in spite of it:
+
+- **Tools are services** — endpoint metadata becomes the tool schema; an RPC
+  executes the call.
+- **Agents are services** — they register, load-balance, expose `Agent.Chat`, and
+  are reachable by other agents.
+- **Workflows are code paths** — use a flow when the path is known; hand off to an
+  agent when it isn't.
+- **Safety lives at execution** — guardrails run on the one path every tool call
+  takes.
+
+## When to reach for it
+
+Use Go Micro when the agent has to **operate a system**, not just answer a prompt
+— when it needs real tools, state that survives, limits you can enforce, and a way
+to be seen and called. If you only need a model in a loop, you don't need a
+harness. When that loop has to touch production, you do.
+
+## See also
+
+- [Agents and Workflows](agents-and-workflows.html) — flows vs. agents
+- [Agent Loops](agent-loops.html) — run-until-done, with a ceiling
+- [Plan & Delegate](plan-delegate.html)
+- [Agent Guardrails](agent-guardrails.html)
+- [Roadmap](/docs/roadmap.html)


### PR DESCRIPTION
Completes the **agent-harness** positioning that #3006 started (headline/landing/comparison) by giving the term an anchor and a public articulation.

- **`docs/guides/agent-harness.md`** (new, + nav) — the canonical concept page: what a harness is, each piece mapped to a real Go Micro feature, in a table that's **honest about shipped vs. in-progress** (the in-progress rows are the roadmap's Now/Next). Everything else can now point here instead of re-explaining.
- **`/blog/30` "Go Micro is an Agent Harness"** — the public statement: first wave put a model in a loop; the hard part is *operating* the loop; the harness is the stack you already deploy. Precise about what ships today vs. what's being built, and links the roadmap.
- **ROADMAP.md** opening line aligned to the harness framing.

Plain language throughout — no marketing inflation; the status table and the blog both say outright what isn't done yet.

Verified with a local Jekyll build (guide renders, blog renders, nav updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_