### PR TITLE
Improve durable flow run inspection

### DIFF
--- a/cmd/micro/flow/flow.go
+++ b/cmd/micro/flow/flow.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -72,7 +73,10 @@ Examples:
 				Name:      "runs",
 				Usage:     "Show durable run history for a flow",
 				ArgsUsage: "[name]",
-				Action:    flowRuns,
+				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "json", Usage: "Print durable run history as JSON for automation"},
+				},
+				Action: flowRuns,
 			},
 		},
 	})
@@ -129,6 +133,15 @@ func flowRuns(c *cli.Context) error {
 		fmt.Printf("  No runs recorded for flow %q.\n", name)
 		return nil
 	}
+	return writeFlowRuns(os.Stdout, runs, c.Bool("json"))
+}
+
+func writeFlowRuns(w io.Writer, runs []aiflow.Run, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(runs)
+	}
 	for _, r := range runs {
 		id := r.ID
 		if len(id) > 8 {
@@ -138,7 +151,15 @@ func flowRuns(c *cli.Context) error {
 		if stage == "" {
 			stage = "-"
 		}
-		fmt.Printf("  %s  %-8s stage=%-12s (%d steps)\n", id, r.Status, stage, len(r.Steps))
+		fmt.Fprintf(w, "  %s  %-8s stage=%-12s updated=%s (%d steps)\n",
+			id, r.Status, stage, r.Updated.Format("2006-01-02T15:04:05Z07:00"), len(r.Steps))
+		for _, step := range r.Steps {
+			fmt.Fprintf(w, "    - %-12s %-11s attempts=%d", step.Name, step.Status, step.Attempts)
+			if step.Error != "" {
+				fmt.Fprintf(w, " error=%q", step.Error)
+			}
+			fmt.Fprintln(w)
+		}
 	}
 	return nil
 }

--- a/cmd/micro/flow/flow_test.go
+++ b/cmd/micro/flow/flow_test.go
@@ -1,0 +1,57 @@
+package flow
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	aiflow "go-micro.dev/v6/flow"
+)
+
+func TestWriteFlowRunsIncludesStepDetails(t *testing.T) {
+	updated := time.Date(2026, 6, 24, 12, 30, 0, 0, time.UTC)
+	runs := []aiflow.Run{{
+		ID:      "1234567890abcdef",
+		Status:  "failed",
+		Updated: updated,
+		State:   aiflow.State{Stage: "charge"},
+		Steps: []aiflow.StepRecord{
+			{Name: "reserve", Status: "done", Attempts: 1},
+			{Name: "charge", Status: "failed", Attempts: 3, Error: "card declined"},
+		},
+	}}
+
+	var out bytes.Buffer
+	if err := writeFlowRuns(&out, runs, false); err != nil {
+		t.Fatalf("writeFlowRuns: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"12345678  failed   stage=charge",
+		"updated=2026-06-24T12:30:00Z",
+		"- reserve      done        attempts=1",
+		`- charge       failed      attempts=3 error="card declined"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteFlowRunsJSON(t *testing.T) {
+	runs := []aiflow.Run{{ID: "run-1", Flow: "checkout", Status: "done"}}
+
+	var out bytes.Buffer
+	if err := writeFlowRuns(&out, runs, true); err != nil {
+		t.Fatalf("writeFlowRuns: %v", err)
+	}
+	var got []aiflow.Run
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if len(got) != 1 || got[0].ID != "run-1" || got[0].Flow != "checkout" || got[0].Status != "done" {
+		t.Fatalf("decoded runs = %+v", got)
+	}
+}


### PR DESCRIPTION
### Motivation

- Make durable flow run history consumable by automation and improve operator observability for resumable, multi-step flows.
- Provide richer, easier-to-parse output so operators can inspect run state, per-step status, and errors quickly.

### Description

- Add a `--json` flag to `micro flow runs` to emit the durable run history as JSON for automation consumers, and wire the flag into the CLI command handler. (changes in `cmd/micro/flow/flow.go`)
- Introduce `writeFlowRuns` which prints either indented JSON or an enhanced text view that includes an `updated=` timestamp and per-step lines with status, attempts, and any error text. (changes in `cmd/micro/flow/flow.go`)
- Add focused tests validating both the detailed text output and JSON output for run history in `cmd/micro/flow/flow_test.go`.
- Closes #3042

### Testing

- Ran `go test ./cmd/micro/flow` and the new package tests passed.
- Ran `go build ./...` which completed successfully.
- Ran `golangci-lint run ./...` which reported `0 issues`.
- Ran `go test ./...` which surfaced unrelated failures in existing grpc/A2A/harness loopback tests due to the execution environment forbidding loopback targets; these failures are not caused by the CLI formatting changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c527bfaf48330a711d4ecd85ad211)