### PR TITLE
flow: add pending run resume helper

### DIFF
--- a/flow/steps.go
+++ b/flow/steps.go
@@ -323,6 +323,27 @@ func (f *Flow) Resume(ctx context.Context, runID string) error {
 	return err
 }
 
+// ResumePending resumes every checkpointed run for this flow that has not
+// completed yet, in the same oldest-first order returned by Pending.
+//
+// It is a convenience for service startup and recovery loops: after a process
+// restart, call ResumePending to drain the durable backlog without having to
+// list and resume each run manually. If any run fails again, ResumePending
+// stops and returns that run id with the error so callers can log, alert, or
+// retry later without hiding the failing run.
+func (f *Flow) ResumePending(ctx context.Context) (string, error) {
+	runs, err := f.Pending(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, run := range runs {
+		if err := f.Resume(ctx, run.ID); err != nil {
+			return run.ID, err
+		}
+	}
+	return "", nil
+}
+
 // Pending returns this flow's runs that have not completed — the ones a
 // process restart should resume.
 func (f *Flow) Pending(ctx context.Context) ([]Run, error) {

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -86,6 +86,80 @@ func TestFlowCheckpointResume(t *testing.T) {
 	}
 }
 
+func TestFlowResumePendingResumesOldestRunsUntilFailure(t *testing.T) {
+	mem := store.NewMemoryStore()
+	ctx := context.Background()
+	var calls int
+	step := Step{Name: "work", Run: func(_ context.Context, in State) (State, error) {
+		calls++
+		if in.String() == "block" {
+			return in, errors.New("still blocked")
+		}
+		in.Data = []byte(in.String() + "-done")
+		return in, nil
+	}}
+	f := New("resume-pending", WithCheckpoint(StoreCheckpoint(mem, "resume-pending")), Steps(step))
+
+	base := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	runs := []Run{
+		{
+			ID:      "run-ok",
+			Flow:    "resume-pending",
+			State:   State{Stage: "work", Data: []byte("ok")},
+			Steps:   []StepRecord{{Name: "work", Status: "failed", Error: "temporary"}},
+			Status:  "failed",
+			Started: base,
+		},
+		{
+			ID:      "run-blocked",
+			Flow:    "resume-pending",
+			State:   State{Stage: "work", Data: []byte("block")},
+			Steps:   []StepRecord{{Name: "work", Status: "failed", Error: "temporary"}},
+			Status:  "failed",
+			Started: base.Add(time.Minute),
+		},
+		{
+			ID:      "run-later",
+			Flow:    "resume-pending",
+			State:   State{Stage: "work", Data: []byte("later")},
+			Steps:   []StepRecord{{Name: "work", Status: "failed", Error: "temporary"}},
+			Status:  "failed",
+			Started: base.Add(2 * time.Minute),
+		},
+	}
+	for _, run := range runs {
+		if err := f.checkpoint.Save(ctx, run); err != nil {
+			t.Fatalf("Save(%s): %v", run.ID, err)
+		}
+	}
+
+	failedRun, err := f.ResumePending(ctx)
+	if err == nil {
+		t.Fatal("expected ResumePending to stop at the blocked run")
+	}
+	if failedRun != "run-blocked" {
+		t.Fatalf("failed run = %q, want run-blocked", failedRun)
+	}
+	if calls != 2 {
+		t.Fatalf("ResumePending should stop before later runs; got %d calls", calls)
+	}
+
+	run, ok, err := f.checkpoint.Load(ctx, "run-ok")
+	if err != nil || !ok {
+		t.Fatalf("Load(run-ok) ok=%v err=%v", ok, err)
+	}
+	if run.Status != "done" || run.State.String() != "ok-done" {
+		t.Fatalf("run-ok not resumed successfully: %+v", run)
+	}
+	run, ok, err = f.checkpoint.Load(ctx, "run-later")
+	if err != nil || !ok {
+		t.Fatalf("Load(run-later) ok=%v err=%v", ok, err)
+	}
+	if run.Status != "failed" {
+		t.Fatalf("run-later should not be resumed after a failure, got %+v", run)
+	}
+}
+
 // A flow-level Retry re-runs a failing step until it succeeds.
 func TestFlowStepRetry(t *testing.T) {
 	var attempts int


### PR DESCRIPTION
### Motivation
- Provide a simple recovery helper for services to resume durable flow runs after a restart so the backlog is drained without manual listing and individual resumes. 
- Keep the change small and non-breaking by adding a convenience API that stops on the first failing run so callers can handle stuck runs explicitly.

### Description
- Add `Flow.ResumePending(ctx) (string, error)` to `flow/steps.go` to resume checkpointed unfinished runs in oldest-first order and return the failing run ID on error. 
- Add unit test `TestFlowResumePendingResumesOldestRunsUntilFailure` in `flow/steps_test.go` verifying ordering, stop-on-failure semantics, and that later runs are not resumed after a failure. 
- Commit message and PR include `Closes #3045` to link the change to the tracker.

### Testing
- Ran `go build ./...` which succeeded. 
- Ran `go test ./flow -run TestFlowResumePendingResumesOldestRunsUntilFailure -v -count=1` which passed. 
- Ran `go test ./...` which surfaced unrelated environment failures in existing network/loopback-dependent tests (e.g. grpc/A2A harness tests) due to the test environment blocking loopback targets. 
- Ran `golangci-lint run ./...` which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c5f71fdb88330ac22fe3a5ee6ee21)