### PR TITLE
website: text-only "Go Micro" brand (remove nav logo)

### DIFF
--- a/internal/website/_includes/marketing-nav.html
+++ b/internal/website/_includes/marketing-nav.html
@@ -1,8 +1,5 @@
 <nav class="nav">
-  <a class="nav-brand" href="/">
-    <img src="https://raw.githubusercontent.com/micro/go-micro/master/logo.png" alt="Go Micro" style="border-radius: 8px;" />
-    Go Micro
-  </a>
+  <a class="nav-brand" href="/">Go Micro</a>
   <div class="nav-links">
     {% include nav-links.html %}
   </div>

--- a/internal/website/_layouts/blog.html
+++ b/internal/website/_layouts/blog.html
@@ -69,10 +69,7 @@
 </head>
 <body>
   <nav class="site-nav">
-    <a class="nav-brand" href="/">
-      <img src="https://raw.githubusercontent.com/micro/go-micro/master/logo.png" alt="Go Micro" style="border-radius: 8px;">
-      Go Micro
-    </a>
+    <a class="nav-brand" href="/">Go Micro</a>
     <div class="nav-links">
       {% include nav-links.html %}
     </div>

--- a/internal/website/_layouts/default.html
+++ b/internal/website/_layouts/default.html
@@ -98,10 +98,7 @@
 </head>
 <body>
   <nav class="site-nav">
-    <a class="nav-brand" href="/">
-      <img src="https://raw.githubusercontent.com/micro/go-micro/master/logo.png" alt="Go Micro" style="border-radius: 8px;">
-      Go Micro
-    </a>
+    <a class="nav-brand" href="/">Go Micro</a>
     <button class="menu-toggle" id="menuToggle">Menu</button>
     <div class="nav-links">
       {% include nav-links.html %}


### PR DESCRIPTION
Drop the logo image from the nav header everywhere — the brand is now just the "Go Micro" wordmark. Removes the `<img>` from the nav-brand in the marketing nav include (landing + support) and the docs and blog layouts. (`badge.html`'s logo reference is the "get a badge" page content — left as-is.)

Jekyll-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_