### PR TITLE
website: tighten hero (drop "in Go", simpler tagline, in-hero image)

### DIFF
--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -167,18 +167,15 @@
 
     <section class="hero">
       <div class="hero-inner">
-        <h1>An Agent Harness and Service Framework in Go</h1>
-        <p class="tagline">Build agents, services, and flows on one runtime — your services become an agent's tools, your agents become services.</p>
+        <h1>An Agent Harness and Service Framework</h1>
+        <p class="tagline">Build agents, services, and workflows on one runtime.</p>
+        <img src="/images/generated/hero.jpg" alt="Go Micro — an agent orchestrating services" style="width: 100%; max-width: 800px; height: auto; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.08); margin: 0.5rem auto 1.5rem;" />
         <pre>curl -fsSL https://go-micro.dev/install.sh | sh</pre>
         <div class="hero-buttons">
           <a href="/docs/getting-started.html" class="btn btn-primary">Get Started</a>
           <a href="https://github.com/micro/go-micro" class="btn btn-secondary">View on GitHub</a>
         </div>
       </div>
-    </section>
-
-    <section class="section">
-      <img src="/images/generated/hero.jpg" alt="Go Micro — AI agent orchestrating microservices" style="width: 100%; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.08);" />
     </section>
 
     <section class="section-alt">


### PR DESCRIPTION
Landing hero polish:
- **h1** → "An Agent Harness and Service Framework" (dropped "in Go")
- **tagline** → "Build agents, services, and workflows on one runtime" (simpler; "workflows")
- **hero image** moved into the hero block, between the tagline and the install line, capped at **800px** to fit the hero column; removed the separate full-width image section.

Jekyll-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_