### PR TITLE
Harden flow step cancellation

### DIFF
--- a/flow/steps.go
+++ b/flow/steps.go
@@ -391,12 +391,20 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 
 // runStep runs one step, retrying on error up to the resolved retry count.
 func (f *Flow) runStep(ctx context.Context, step Step, in State) (State, int, error) {
+	if step.Run == nil {
+		return in, 0, fmt.Errorf("flow step %q has no Run function", step.Name)
+	}
+
 	retries := f.opts.Retry
 	if step.Retry > 0 {
 		retries = step.Retry
 	}
 	var lastErr error
 	for attempt := 1; attempt <= retries+1; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return in, attempt - 1, err
+		}
+
 		out, err := step.Run(ctx, in)
 		if err == nil {
 			return out, attempt, nil

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -145,3 +145,35 @@ func TestStateSetScan(t *testing.T) {
 		t.Errorf("round-trip failed: %+v", got)
 	}
 }
+
+func TestFlowStepStopsRetryingWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var attempts int
+	step := Step{Name: "cancel", Run: func(_ context.Context, in State) (State, error) {
+		attempts++
+		cancel()
+		return in, errors.New("transient")
+	}}
+
+	f := New("cancel-retry",
+		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "cancel-retry")),
+		Retry(5),
+		Steps(step),
+	)
+	if err := f.Execute(ctx, ""); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute error = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Errorf("canceled flow should not retry; got %d attempts", attempts)
+	}
+}
+
+func TestFlowStepRequiresRunFunc(t *testing.T) {
+	f := New("nil-step",
+		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "nil-step")),
+		Steps(Step{Name: "missing"}),
+	)
+	if err := f.Execute(context.Background(), ""); err == nil {
+		t.Fatal("expected missing Run function error")
+	}
+}


### PR DESCRIPTION
### Motivation
- Improve robustness of the stepped flow execution path by ensuring cancellation semantics are respected during retries and avoiding panics when a step is misconfigured.

### Description
- Return a clear error when a `Step` has no `Run` function instead of panicking by adding a nil check in `runStep` in `flow/steps.go`.
- Stop retrying a failing step once the execution context is canceled by checking `ctx.Err()` before each retry in `runStep`.
- Add `TestFlowStepStopsRetryingWhenContextCanceled` and `TestFlowStepRequiresRunFunc` in `flow/steps_test.go` to cover cancellation-aware retry behavior and nil-step validation.
- Files changed: `flow/steps.go` and `flow/steps_test.go`.

### Testing
- Ran `go test ./flow` and the flow package tests passed.
- Ran `go build ./...` and the build succeeded.
- Ran `go test ./...` but unrelated networking/harness tests failed in this environment due to loopback/gRPC restrictions (Envoy `Loopback targets forbidden`), not regressions from these changes.
- Ran `golangci-lint run ./...` and lint reported `0 issues`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0fe6320883308900c6c8e9cb3bbe)