### PR TITLE
loop: hourly Codex dispatch + auto-merge green Codex PRs

### DIFF
--- a/.github/workflows/auto-merge-codex.yml
+++ b/.github/workflows/auto-merge-codex.yml
@@ -1,0 +1,42 @@
+name: Auto-merge Codex PRs
+
+# Part of the autonomous improvement loop (internal/docs/CONTINUOUS_IMPROVEMENT.md).
+# Merges Codex's PRs once CI is green — no human involvement; CI (build, test,
+# golangci-lint, harnesses) is the only gate. Scoped to PRs that are BOTH
+# codex-labelled AND from a codex/* branch, so nothing else can auto-merge.
+
+on:
+  schedule:
+    - cron: "*/15 * * * *" # sweep every 15 min
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-merge-codex
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge green Codex PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr list --repo "$REPO" --label codex --state open \
+            --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("codex/")) | .number' \
+          | while read -r pr; do
+              [ -z "$pr" ] && continue
+              if gh pr checks "$pr" --repo "$REPO" >/dev/null 2>&1; then
+                echo "Checks green on #$pr — merging."
+                gh pr merge "$pr" --repo "$REPO" --squash --delete-branch \
+                  || echo "skip #$pr (not mergeable — conflicts?)"
+              else
+                echo "skip #$pr (checks pending/failing)"
+              fi
+            done

--- a/.github/workflows/continuous-improvement.yml
+++ b/.github/workflows/continuous-improvement.yml
@@ -14,7 +14,7 @@ name: Continuous Improvement
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "29 */12 * * *" # twice daily, off-minute (tune as needed)
+    - cron: "29 * * * *" # hourly, off-minute (tune as needed)
 
 permissions:
   issues: write


### PR DESCRIPTION
Makes the loop run continuously with zero human involvement.

- **Hourly dispatch** — `continuous-improvement.yml` cadence 12h → hourly (`@codex` on tracker #3024).
- **Self-merge** — new `auto-merge-codex.yml` sweeps every 15 min and merges open PRs that are **codex-labelled AND from a `codex/*` branch** once **all checks are green** (`gh pr checks`). CI (build / test / golangci-lint / harnesses) is the only gate — no review required. Tightly scoped so nothing else can auto-merge.

**Honest caveats:**
- This auto-merges AI-generated PRs with **no human/agent review** — CI is comprehensive but can't catch design/correctness it doesn't test. You asked for zero human involvement; this delivers it. I review merged changes during sessions and can revert anything.
- "No further setup" holds **only if Codex responds to a bot-authored `@codex`** (untested — the MCP token can't dispatch the workflow, so it'll first fire on the hourly cron, or you can hit *Run workflow*). If Codex ignores bot comments, add a `CODEX_TRIGGER_TOKEN` PAT (already wired) — that's the one possible setup step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_