### PR TITLE
website: size hero image to 600px

### DIFF
--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -169,7 +169,7 @@
       <div class="hero-inner">
         <h1>An Agent Harness and Service Framework</h1>
         <p class="tagline">Build agents, services, and workflows on one runtime.</p>
-        <img src="/images/generated/hero.jpg" alt="Go Micro — an agent orchestrating services" style="width: 100%; max-width: 800px; height: auto; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.08); margin: 0.5rem auto 1.5rem;" />
+        <img src="/images/generated/hero.jpg" alt="Go Micro — an agent orchestrating services" style="width: 100%; max-width: 600px; height: auto; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.08); margin: 0.5rem auto 1.5rem;" />
         <pre>curl -fsSL https://go-micro.dev/install.sh | sh</pre>
         <div class="hero-buttons">
           <a href="/docs/getting-started.html" class="btn btn-primary">Get Started</a>


### PR DESCRIPTION
Cap the in-hero image at 600px (down from 800px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_