### PR TITLE
loop: continuous-improvement charter + scheduled backbone

### DIFF
--- a/.github/workflows/continuous-improvement.yml
+++ b/.github/workflows/continuous-improvement.yml
@@ -1,0 +1,49 @@
+name: Continuous Improvement
+
+# Durable, session-independent backbone for the autonomous improvement loop.
+# See internal/docs/CONTINUOUS_IMPROVEMENT.md for the charter.
+#
+# REQUIRES an ANTHROPIC_API_KEY repo secret — until that's set this workflow
+# is a safe no-op. Verify the Claude Code install/flags against current docs
+# before relying on it; the loop's correctness gate is build + test + lint.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "29 */6 * * *" # every 6h, off-minute (tune as needed)
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: continuous-improvement
+  cancel-in-progress: false
+
+jobs:
+  improve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          check-latest: true
+          cache: true
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Run one improvement increment
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ANTHROPIC_API_KEY not set — skipping. Add the repo secret to enable the loop."
+            exit 0
+          fi
+          claude -p "Run ONE continuous-improvement increment for go-micro per internal/docs/CONTINUOUS_IMPROVEMENT.md: pick the single highest-value roadmap/issue/radar item, implement it or dispatch to Codex, verify build+test+lint, open a PR and merge it, then print a one-line digest. Full autonomy, no approvals; correctness is the only gate; one concern per PR; stay out of brand/positioning copy and breaking public API." \
+            --permission-mode acceptEdits \
+            --allowedTools "Bash,Edit,Write,Read,Glob,Grep"

--- a/internal/docs/CONTINUOUS_IMPROVEMENT.md
+++ b/internal/docs/CONTINUOUS_IMPROVEMENT.md
@@ -1,0 +1,74 @@
+# Continuous Improvement Loop
+
+Go Micro is an agent harness. This file defines the **autonomous loop that builds
+it** — the framework's own thesis (an agent operating a system) pointed at itself.
+Claude Code drives the loop; Codex executes scoped tasks; the human sets direction
+and can stop or revert anything at any time.
+
+## Autonomy
+
+Full autonomy, **no approval gates**. Each increment: Claude Code picks the work,
+implements it (or dispatches Codex), opens a PR, and **merges it** — including
+reviewing and merging Codex's PRs. The only gate is **correctness**: `go build`,
+`go test`, and `golangci-lint` must be green (that's not an approval, it's not
+shipping broken code).
+
+Transparency replaces approval: every increment ends with a one-line digest, and
+every change is a small, reversible, single-concern PR the human can revert.
+
+## What counts as an improvement
+
+Grounded in real signal, never speculative rewrites. Each cycle draws from:
+
+1. **Roadmap** — the Now/Next items in `ROADMAP.md` (harness depth: durable runs,
+   observability, streaming, human-in-the-loop; hardening: resilience, conformance).
+2. **Open issues** — the scoped backlog (e.g. #3010–#3014).
+3. **Improvement radar** — a scan each cycle for: missing/weak tests, lint or
+   quality issues, docs/code drift, and DX friction.
+4. **Dogfooding** — actually build with the harness (`micro new` → `run` → `chat`,
+   an agent + a flow) and fix what hurts. Friction found here is high-signal.
+
+## The cycle (one increment)
+
+1. Sync `master`.
+2. If a Codex PR is open and CI-green → review (diff + gates + correctness vs its
+   issue) and merge it.
+3. Else pick the single highest-value item from the sources above.
+4. Implement it, or dispatch to Codex (`@codex <instruction>` on the issue) if it's
+   a well-scoped chunk and Codex is free. **Codex is serial — one task at a time.**
+5. Verify `build`/`test`/`lint` locally.
+6. Open a PR (one concern) and merge it.
+7. Post a one-line digest; refresh the backlog from the radar.
+
+## Roles
+
+- **Claude Code** — orchestrator, implementer, reviewer, integrator, merger.
+- **Codex** — serial builder for well-scoped chunks, dispatched via `@codex`.
+- **Human** — sets direction; owns brand/positioning copy and breaking public-API
+  decisions; can stop or revert anything.
+
+## Guardrails
+
+- One concern per PR; small and reversible.
+- Stay on `claude/*` branches (Codex on `codex/*`); never two agents on one branch;
+  base PRs on `master` (don't stack on an in-flight branch). See `CODEX.md`.
+- **Off-limits without the human:** brand/positioning/marketing copy, breaking
+  public API changes, product-default changes with broad behavioral impact, new
+  dependencies, architectural rewrites. The loop proposes these in the digest; it
+  does not merge them autonomously.
+
+## Scheduling
+
+- **In-session cron** (`CronCreate`) — runs increments while this Claude session is
+  alive. Convenient, but the remote environment is reclaimed on inactivity and
+  recurring jobs expire after 7 days, so it is **not** a durable scheduler.
+- **GitHub Actions (durable)** — a scheduled workflow that runs the loop
+  independently of any session. This is the real backbone; it needs an
+  `ANTHROPIC_API_KEY` repo secret. See `.github/workflows/continuous-improvement.yml`.
+
+## Stop / redirect
+
+- In-session: `CronDelete <id>` (or end the session).
+- Durable: disable/delete the workflow.
+- Or just tell Claude Code to pause or change focus — direction always wins over
+  the loop.


### PR DESCRIPTION
Establishes the autonomous continuous-improvement loop — the framework's own agent-harness thesis pointed at building the framework.

- **`internal/docs/CONTINUOUS_IMPROVEMENT.md`** — the charter: full autonomy with **correctness (build/test/lint) as the only gate**, work sourced from the roadmap + open issues + an improvement radar + dogfooding, Claude Code driving and Codex executing scoped tasks, transparency-via-digest instead of approvals, and brand/positioning + breaking-API changes kept with the human.
- **`.github/workflows/continuous-improvement.yml`** — the durable, session-independent scheduler (every 6h). It's a **safe no-op until an `ANTHROPIC_API_KEY` repo secret is added**; verify the Claude Code flags against current docs before relying on it.

An in-session cron is also running for immediate increments while this session is alive, but the GitHub Action is the real backbone (the remote session env is ephemeral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_