### PR TITLE
Add agent OpenTelemetry run observability

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -130,6 +130,9 @@ func (a *agentImpl) setup() {
 	a.tools = ai.NewTools(a.opts.Registry, ai.ToolClient(a.opts.Client))
 	modelOpts = append(modelOpts, ai.WithToolHandler(a.toolHandler()))
 	a.model = ai.New(a.opts.Provider, modelOpts...)
+	if a.opts.TraceProvider != nil && a.model != nil {
+		a.model = a.tracedModel(a.model)
+	}
 
 	// Memory is pluggable. Use the configured one, otherwise the default
 	// store-backed memory — except ephemeral sub-agents, which keep an
@@ -182,6 +185,8 @@ func (a *agentImpl) Ask(ctx context.Context, message string) (*Response, error) 
 		ParentID: a.parentRunID,
 		Agent:    a.opts.Name,
 	})
+	ctx, endRun := a.startRun(ctx, message)
+	defer func() { endRun(err) }()
 
 	resp, err := ai.GenerateWithRetry(ctx, a.model, &ai.Request{
 		Prompt:       message,

--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -108,6 +108,7 @@ func (a *agentImpl) toolHandler() ai.ToolHandler {
 	h = a.loopWrap(h)
 	h = a.stepWrap(h)
 	h = a.planWrap(h)
+	h = a.traceTool(h)
 	for i := len(a.opts.wrappers) - 1; i >= 0; i-- {
 		h = a.opts.wrappers[i](h)
 	}
@@ -260,6 +261,7 @@ func (a *agentImpl) handleDelegate(ctx context.Context, call ai.ToolCall) ai.Too
 		WithRegistry(a.opts.Registry),
 		WithClient(a.opts.Client),
 		WithStore(a.opts.Store),
+		TraceProvider(a.opts.TraceProvider),
 	)
 	// Record lineage so the sub-agent's tool calls carry this run as parent.
 	sub.parentRunID = a.runID

--- a/agent/options.go
+++ b/agent/options.go
@@ -8,6 +8,7 @@ import (
 	"go-micro.dev/v6/client"
 	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/store"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Option configures an Agent.
@@ -73,6 +74,10 @@ type Options struct {
 	// A2AAddress, if set, makes Run serve this agent over the A2A protocol
 	// on that address directly (no separate gateway), e.g. ":4000".
 	A2AAddress string
+
+	// TraceProvider enables OpenTelemetry spans for agent runs, model calls,
+	// and tool calls. Nil disables instrumentation.
+	TraceProvider trace.TracerProvider
 
 	// tools are developer-registered custom tools (see WithTool).
 	tools []customTool
@@ -235,4 +240,10 @@ func WithTool(name, description string, properties map[string]any, handler ToolF
 			handler: handler,
 		})
 	}
+}
+
+// TraceProvider enables OpenTelemetry tracing for agent runs. When nil,
+// agent tracing and run timeline recording are disabled.
+func TraceProvider(tp trace.TracerProvider) Option {
+	return func(o *Options) { o.TraceProvider = tp }
 }

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -1,0 +1,201 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/store"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const agentInstrumentationName = "go-micro.dev/v6/agent"
+
+const (
+	spanNameRun       = "agent.run"
+	spanNameModelCall = "agent.model.call"
+	spanNameToolCall  = "agent.tool.call"
+
+	AttrRunID          = "agent.run.id"
+	AttrParentRunID    = "agent.run.parent_id"
+	AttrAgentName      = "agent.name"
+	AttrProvider       = "agent.model.provider"
+	AttrModel          = "agent.model.name"
+	AttrLatencyMS      = "agent.latency_ms"
+	AttrInputTokens    = "agent.tokens.input"
+	AttrOutputTokens   = "agent.tokens.output"
+	AttrTotalTokens    = "agent.tokens.total"
+	AttrToolName       = "agent.tool.name"
+	AttrDelegate       = "agent.delegate"
+	AttrGuardrailBlock = "agent.guardrail.block"
+	AttrRefusal        = "agent.refusal"
+)
+
+type RunEvent struct {
+	Time      time.Time `json:"time"`
+	RunID     string    `json:"run_id"`
+	ParentID  string    `json:"parent_id,omitempty"`
+	Agent     string    `json:"agent"`
+	Kind      string    `json:"kind"`
+	Name      string    `json:"name,omitempty"`
+	Provider  string    `json:"provider,omitempty"`
+	Model     string    `json:"model,omitempty"`
+	LatencyMS int64     `json:"latency_ms,omitempty"`
+	Tokens    Usage     `json:"tokens,omitempty"`
+	Refused   string    `json:"refused,omitempty"`
+	Error     string    `json:"error,omitempty"`
+}
+
+type Usage = ai.Usage
+
+func (a *agentImpl) tracer() trace.Tracer {
+	return a.opts.TraceProvider.Tracer(agentInstrumentationName)
+}
+
+func (a *agentImpl) startRun(ctx context.Context, message string) (context.Context, func(error)) {
+	if a.opts.TraceProvider == nil {
+		return ctx, func(error) {}
+	}
+	info, _ := ai.RunInfoFrom(ctx)
+	ctx, span := a.tracer().Start(ctx, spanNameRun, trace.WithSpanKind(trace.SpanKindInternal), trace.WithAttributes(
+		attribute.String(AttrRunID, info.RunID), attribute.String(AttrParentRunID, info.ParentID), attribute.String(AttrAgentName, info.Agent)))
+	start := time.Now()
+	a.recordRunEvent(RunEvent{Time: start, RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "run", Name: message})
+	return ctx, func(err error) {
+		span.SetAttributes(attribute.Int64(AttrLatencyMS, time.Since(start).Milliseconds()))
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "error", Error: err.Error()})
+		} else {
+			span.SetStatus(codes.Ok, "")
+		}
+		span.End()
+	}
+}
+
+type tracedModel struct {
+	ai.Model
+	a *agentImpl
+}
+
+func (a *agentImpl) tracedModel(m ai.Model) ai.Model { return &tracedModel{Model: m, a: a} }
+func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (*ai.Response, error) {
+	if m.a.opts.TraceProvider == nil {
+		return m.Model.Generate(ctx, req, opts...)
+	}
+	info, _ := ai.RunInfoFrom(ctx)
+	provider := m.String()
+	model := m.Options().Model
+	ctx, span := m.a.tracer().Start(ctx, spanNameModelCall, trace.WithAttributes(attribute.String(AttrProvider, provider), attribute.String(AttrModel, model)))
+	start := time.Now()
+	resp, err := m.Model.Generate(ctx, req, opts...)
+	dur := time.Since(start).Milliseconds()
+	attrs := []attribute.KeyValue{attribute.Int64(AttrLatencyMS, dur)}
+	usage := ai.Usage{}
+	if resp != nil {
+		usage = resp.Usage
+		attrs = appendUsage(attrs, usage)
+	}
+	span.SetAttributes(attrs...)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	span.End()
+	e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "model", Provider: provider, Model: model, LatencyMS: dur, Tokens: usage}
+	if err != nil {
+		e.Error = err.Error()
+	}
+	m.a.recordRunEvent(e)
+	return resp, err
+}
+
+func appendUsage(attrs []attribute.KeyValue, u ai.Usage) []attribute.KeyValue {
+	if u.InputTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrInputTokens, u.InputTokens))
+	}
+	if u.OutputTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrOutputTokens, u.OutputTokens))
+	}
+	if u.TotalTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrTotalTokens, u.TotalTokens))
+	}
+	return attrs
+}
+
+func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
+	if a.opts.TraceProvider == nil {
+		return next
+	}
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		info, _ := ai.RunInfoFrom(ctx)
+		ctx, span := a.tracer().Start(ctx, spanNameToolCall, trace.WithAttributes(attribute.String(AttrToolName, call.Name), attribute.Bool(AttrDelegate, call.Name == toolDelegate)))
+		start := time.Now()
+		res := next(ctx, call)
+		dur := time.Since(start).Milliseconds()
+		attrs := []attribute.KeyValue{attribute.Int64(AttrLatencyMS, dur)}
+		if res.Refused != "" {
+			attrs = append(attrs, attribute.Bool(AttrGuardrailBlock, true), attribute.String(AttrRefusal, res.Refused))
+		}
+		span.SetAttributes(attrs...)
+		resErr := resultError(res)
+		if res.Refused != "" {
+			span.SetStatus(codes.Error, res.Refused)
+		} else if resErr != "" {
+			span.SetStatus(codes.Error, resErr)
+		} else {
+			span.SetStatus(codes.Ok, "")
+		}
+		span.End()
+		a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, LatencyMS: dur, Refused: res.Refused, Error: resErr})
+		return res
+	}
+}
+
+func resultError(res ai.ToolResult) string {
+	if m, ok := res.Value.(map[string]string); ok {
+		return m["error"]
+	}
+	if m, ok := res.Value.(map[string]any); ok {
+		if err, _ := m["error"].(string); err != "" {
+			return err
+		}
+	}
+	return ""
+}
+
+func (a *agentImpl) recordRunEvent(e RunEvent) {
+	if a.opts.TraceProvider == nil || e.RunID == "" {
+		return
+	}
+	b, _ := json.Marshal(e)
+	key := fmt.Sprintf("runs/%s/%020d-%s", e.RunID, e.Time.UnixNano(), e.Kind)
+	_ = a.stateStore().Write(&store.Record{Key: key, Value: b})
+}
+
+func LoadRunEvents(s store.Store, agentName, runID string) ([]RunEvent, error) {
+	st := store.Scope(s, "agent", agentName)
+	keys, err := st.List(store.ListPrefix("runs/" + runID + "/"))
+	if err != nil {
+		return nil, err
+	}
+	events := make([]RunEvent, 0, len(keys))
+	for _, k := range keys {
+		recs, err := st.Read(k)
+		if err != nil || len(recs) == 0 {
+			continue
+		}
+		var e RunEvent
+		if json.Unmarshal(recs[0].Value, &e) == nil {
+			events = append(events, e)
+		}
+	}
+	return events, nil
+}

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/store"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+type otelTestModel struct{ opts ai.Options }
+
+func (m *otelTestModel) Init(opts ...ai.Option) error {
+	for _, o := range opts {
+		o(&m.opts)
+	}
+	return nil
+}
+func (m *otelTestModel) Options() ai.Options { return m.opts }
+func (m *otelTestModel) String() string      { return "oteltest" }
+func (m *otelTestModel) Stream(context.Context, *ai.Request, ...ai.GenerateOption) (ai.Stream, error) {
+	return nil, nil
+}
+func (m *otelTestModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (*ai.Response, error) {
+	if m.opts.ToolHandler != nil {
+		_ = m.opts.ToolHandler(ctx, ai.ToolCall{ID: "call-1", Name: "probe", Input: map[string]any{"ok": true}})
+	}
+	return &ai.Response{Reply: "done", Usage: ai.Usage{InputTokens: 2, OutputTokens: 3, TotalTokens: 5}}, nil
+}
+
+func init() {
+	ai.Register("oteltest", func(opts ...ai.Option) ai.Model { return &otelTestModel{opts: ai.NewOptions(opts...)} })
+}
+
+func TestAgentOpenTelemetrySpans(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exp))
+	st := store.NewMemoryStore()
+	a := New(Name("runner"), Provider("oteltest"), Model("unit-model"), WithStore(st), TraceProvider(tp), WithTool("probe", "probe", nil, func(context.Context, map[string]any) (string, error) { return "ok", nil }))
+	if _, err := a.Ask(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	spans := exp.GetSpans().Snapshots()
+	want := map[string]bool{spanNameRun: false, spanNameModelCall: false, spanNameToolCall: false}
+	for _, s := range spans {
+		if _, ok := want[s.Name()]; ok {
+			want[s.Name()] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Fatalf("span %s not emitted; got %d spans", name, len(spans))
+		}
+	}
+	keys, err := store.Scope(st, "agent", "runner").List(store.ListPrefix("runs/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) == 0 {
+		t.Fatal("expected run events to be recorded")
+	}
+}
+
+func TestAgentOpenTelemetryNoopWhenUnconfigured(t *testing.T) {
+	st := store.NewMemoryStore()
+	a := New(Name("runner-noop"), Provider("oteltest"), WithStore(st), WithTool("probe", "probe", nil, func(context.Context, map[string]any) (string, error) { return "ok", nil }))
+	if _, err := a.Ask(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := store.Scope(st, "agent", "runner-noop").List(store.ListPrefix("runs/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("expected no run timeline without TraceProvider, got %v", keys)
+	}
+	if _, ok := a.(*agentImpl).model.(*tracedModel); ok {
+		t.Fatal("model should not be wrapped when TraceProvider is nil")
+	}
+}

--- a/ai/model.go
+++ b/ai/model.go
@@ -48,6 +48,13 @@ type Message struct {
 	Content any    // Can be string or structured content
 }
 
+// Usage describes token counts returned by model providers.
+type Usage struct {
+	InputTokens  int `json:"input_tokens,omitempty"`
+	OutputTokens int `json:"output_tokens,omitempty"`
+	TotalTokens  int `json:"total_tokens,omitempty"`
+}
+
 // Response represents the response from a model
 type Response struct {
 	// Reply is the text response from the model
@@ -56,6 +63,8 @@ type Response struct {
 	ToolCalls []ToolCall
 	// Answer is the final answer after tool execution (if tools were used)
 	Answer string
+	// Usage contains provider token usage when available.
+	Usage Usage
 }
 
 // ToolCall represents a request to call a tool and its result

--- a/ai/openai/openai.go
+++ b/ai/openai/openai.go
@@ -179,6 +179,11 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 
 	// Parse response
 	var chatResp struct {
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
 		Choices []struct {
 			Message struct {
 				Content   string `json:"content"`
@@ -204,6 +209,7 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 	choice := chatResp.Choices[0]
 	response := &ai.Response{
 		Reply: choice.Message.Content,
+		Usage: ai.Usage{InputTokens: chatResp.Usage.PromptTokens, OutputTokens: chatResp.Usage.CompletionTokens, TotalTokens: chatResp.Usage.TotalTokens},
 	}
 
 	// Extract tool calls

--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -4,6 +4,8 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 	goagent "go-micro.dev/v6/agent"
@@ -13,6 +15,22 @@ import (
 )
 
 func init() {
+	cmd.Register(&cli.Command{
+		Name:      "runs",
+		Usage:     "Show recorded agent runs",
+		ArgsUsage: "[agent] [run-id]",
+		Action: func(c *cli.Context) error {
+			name := c.Args().First()
+			if name == "" {
+				return fmt.Errorf("usage: micro runs [agent] [run-id]")
+			}
+			if runID := c.Args().Get(1); runID != "" {
+				return printRunHistory(name, runID)
+			}
+			return printRunIndex(name)
+		},
+	})
+
 	cmd.Register(&cli.Command{
 		Name:  "agent",
 		Usage: "Manage AI agents",
@@ -79,12 +97,15 @@ func init() {
 			},
 			{
 				Name:      "history",
-				Usage:     "Show an agent's stored conversation history",
-				ArgsUsage: "[name]",
+				Usage:     "Show an agent's stored conversation and run history",
+				ArgsUsage: "[name] [run-id]",
 				Action: func(c *cli.Context) error {
 					name := c.Args().First()
 					if name == "" {
-						return fmt.Errorf("usage: micro agent history [name]")
+						return fmt.Errorf("usage: micro agent history [name] [run-id]")
+					}
+					if runID := c.Args().Get(1); runID != "" {
+						return printRunHistory(name, runID)
 					}
 					// Read from the agent's scoped state store (database
 					// "agent", table = name) — available whether or not the
@@ -93,14 +114,77 @@ func init() {
 					msgs := mem.Messages()
 					if len(msgs) == 0 {
 						fmt.Printf("  No history for agent %q.\n", name)
-						return nil
+					} else {
+						for _, m := range msgs {
+							fmt.Printf("  \033[2m%s:\033[0m %v\n", m.Role, m.Content)
+						}
 					}
-					for _, m := range msgs {
-						fmt.Printf("  \033[2m%s:\033[0m %v\n", m.Role, m.Content)
-					}
-					return nil
+					return printRunIndex(name)
 				},
 			},
 		},
 	})
+}
+
+func printRunIndex(name string) error {
+	st := store.Scope(store.DefaultStore, "agent", name)
+	keys, err := st.List(store.ListPrefix("runs/"))
+	if err != nil {
+		return err
+	}
+	runs := map[string]bool{}
+	for _, k := range keys {
+		parts := strings.Split(k, "/")
+		if len(parts) >= 2 {
+			runs[parts[1]] = true
+		}
+	}
+	if len(runs) == 0 {
+		fmt.Printf("  No runs recorded for agent %q.\n", name)
+		return nil
+	}
+	ids := make([]string, 0, len(runs))
+	for id := range runs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	fmt.Println("  Runs:")
+	for _, id := range ids {
+		fmt.Printf("    %s\n", id)
+	}
+	return nil
+}
+
+func printRunHistory(name, runID string) error {
+	events, err := goagent.LoadRunEvents(store.DefaultStore, name, runID)
+	if err != nil {
+		return err
+	}
+	if len(events) == 0 {
+		fmt.Printf("  No run %q for agent %q.\n", runID, name)
+		return nil
+	}
+	for _, e := range events {
+		line := fmt.Sprintf("  %s %-5s", e.Time.Format("15:04:05.000"), e.Kind)
+		if e.Name != "" {
+			line += " " + e.Name
+		}
+		if e.Provider != "" || e.Model != "" {
+			line += fmt.Sprintf(" %s/%s", e.Provider, e.Model)
+		}
+		if e.LatencyMS > 0 {
+			line += fmt.Sprintf(" %dms", e.LatencyMS)
+		}
+		if e.Tokens.TotalTokens > 0 {
+			line += fmt.Sprintf(" tokens=%d", e.Tokens.TotalTokens)
+		}
+		if e.Refused != "" {
+			line += " refused=" + e.Refused
+		}
+		if e.Error != "" {
+			line += " error=" + e.Error
+		}
+		fmt.Println(line)
+	}
+	return nil
 }


### PR DESCRIPTION
### Motivation
- Make the agent run loop observable with OpenTelemetry spans and a CLI-inspectable timeline so operator/debugging workflows can see model and tool calls per run. 
- Keep instrumentation opt-in and zero-overhead when no tracer is configured by following the existing MCP `otel.go` pattern.

### Description
- Add an opt-in `TraceProvider` option (`agent.TraceProvider`) and wire it into agent setup so the model is wrapped with a `tracedModel` only when a provider is configured. 
- Implement `agent/otel.go` which emits `agent.run`, `agent.model.call`, and `agent.tool.call` spans with attributes for run id, parent id, agent name, provider, model, latency, token usage, tool name, delegate boundaries, guardrail refusals, and errors, and records per-run timeline events into the agent-scoped store under keys prefixed with `runs/<run-id>/...`.
- Add a tool-tracing wrapper (`traceTool`) into the existing tool wrapper chain and record run events via `recordRunEvent`, preserving zero overhead when `TraceProvider` is nil. 
- Add token usage plumbing (`ai.Usage`) and extract OpenAI `usage` counts in `ai/openai` so spans and run events can show token counts when providers return them. 
- Extend CLI to inspect runs by adding `micro runs <agent> [run-id]` and extending `micro agent history <agent> [run-id]` to list run ids and print a run's timeline (reuse agent state store; no duplication of conversation history). 
- Add tests `agent/otel_test.go` that use an in-memory test exporter to assert spans are emitted and verify no-op behavior when `TraceProvider` is not set.

### Testing
- Ran `go build ./...` and it succeeded. 
- Ran unit tests for the agent: `go test ./agent/...` and the new tests passed. 
- Ran linter: `golangci-lint run ./...` and it reported no issues after fixes. 
- Ran `go test ./...` for the whole repo; several unrelated integration/harness/transport tests failed due to environment/network loopback restrictions (e.g. loopback targets forbidden / connection resets) that are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc2b0e6688330b9a851db8861c04d)