### PR TITLE
website: h1 → "An Agent Harness for Go"

### DIFF
--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -170,7 +170,7 @@
 
     <section class="hero">
       <div class="hero-inner">
-        <h1>An Agent Harness and Service Framework</h1>
+        <h1>An Agent Harness for Go</h1>
         <p class="tagline">Build agents, services, and workflows on one runtime.</p>
         <img src="/images/generated/hero.jpg" alt="Go Micro — an agent orchestrating services" style="width: 100%; max-width: 600px; height: auto; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.08); margin: 0.5rem auto 1.5rem;" />
         <pre>curl -fsSL https://go-micro.dev/install.sh | sh</pre>


### PR DESCRIPTION
Updates the landing-page hero headline to **"An Agent Harness for Go"** (was "An Agent Harness and Service Framework"). The `<title>` tag already matched this framing. Tagline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_