### PR TITLE
website: fix mobile horizontal overflow on the landing page

### DIFF
--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -115,6 +115,7 @@
 
       /* Two-column layout */
       .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 3rem; align-items: center; overflow: hidden; }
+      .two-col > * { min-width: 0; } /* let grid items shrink so wide <pre> can't blow out the row */
       .two-col img { width: 100%; max-width: 100%; height: auto; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.08); }
       .two-col-text h2 { font-size: 1.5rem; margin-bottom: 0.5rem; }
       .two-col-text p { color: #555; line-height: 1.7; }
@@ -158,6 +159,8 @@
         .two-col-text pre { font-size: 0.75rem; }
         .nav-links { gap: 0.75rem; font-size: 0.8rem; }
         .footer { flex-direction: column; text-align: center; }
+        /* wrap code blocks instead of overflowing/scrolling, so they fit the viewport */
+        .hero pre, .two-col-text pre { white-space: pre-wrap; overflow-wrap: anywhere; overflow-x: visible; }
       }
     </style>
   </head>


### PR DESCRIPTION
Fixes horizontal overflow on the landing page on mobile.

**Cause:** grid items default to `min-width:auto`, so the wide `<pre>` blocks (the install command and the `micro run` sample) forced their `.two-col` row wider than the viewport. `body { overflow-x:hidden }` then clipped it — hence "overflows but no scroll, doesn't fit."

**Fix:**
- `.two-col > * { min-width: 0 }` — let grid items shrink to the track.
- On mobile, `.hero pre, .two-col-text pre { white-space: pre-wrap; overflow-wrap: anywhere; overflow-x: visible }` — code blocks wrap to fit instead of overflowing or scrolling.

Now every section fits the viewport width with no horizontal overflow or scroll. Jekyll-verified; no fixed-px-width elements remain in the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_