### PR TITLE
ci: gate Codex dispatch on CODEX_TRIGGER_TOKEN secret

### DIFF
--- a/.github/workflows/continuous-improvement.yml
+++ b/.github/workflows/continuous-improvement.yml
@@ -7,9 +7,11 @@ name: Continuous Improvement
 # Codex rather than Claude Code: on a cadence this posts an @codex instruction on
 # the tracker issue (#3024), and Codex runs one improvement increment + opens a PR.
 #
-# NOTE: this posts as the github-actions bot. If Codex only responds to a human
-# account, add a CODEX_TRIGGER_TOKEN secret (a PAT for a user Codex follows) — the
-# step below already prefers it over the default token.
+# Codex does NOT respond to comments authored by the github-actions bot, so the
+# dispatch is GATED on a CODEX_TRIGGER_TOKEN secret (a PAT for a user account Codex
+# follows). Until that secret is set the workflow runs but no-ops — this avoids
+# piling up @codex comments that Codex silently ignores. The moment the secret is
+# added the loop activates with no further change.
 
 on:
   workflow_dispatch: {}
@@ -30,6 +32,14 @@ jobs:
       - name: Ask Codex to run one increment
         env:
           GH_TOKEN: ${{ secrets.CODEX_TRIGGER_TOKEN || github.token }}
+          HAS_TRIGGER_TOKEN: ${{ secrets.CODEX_TRIGGER_TOKEN != '' }}
         run: |
+          if [ "$HAS_TRIGGER_TOKEN" != "true" ]; then
+            echo "CODEX_TRIGGER_TOKEN is not set — skipping dispatch."
+            echo "Codex ignores comments from the github-actions bot, so posting now"
+            echo "would only create noise. Add a CODEX_TRIGGER_TOKEN secret (a PAT for"
+            echo "a user account Codex follows) to activate the loop."
+            exit 0
+          fi
           gh issue comment 3024 --repo "${{ github.repository }}" --body \
           "@codex Run one continuous-improvement increment per internal/docs/CONTINUOUS_IMPROVEMENT.md, aligned to the North Star in internal/docs/THESIS.md (the holistic services → agents → workflows lifecycle). Pick the single highest-value roadmap/issue/improvement-radar item that advances that thesis, implement it, verify \`go build ./...\`, \`go test ./...\`, and \`golangci-lint run ./...\`, and open a PR against master. One concern per PR; stay out of brand/positioning copy and breaking public API."

--- a/internal/docs/THESIS.md
+++ b/internal/docs/THESIS.md
@@ -27,6 +27,33 @@ Value is unlocked in order, and each layer needs the one beneath it:
 A harness that stops at "a model in a loop" is incomplete. The point is the whole
 lifecycle — capability, intelligence, and orchestration as one runtime.
 
+## Where we fit — complementary, not competing
+
+"Agent = Model + Harness" ([LangChain](https://www.langchain.com/blog/the-anatomy-of-an-agent-harness))
+is the right frame, but *harness* has two layers, and we own the second:
+
+- **The intra-agent harness** — the runtime around a *single model*: system prompt,
+  tools, context compaction, sandbox, self-verification, and the continuation
+  ("Ralph") loop. LangChain / LangGraph, deepagents, and Claude Code do this well.
+  **We do not compete here.**
+- **The operational harness** — the distributed substrate agents *operate inside*:
+  services as typed tools, discovery and RPC, durable and resumable runs,
+  observability, scheduling, and the protocols agents use to reach each other. The
+  place a single agent becomes part of a system, and many agents, services, and
+  workflows compose. **This is Go Micro's focus.**
+
+They stack. An intra-agent harness produces an agent; Go Micro is where that agent
+runs as a first-class service and gets composed into workflows with other services
+and agents. They plug together through open protocols — a LangGraph or deepagents
+agent is reachable over A2A and consumes Go Micro tools over MCP, and the reverse.
+We make those agents better neighbours, not obsolete.
+
+So the focus is deliberately narrow: **the operational harness for Go, and the
+services → agents → workflows lifecycle** — not a model-orchestration framework, not
+a graph DSL, not a prompt layer. Lead with interop and the distributed substrate;
+treat LangChain-class tools as complements to build alongside, never as targets to
+replace.
+
 ## Why now
 
 The frontier is moving from chat to **scheduled, looping, work-performing agents**:


### PR DESCRIPTION
Codex ignores `@codex` comments authored by the `github-actions` bot, so the hourly continuous-improvement dispatch was producing no PRs while still posting to tracker issue #3024.

This gates the comment step on the presence of a `CODEX_TRIGGER_TOKEN` secret (a PAT for a user account Codex follows):

- While the secret is unset, the workflow runs but **no-ops** — avoiding a pile-up of `@codex` comments Codex silently ignores.
- The moment the secret is added, the loop **activates automatically** with no further change (the step already prefers `CODEX_TRIGGER_TOKEN` over `github.token`).

The secret is now set, so on the next scheduled run the dispatch will post as a user account and Codex should respond with a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_