### PR TITLE
Expose agent run IDs on Ask responses

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -52,6 +52,12 @@ type Response struct {
 	Reply     string
 	ToolCalls []ai.ToolCall
 	Agent     string
+
+	// RunID correlates this Ask with tool calls, trace spans, and the
+	// persisted run timeline. ParentID is set when this response belongs
+	// to a delegated sub-agent run.
+	RunID    string
+	ParentID string
 }
 
 type agentImpl struct {
@@ -221,6 +227,8 @@ func (a *agentImpl) Ask(ctx context.Context, message string) (*Response, error) 
 		Reply:     reply,
 		ToolCalls: resp.ToolCalls,
 		Agent:     a.opts.Name,
+		RunID:     a.runID,
+		ParentID:  a.parentRunID,
 	}, nil
 }
 

--- a/agent/wrap_test.go
+++ b/agent/wrap_test.go
@@ -146,7 +146,8 @@ func TestWrapToolSeesRunInfo(t *testing.T) {
 		}),
 	)
 
-	if _, err := a.Ask(context.Background(), "go"); err != nil {
+	resp, err := a.Ask(context.Background(), "go")
+	if err != nil {
 		t.Fatalf("Ask: %v", err)
 	}
 	if !ok {
@@ -157,6 +158,12 @@ func TestWrapToolSeesRunInfo(t *testing.T) {
 	}
 	if got.RunID == "" {
 		t.Error("RunInfo.RunID is empty")
+	}
+	if resp.RunID != got.RunID {
+		t.Errorf("Response.RunID = %q, want wrapper RunID %q", resp.RunID, got.RunID)
+	}
+	if resp.ParentID != "" {
+		t.Errorf("Response.ParentID = %q, want empty", resp.ParentID)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Callers and tool wrappers need a stable correlation ID to tie an `Ask` response to the run timeline, tool calls, and OpenTelemetry spans. 
- Surface the agent run lineage (`RunID` / `ParentID`) directly on responses so external middleware and consumers can correlate results without relying on internal context plumbing.

### Description
- Add `RunID` and `ParentID` fields to `agent.Response` and populate them from the agent's active run when returning from `Agent.Ask`.
- Update the `TestWrapToolSeesRunInfo` wrapper test to assert the `Response.RunID` matches the `RunInfo` observed by tool middleware and that top-level responses have an empty `ParentID`.
- PR description includes `Closes #3041` to track the request/issue this change addresses.

### Testing
- Ran `go test ./agent`, which passed successfully. 
- Ran `go build ./...`, which completed successfully. 
- Ran `go test ./...`, which exercised the repo but failed in this environment due to unrelated environment-sensitive issues (loopback/Envoy restrictions and a flaky cache expiry assertion). 
- Ran `golangci-lint run ./...`, which reported `0 issues`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c45c00a08833089800da6652ff277)