### PR TITLE
Add agent model retry and timeout resilience

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -183,11 +183,15 @@ func (a *agentImpl) Ask(ctx context.Context, message string) (*Response, error) 
 		Agent:    a.opts.Name,
 	})
 
-	resp, err := a.model.Generate(ctx, &ai.Request{
+	resp, err := ai.GenerateWithRetry(ctx, a.model, &ai.Request{
 		Prompt:       message,
 		SystemPrompt: a.buildPrompt(),
 		Tools:        toolList,
 		Messages:     a.mem.Messages(),
+	}, ai.GeneratePolicy{
+		Timeout:     a.opts.ModelTimeout,
+		MaxAttempts: a.opts.ModelMaxAttempts,
+		Backoff:     a.opts.ModelRetryBackoff,
 	})
 	if err != nil {
 		return nil, err

--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -79,7 +79,7 @@ func Builtins(opts ...Option) (tools []ai.Tool, handle func(name string, input m
 			r := a.handlePlan(ai.ToolCall{Name: name, Input: input})
 			return r.Value, r.Content, true
 		case toolDelegate:
-			r := a.handleDelegate(ai.ToolCall{Name: name, Input: input})
+			r := a.handleDelegate(context.Background(), ai.ToolCall{Name: name, Input: input})
 			return r.Value, r.Content, true
 		}
 		return nil, "", false
@@ -129,7 +129,7 @@ func (a *agentImpl) baseHandler() ai.ToolHandler {
 			}
 		}
 		if call.Name == toolDelegate {
-			return a.handleDelegate(call)
+			return a.handleDelegate(ctx, call)
 		}
 		return rpc(ctx, call)
 	}
@@ -213,7 +213,7 @@ func (a *agentImpl) handlePlan(call ai.ToolCall) ai.ToolResult {
 // if 'to' names a registered agent, it is called via RPC. Otherwise an
 // ephemeral sub-agent is created with a fresh, isolated context, asked
 // the subtask, and its reply returned.
-func (a *agentImpl) handleDelegate(call ai.ToolCall) ai.ToolResult {
+func (a *agentImpl) handleDelegate(ctx context.Context, call ai.ToolCall) ai.ToolResult {
 	input := call.Input
 	task, _ := input["task"].(string)
 	if task == "" {
@@ -223,7 +223,7 @@ func (a *agentImpl) handleDelegate(call ai.ToolCall) ai.ToolResult {
 
 	// An external agent on another framework, addressed by A2A URL.
 	if strings.HasPrefix(to, "http://") || strings.HasPrefix(to, "https://") {
-		reply, err := a2a.NewClient(to).Send(context.Background(), task)
+		reply, err := a2a.NewClient(to).Send(ctx, task)
 		if err != nil {
 			return errResult(call.ID, "delegate to A2A agent "+to+": "+err.Error())
 		}
@@ -234,7 +234,7 @@ func (a *agentImpl) handleDelegate(call ai.ToolCall) ai.ToolResult {
 
 	// Delegate-first: an existing agent that owns the domain handles it.
 	if to != "" && a.isAgent(to) {
-		reply, err := a.callAgentRPC(context.Background(), to, task)
+		reply, err := a.callAgentRPC(ctx, to, task)
 		if err != nil {
 			return errResult(call.ID, "delegate to agent "+to+": "+err.Error())
 		}
@@ -264,7 +264,7 @@ func (a *agentImpl) handleDelegate(call ai.ToolCall) ai.ToolResult {
 	// Record lineage so the sub-agent's tool calls carry this run as parent.
 	sub.parentRunID = a.runID
 
-	resp, err := sub.Ask(context.Background(), task)
+	resp, err := sub.Ask(ctx, task)
 	if err != nil {
 		return errResult(call.ID, "sub-agent: "+err.Error())
 	}

--- a/agent/integration_test.go
+++ b/agent/integration_test.go
@@ -15,7 +15,7 @@ import (
 // fakeGen drives the fake provider's Generate. Tests set it and reset
 // it with a deferred cleanup. Tests in this package are not parallel,
 // so a package-level hook is safe.
-var fakeGen func(opts ai.Options, req *ai.Request) (*ai.Response, error)
+var fakeGen func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error)
 
 type fakeModel struct{ opts ai.Options }
 
@@ -28,7 +28,7 @@ func (m *fakeModel) Init(opts ...ai.Option) error {
 func (m *fakeModel) Options() ai.Options { return m.opts }
 func (m *fakeModel) Generate(ctx context.Context, req *ai.Request, _ ...ai.GenerateOption) (*ai.Response, error) {
 	if fakeGen != nil {
-		return fakeGen(m.opts, req)
+		return fakeGen(ctx, m.opts, req)
 	}
 	return &ai.Response{Reply: "ok"}, nil
 }
@@ -71,7 +71,7 @@ func newTestAgent(opts ...Option) *agentImpl {
 // plan tool persists the plan to memory.
 func TestAskExposesAndRunsPlan(t *testing.T) {
 	var sawPlan, sawDelegate bool
-	fakeGen = func(opts ai.Options, req *ai.Request) (*ai.Response, error) {
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
 		for _, tl := range req.Tools {
 			switch tl.Name {
 			case toolPlan:
@@ -112,7 +112,7 @@ func TestAskExposesAndRunsPlan(t *testing.T) {
 // Delegating with no matching agent creates an ephemeral sub-agent with
 // a fresh, isolated context (no builtin tools) and returns its reply.
 func TestDelegateEphemeral(t *testing.T) {
-	fakeGen = func(opts ai.Options, req *ai.Request) (*ai.Response, error) {
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
 		if strings.Contains(req.SystemPrompt, "sub-agent") {
 			for _, tl := range req.Tools {
 				if tl.Name == toolPlan || tl.Name == toolDelegate {
@@ -126,7 +126,7 @@ func TestDelegateEphemeral(t *testing.T) {
 	defer func() { fakeGen = nil }()
 
 	a := newTestAgent(Name("root"))
-	content := a.handleDelegate(ai.ToolCall{Name: "delegate", Input: map[string]any{"task": "summarize the report"}}).Content
+	content := a.handleDelegate(context.Background(), ai.ToolCall{Name: "delegate", Input: map[string]any{"task": "summarize the report"}}).Content
 	if !strings.Contains(content, "subtask complete") {
 		t.Errorf("delegate should return the sub-agent's reply; got %q", content)
 	}
@@ -154,14 +154,14 @@ func TestDelegateToRegisteredAgent(t *testing.T) {
 	}
 
 	// fakeGen guards against the ephemeral path being taken by mistake.
-	fakeGen = func(opts ai.Options, req *ai.Request) (*ai.Response, error) {
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
 		t.Error("delegate to a registered agent must not spawn a sub-agent")
 		return &ai.Response{}, nil
 	}
 	defer func() { fakeGen = nil }()
 
 	a := newTestAgent(Name("root"), WithRegistry(reg), WithClient(fc))
-	content := a.handleDelegate(ai.ToolCall{Name: "delegate", Input: map[string]any{"task": "notify alice", "to": "comms"}}).Content
+	content := a.handleDelegate(context.Background(), ai.ToolCall{Name: "delegate", Input: map[string]any{"task": "notify alice", "to": "comms"}}).Content
 
 	if calledService != "comms" || calledEndpoint != "Agent.Chat" {
 		t.Errorf("expected RPC to comms Agent.Chat, got %s %s", calledService, calledEndpoint)
@@ -174,7 +174,7 @@ func TestDelegateToRegisteredAgent(t *testing.T) {
 // Delegate requires a task.
 func TestDelegateRequiresTask(t *testing.T) {
 	a := newTestAgent(Name("root"))
-	content := a.handleDelegate(ai.ToolCall{Name: "delegate", Input: map[string]any{}}).Content
+	content := a.handleDelegate(context.Background(), ai.ToolCall{Name: "delegate", Input: map[string]any{}}).Content
 	if !strings.Contains(content, "error") {
 		t.Errorf("delegate with no task should error; got %q", content)
 	}

--- a/agent/options.go
+++ b/agent/options.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"time"
 
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/client"
@@ -42,6 +43,13 @@ type Options struct {
 	Store        store.Store
 	HistoryLimit int
 
+	// ModelTimeout bounds each provider Generate call (0 disables).
+	ModelTimeout time.Duration
+	// ModelMaxAttempts bounds provider Generate attempts including the first call.
+	ModelMaxAttempts int
+	// ModelRetryBackoff is the delay between transient provider failures.
+	ModelRetryBackoff time.Duration
+
 	// Memory is the agent's conversation memory. Nil = the default
 	// store-backed memory (durable across restarts).
 	Memory Memory
@@ -71,10 +79,13 @@ type Options struct {
 
 func newOptions(opts ...Option) Options {
 	o := Options{
-		Registry:     registry.DefaultRegistry,
-		Client:       client.DefaultClient,
-		Store:        store.DefaultStore,
-		HistoryLimit: 50,
+		Registry:          registry.DefaultRegistry,
+		Client:            client.DefaultClient,
+		Store:             store.DefaultStore,
+		HistoryLimit:      50,
+		ModelTimeout:      30 * time.Second,
+		ModelMaxAttempts:  3,
+		ModelRetryBackoff: 100 * time.Millisecond,
 		// On by default and lenient: identical repeated calls are a
 		// no-progress loop, never useful. Set LoopLimit(0) to disable.
 		LoopLimit: 3,
@@ -153,6 +164,19 @@ func ApproveTool(fn ApproveFunc) Option {
 // no-progress loop. 0 disables loop detection.
 func LoopLimit(n int) Option {
 	return func(o *Options) { o.LoopLimit = n }
+}
+
+// ModelCallTimeout sets the timeout for each provider Generate call.
+func ModelCallTimeout(d time.Duration) Option {
+	return func(o *Options) { o.ModelTimeout = d }
+}
+
+// ModelRetry sets the provider retry budget and backoff for transient failures.
+func ModelRetry(maxAttempts int, backoff time.Duration) Option {
+	return func(o *Options) {
+		o.ModelMaxAttempts = maxAttempts
+		o.ModelRetryBackoff = backoff
+	}
 }
 
 // WithA2A makes Run serve the agent over the A2A protocol on addr (e.g.

--- a/agent/resilience_test.go
+++ b/agent/resilience_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go-micro.dev/v6/ai"
+)
+
+func TestAskCancellationAbortsPromptly(t *testing.T) {
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("cancel"), ModelCallTimeout(time.Second), ModelRetry(3, time.Millisecond))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := a.Ask(ctx, "stop")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Ask error = %v, want context canceled", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("Ask took %s after cancellation, want prompt abort", elapsed)
+	}
+}
+
+func TestAskRetriesTransientErrorsThenSucceeds(t *testing.T) {
+	attempts := 0
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, context.DeadlineExceeded
+		}
+		return &ai.Response{Reply: "ok"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("retry-success"), ModelRetry(3, time.Millisecond))
+	resp, err := a.Ask(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Ask returned error: %v", err)
+	}
+	if resp.Reply != "ok" {
+		t.Fatalf("reply = %q, want ok", resp.Reply)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestAskRetriesTransientErrorsThenSurfacesStructuredError(t *testing.T) {
+	attempts := 0
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		attempts++
+		return nil, context.DeadlineExceeded
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("retry-fail"), ModelRetry(2, time.Millisecond))
+	_, err := a.Ask(context.Background(), "hello")
+	var retryErr *ai.RetryError
+	if !errors.As(err, &retryErr) {
+		t.Fatalf("Ask error = %T %v, want *ai.RetryError", err, err)
+	}
+	if retryErr.Attempts != 2 {
+		t.Fatalf("retry attempts = %d, want 2", retryErr.Attempts)
+	}
+	if attempts != 2 {
+		t.Fatalf("model attempts = %d, want 2", attempts)
+	}
+}

--- a/ai/retry.go
+++ b/ai/retry.go
@@ -1,0 +1,114 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// StatusCoder is implemented by provider errors that expose an HTTP-like status code.
+type StatusCoder interface {
+	StatusCode() int
+}
+
+// RetryError is returned when Generate is retried and still fails.
+type RetryError struct {
+	Attempts int
+	Err      error
+}
+
+func (e *RetryError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("ai generate failed after %d attempt(s): %v", e.Attempts, e.Err)
+}
+
+func (e *RetryError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// GeneratePolicy controls timeout and retry behavior for a model call.
+type GeneratePolicy struct {
+	Timeout     time.Duration
+	MaxAttempts int
+	Backoff     time.Duration
+}
+
+// GenerateWithRetry calls m.Generate with per-attempt timeout and bounded retry.
+func GenerateWithRetry(ctx context.Context, m Model, req *Request, policy GeneratePolicy, opts ...GenerateOption) (*Response, error) {
+	if policy.MaxAttempts <= 0 {
+		policy.MaxAttempts = 1
+	}
+	if m == nil {
+		return nil, errors.New("ai model is nil")
+	}
+
+	var last error
+	for attempt := 1; attempt <= policy.MaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		callCtx := ctx
+		cancel := func() {}
+		if policy.Timeout > 0 {
+			callCtx, cancel = context.WithTimeout(ctx, policy.Timeout)
+		}
+		resp, err := m.Generate(callCtx, req, opts...)
+		cancel()
+		if err == nil {
+			return resp, nil
+		}
+		last = err
+
+		// Caller cancellation/deadline always wins and is not retried.
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if attempt == policy.MaxAttempts || !IsTransientError(err) {
+			if attempt > 1 || IsTransientError(err) {
+				return nil, &RetryError{Attempts: attempt, Err: err}
+			}
+			return nil, err
+		}
+
+		if policy.Backoff > 0 {
+			t := time.NewTimer(policy.Backoff)
+			select {
+			case <-ctx.Done():
+				if !t.Stop() {
+					<-t.C
+				}
+				return nil, ctx.Err()
+			case <-t.C:
+			}
+		}
+	}
+	return nil, &RetryError{Attempts: policy.MaxAttempts, Err: last}
+}
+
+// IsTransientError reports whether err is worth retrying at the provider boundary.
+func IsTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var sc StatusCoder
+	if errors.As(err, &sc) {
+		code := sc.StatusCode()
+		return code == 429 || code >= 500
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "rate limit") || strings.Contains(msg, "too many requests") || strings.Contains(msg, "timeout") || strings.Contains(msg, "temporar")
+}


### PR DESCRIPTION
### Motivation

- Improve agent-run resilience by ensuring deadlines and cancellations propagate end-to-end and provider calls are bounded and retried for transient failures. 

### Description

- Add a provider-boundary helper `ai.GenerateWithRetry` with `GeneratePolicy`, `RetryError`, and `IsTransientError` to apply per-attempt timeouts, bounded retries, and backoff. 
- Wire `Agent.Ask` to call `ai.GenerateWithRetry` using new agent options `ModelTimeout`, `ModelMaxAttempts`, and `ModelRetryBackoff` with sane defaults and option helpers `ModelCallTimeout` and `ModelRetry`. 
- Propagate `context.Context` through tool delegation paths so A2A calls, `callAgentRPC`, and ephemeral sub-agent `Ask` inherit the caller context instead of using background contexts. 
- Update the fake model test harness to accept a `ctx` in the `fakeGen` hook and add `agent/resilience_test.go` tests that verify prompt cancellation, transient-retry-then-success, and exhausted-retries returning a structured `*ai.RetryError`. 

### Testing

- Ran `go build ./...` which succeeded. 
- Ran unit tests for the modified packages with `go test ./agent/... ./ai/...` which passed. 
- Ran `golangci-lint run ./...` with no issues. 
- Note: a full `go test ./...` was attempted but unrelated loopback/network-dependent harness tests failed in this environment (external to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bb8fa955083309a1be602e32ef037)