### PR TITLE
Make flow checkpoint listing deterministic

### DIFF
--- a/flow/steps.go
+++ b/flow/steps.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"text/template"
 	"time"
 
@@ -149,6 +150,12 @@ func (c *storeCheckpoint) List(ctx context.Context) ([]Run, error) {
 			runs = append(runs, run)
 		}
 	}
+	sort.SliceStable(runs, func(i, j int) bool {
+		if runs[i].Started.Equal(runs[j].Started) {
+			return runs[i].ID < runs[j].ID
+		}
+		return runs[i].Started.Before(runs[j].Started)
+	})
 	return runs, nil
 }
 

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"go-micro.dev/v6/store"
 )
@@ -169,6 +170,36 @@ func TestFlowStepNilRun(t *testing.T) {
 	err := f.Execute(context.Background(), "")
 	if err == nil {
 		t.Fatal("expected an error for a step with no Run function")
+	}
+}
+
+func TestStoreCheckpointListReturnsRunsInStartedOrder(t *testing.T) {
+	cp := StoreCheckpoint(store.NewMemoryStore(), "ordered")
+	ctx := context.Background()
+	base := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	runs := []Run{
+		{ID: "run-c", Flow: "ordered", Status: "failed", Started: base.Add(2 * time.Minute)},
+		{ID: "run-a", Flow: "ordered", Status: "failed", Started: base},
+		{ID: "run-b", Flow: "ordered", Status: "failed", Started: base.Add(time.Minute)},
+	}
+	for _, run := range runs {
+		if err := cp.Save(ctx, run); err != nil {
+			t.Fatalf("Save(%s): %v", run.ID, err)
+		}
+	}
+
+	got, err := cp.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("List returned %d runs, want 3", len(got))
+	}
+	want := []string{"run-a", "run-b", "run-c"}
+	for i, id := range want {
+		if got[i].ID != id {
+			t.Fatalf("run %d = %q, want %q (all runs: %+v)", i, got[i].ID, id, got)
+		}
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Store-backed flow checkpoints can be returned in non-deterministic order depending on backend key iteration, which breaks chronological observability and makes pending-run timelines unstable.
- Consumers expect `Checkpoint.List` to return a durable run timeline in start-time order so UI/metrics and resumption logic are consistent across stores.

### Description
- Sort runs returned by `StoreCheckpoint.List` using `sort.SliceStable` so results are ordered by `Run.Started` and tie-broken by `Run.ID` for stability.
- Added an import for `sort` and the ordering logic inside `flow` package's `storeCheckpoint.List` implementation.
- Added regression test `TestStoreCheckpointListReturnsRunsInStartedOrder` in `flow/steps_test.go` that saves runs out-of-order and verifies `List` returns them in started order.

### Testing
- Ran `go build ./...` and it succeeded.
- Ran `go test ./flow` and the flow package tests passed, including the new regression test.
- Ran `golangci-lint run ./...` and the linter passed with no issues.
- Attempted `go test ./...` but top-level test run hit unrelated environment/networking failures (Envoy "Loopback targets forbidden") in packages such as `client/grpc` and `gateway/a2a`, causing the full test sweep to report failures unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c38ccb3b083309f7ff637aec1b3e3)