### PR TITLE
agent: make model retries opt-in + harden retry backoff

### DIFF
--- a/agent/options.go
+++ b/agent/options.go
@@ -45,9 +45,13 @@ type Options struct {
 
 	// ModelTimeout bounds each provider Generate call (0 disables).
 	ModelTimeout time.Duration
-	// ModelMaxAttempts bounds provider Generate attempts including the first call.
+	// ModelMaxAttempts bounds provider Generate attempts including the first
+	// call. Default 1 — retries are opt-in (enable with ModelRetry). A Generate
+	// runs the whole tool-execution turn, so auto-retrying it would re-run
+	// already-executed, possibly side-effecting tool calls; keep it explicit.
 	ModelMaxAttempts int
-	// ModelRetryBackoff is the delay between transient provider failures.
+	// ModelRetryBackoff is the base delay between transient provider failures
+	// (grows exponentially per attempt when retries are enabled).
 	ModelRetryBackoff time.Duration
 
 	// Memory is the agent's conversation memory. Nil = the default
@@ -84,7 +88,7 @@ func newOptions(opts ...Option) Options {
 		Store:             store.DefaultStore,
 		HistoryLimit:      50,
 		ModelTimeout:      30 * time.Second,
-		ModelMaxAttempts:  3,
+		ModelMaxAttempts:  1, // retries opt-in via ModelRetry (see field doc)
 		ModelRetryBackoff: 100 * time.Millisecond,
 		// On by default and lenient: identical repeated calls are a
 		// no-progress loop, never useful. Set LoopLimit(0) to disable.

--- a/ai/retry.go
+++ b/ai/retry.go
@@ -78,16 +78,27 @@ func GenerateWithRetry(ctx context.Context, m Model, req *Request, policy Genera
 			return nil, err
 		}
 
-		if policy.Backoff > 0 {
-			t := time.NewTimer(policy.Backoff)
-			select {
-			case <-ctx.Done():
-				if !t.Stop() {
-					<-t.C
-				}
-				return nil, ctx.Err()
-			case <-t.C:
+		// Always back off between retries — exponential and capped — so an
+		// opt-in retry can never become a tight loop hammering the provider,
+		// even if Backoff was left at zero.
+		backoff := policy.Backoff
+		if backoff <= 0 {
+			backoff = 200 * time.Millisecond
+		}
+		if shift := attempt - 1; shift > 0 {
+			backoff <<= shift
+		}
+		if backoff > 30*time.Second {
+			backoff = 30 * time.Second
+		}
+		t := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			if !t.Stop() {
+				<-t.C
 			}
+			return nil, ctx.Err()
+		case <-t.C:
 		}
 	}
 	return nil, &RetryError{Attempts: policy.MaxAttempts, Err: last}


### PR DESCRIPTION
Follow-up to #3017 (the resilience review concern).

**Why:** `Generate` runs the whole tool-execution turn, so auto-retrying it re-runs already-executed, possibly side-effecting tool calls. And the backoff only applied when `Backoff > 0`, so an opt-in retry with no backoff would tight-loop the provider.

**Changes:**
- `ModelMaxAttempts` default **3 → 1** — retries are now **opt-in** via `ModelRetry(n, backoff)`. The 30s timeout stays as a safety net.
- `ai.GenerateWithRetry`: **always** back off between retries — exponential, capped at 30s, defaulting to 200ms if unset — so an opt-in retry can never busy-loop even with `Backoff=0`.

Existing resilience tests set `ModelRetry(...)` explicitly, so they're unaffected.

Verified locally: `go build ./...`, `go test -race ./agent/... ./ai/`, `golangci-lint run` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_