### PR TITLE
fix: harden flow step execution against nil Run and cancellation

### DIFF
--- a/flow/steps.go
+++ b/flow/steps.go
@@ -390,13 +390,24 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 }
 
 // runStep runs one step, retrying on error up to the resolved retry count.
+// A step with no Run function is a configuration error, and a canceled run
+// stops retrying immediately rather than burning the rest of its budget.
 func (f *Flow) runStep(ctx context.Context, step Step, in State) (State, int, error) {
+	if step.Run == nil {
+		return in, 0, fmt.Errorf("flow: step %q has no Run function", step.Name)
+	}
 	retries := f.opts.Retry
 	if step.Retry > 0 {
 		retries = step.Retry
 	}
 	var lastErr error
 	for attempt := 1; attempt <= retries+1; attempt++ {
+		// Stop the moment the run's context is canceled or its deadline
+		// passes — a canceled run shouldn't keep retrying, and the context
+		// error is surfaced so callers can detect cancellation upstream.
+		if err := ctx.Err(); err != nil {
+			return in, attempt - 1, err
+		}
 		out, err := step.Run(ctx, in)
 		if err == nil {
 			return out, attempt, nil

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -129,6 +129,49 @@ func TestFlowStepRetryOverride(t *testing.T) {
 	}
 }
 
+// A canceled run stops retrying immediately instead of burning the whole
+// retry budget, and surfaces the context error.
+func TestFlowStepRetryStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var attempts int
+	step := Step{Name: "cancelaware", Run: func(_ context.Context, in State) (State, error) {
+		attempts++
+		cancel() // the run is canceled while this step is in flight
+		return in, errors.New("transient")
+	}}
+
+	f := New("cancelretry",
+		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "cancelretry")),
+		Retry(5), // would be 6 tries without the cancellation check
+		Steps(step),
+	)
+
+	err := f.Execute(ctx, "")
+	if err == nil {
+		t.Fatal("expected the canceled run to fail")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("want a context.Canceled error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("cancellation should stop retries after the first attempt, got %d", attempts)
+	}
+}
+
+// A step with no Run function is reported as a configuration error rather
+// than panicking the run.
+func TestFlowStepNilRun(t *testing.T) {
+	f := New("nilstep",
+		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "nilstep")),
+		Steps(Step{Name: "missing"}),
+	)
+	err := f.Execute(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected an error for a step with no Run function")
+	}
+}
+
 func TestStateSetScan(t *testing.T) {
 	var s State
 	type payload struct {


### PR DESCRIPTION
Codex produced this increment but its output never reached the remote — it committed `6b6bae6` inside its sandbox and reported "opened a PR," but no branch was pushed and no PR exists (the Codex connector can comment on issues but lacks push / PR-creation permission). Re-landing the change here so the increment isn't lost.

Hardens `Flow.runStep`:

- **Nil `Run` guard** — a `Step` with no `Run` function panicked the run. It now returns a clear configuration error (`flow: step %q has no Run function`).
- **Cancellation-aware retries** — the retry loop kept retrying after the run's context was canceled or its deadline passed, burning the whole retry budget. It now checks `ctx.Err()` before each attempt, stops immediately, and surfaces the context error so callers can detect cancellation/deadline upstream (`errors.Is(err, context.Canceled)`).

Adds regression tests for both: `TestFlowStepRetryStopsOnCancel` and `TestFlowStepNilRun`.

Verified: `go build ./...`, `go test ./flow/`, `golangci-lint run ./flow/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_