### PR TITLE
docs: align continuous improvement scheduler notes

### DIFF
--- a/internal/docs/CONTINUOUS_IMPROVEMENT.md
+++ b/internal/docs/CONTINUOUS_IMPROVEMENT.md
@@ -68,8 +68,12 @@ Grounded in real signal, never speculative rewrites. Each cycle draws from:
   alive. Convenient, but the remote environment is reclaimed on inactivity and
   recurring jobs expire after 7 days, so it is **not** a durable scheduler.
 - **GitHub Actions (durable)** — a scheduled workflow that runs the loop
-  independently of any session. This is the real backbone; it needs an
-  `ANTHROPIC_API_KEY` repo secret. See `.github/workflows/continuous-improvement.yml`.
+  independently of any session. This is the real backbone; it opens a fresh
+  tracking issue for each increment and dispatches Codex there, so every run gets
+  a unique Codex-derived branch and a PR that closes its tracking issue. It needs
+  a `CODEX_TRIGGER_TOKEN` repo secret from a user account Codex responds to;
+  without that secret the workflow deliberately no-ops to avoid ignored bot
+  comments. See `.github/workflows/continuous-improvement.yml`.
 
 ## Stop / redirect
 


### PR DESCRIPTION
### Motivation
- Clarify the continuous-improvement scheduler documentation to match the durable GitHub Actions flow so each increment opens a fresh tracking issue (producing unique `codex/*` branches) and to document the required `CODEX_TRIGGER_TOKEN` and intentional no-op behavior when it is absent.

### Description
- Update `internal/docs/CONTINUOUS_IMPROVEMENT.md` to explain that the GitHub Actions workflow opens a fresh tracking issue per increment, dispatches `@codex` there, requires a `CODEX_TRIGGER_TOKEN` from a user account Codex responds to, and deliberately no-ops when that token is not set, with a pointer to `.github/workflows/continuous-improvement.yml`.

### Testing
- Ran `git diff --check` (clean) and started `go test ./...`, which was initiated but did not complete in this environment; this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c423862c08330998271eec5d9395b)