### PR TITLE
Make agent run timelines deterministic

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	"go-micro.dev/v6/ai"
@@ -186,6 +187,7 @@ func LoadRunEvents(s store.Store, agentName, runID string) ([]RunEvent, error) {
 	if err != nil {
 		return nil, err
 	}
+	sort.Strings(keys)
 	events := make([]RunEvent, 0, len(keys))
 	for _, k := range keys {
 		recs, err := st.Read(k)

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -2,7 +2,9 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/store"
@@ -78,5 +80,39 @@ func TestAgentOpenTelemetryNoopWhenUnconfigured(t *testing.T) {
 	}
 	if _, ok := a.(*agentImpl).model.(*tracedModel); ok {
 		t.Fatal("model should not be wrapped when TraceProvider is nil")
+	}
+}
+
+func TestLoadRunEventsSortsTimelineKeys(t *testing.T) {
+	st := store.NewMemoryStore()
+	scoped := store.Scope(st, "agent", "runner")
+	runID := "run-1"
+	events := []RunEvent{
+		{Time: time.Unix(0, 3), RunID: runID, Agent: "runner", Kind: "tool", Name: "third"},
+		{Time: time.Unix(0, 1), RunID: runID, Agent: "runner", Kind: "run", Name: "first"},
+		{Time: time.Unix(0, 2), RunID: runID, Agent: "runner", Kind: "model", Name: "second"},
+	}
+	for _, e := range events {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		key := "runs/" + runID + "/" + e.Time.Format("20060102150405.000000000") + "-" + e.Kind
+		if err := scoped.Write(&store.Record{Key: key, Value: b}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := LoadRunEvents(st, "runner", runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d events, want 3", len(got))
+	}
+	for i, want := range []string{"first", "second", "third"} {
+		if got[i].Name != want {
+			t.Fatalf("event %d = %q, want %q (timeline: %#v)", i, got[i].Name, want, got)
+		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Ensure observability timelines are stable across different store backends by deterministically ordering persisted run-event keys before loading them and add regression coverage for this behavior.

### Description
- Sort persisted run-event keys in `LoadRunEvents` (add `sort.Strings(keys)` and import) in `agent/otel.go`, and add `TestLoadRunEventsSortsTimelineKeys` in `agent/otel_test.go` that writes events out-of-order and verifies chronological loading.

### Testing
- Ran `go test ./agent` (passed), `go build ./...` (passed), `go test -timeout=2m ./...` (environment-level loopback/gRPC tests failed with Envoy `Loopback targets forbidden`, unrelated to this change), and `golangci-lint run ./...` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c29d2e4248330a473251fbd928258)