### PR TITLE
Add deterministic agent run summaries and show summaries in CLI run index

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"go-micro.dev/v6/ai"
@@ -52,6 +53,18 @@ type RunEvent struct {
 }
 
 type Usage = ai.Usage
+
+// RunSummary is a compact index entry for a recorded agent run.
+type RunSummary struct {
+	RunID     string    `json:"run_id"`
+	Agent     string    `json:"agent"`
+	ParentID  string    `json:"parent_id,omitempty"`
+	StartedAt time.Time `json:"started_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Events    int       `json:"events"`
+	LastKind  string    `json:"last_kind,omitempty"`
+	LastError string    `json:"last_error,omitempty"`
+}
 
 func (a *agentImpl) tracer() trace.Tracer {
 	return a.opts.TraceProvider.Tracer(agentInstrumentationName)
@@ -179,6 +192,63 @@ func (a *agentImpl) recordRunEvent(e RunEvent) {
 	b, _ := json.Marshal(e)
 	key := fmt.Sprintf("runs/%s/%020d-%s", e.RunID, e.Time.UnixNano(), e.Kind)
 	_ = a.stateStore().Write(&store.Record{Key: key, Value: b})
+}
+
+// ListRunSummaries returns a deterministic summary of recorded runs for agentName.
+func ListRunSummaries(s store.Store, agentName string) ([]RunSummary, error) {
+	st := store.Scope(s, "agent", agentName)
+	keys, err := st.List(store.ListPrefix("runs/"))
+	if err != nil {
+		return nil, err
+	}
+	runs := map[string]bool{}
+	for _, k := range keys {
+		parts := strings.Split(k, "/")
+		if len(parts) >= 2 && parts[1] != "" {
+			runs[parts[1]] = true
+		}
+	}
+	ids := make([]string, 0, len(runs))
+	for id := range runs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	summaries := make([]RunSummary, 0, len(ids))
+	for _, id := range ids {
+		events, err := LoadRunEvents(s, agentName, id)
+		if err != nil {
+			return nil, err
+		}
+		if len(events) == 0 {
+			continue
+		}
+		first := events[0]
+		last := events[len(events)-1]
+		summary := RunSummary{
+			RunID:     id,
+			Agent:     first.Agent,
+			ParentID:  first.ParentID,
+			StartedAt: first.Time,
+			UpdatedAt: last.Time,
+			Events:    len(events),
+			LastKind:  last.Kind,
+			LastError: last.Error,
+		}
+		for _, e := range events {
+			if e.Agent != "" {
+				summary.Agent = e.Agent
+			}
+			if e.ParentID != "" {
+				summary.ParentID = e.ParentID
+			}
+			if e.Error != "" {
+				summary.LastError = e.Error
+			}
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries, nil
 }
 
 func LoadRunEvents(s store.Store, agentName, runID string) ([]RunEvent, error) {

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -116,3 +116,38 @@ func TestLoadRunEventsSortsTimelineKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestListRunSummaries(t *testing.T) {
+	st := store.NewMemoryStore()
+	scoped := store.Scope(st, "agent", "runner")
+	events := []RunEvent{
+		{Time: time.Unix(0, 1), RunID: "run-a", Agent: "runner", Kind: "run", Name: "first"},
+		{Time: time.Unix(0, 2), RunID: "run-a", Agent: "runner", Kind: "tool", Name: "probe"},
+		{Time: time.Unix(0, 3), RunID: "run-b", Agent: "runner", ParentID: "parent", Kind: "run", Name: "second"},
+		{Time: time.Unix(0, 4), RunID: "run-b", Agent: "runner", ParentID: "parent", Kind: "error", Error: "boom"},
+	}
+	for _, e := range events {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		key := "runs/" + e.RunID + "/" + e.Time.Format("20060102150405.000000000") + "-" + e.Kind
+		if err := scoped.Write(&store.Record{Key: key, Value: b}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := ListRunSummaries(st, "runner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d summaries, want 2: %#v", len(got), got)
+	}
+	if got[0].RunID != "run-a" || got[0].Events != 2 || got[0].LastKind != "tool" || !got[0].UpdatedAt.Equal(time.Unix(0, 2)) {
+		t.Fatalf("unexpected run-a summary: %#v", got[0])
+	}
+	if got[1].RunID != "run-b" || got[1].ParentID != "parent" || got[1].Events != 2 || got[1].LastKind != "error" || got[1].LastError != "boom" {
+		t.Fatalf("unexpected run-b summary: %#v", got[1])
+	}
+}

--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -4,8 +4,6 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/urfave/cli/v2"
 	goagent "go-micro.dev/v6/agent"
@@ -127,30 +125,21 @@ func init() {
 }
 
 func printRunIndex(name string) error {
-	st := store.Scope(store.DefaultStore, "agent", name)
-	keys, err := st.List(store.ListPrefix("runs/"))
+	runs, err := goagent.ListRunSummaries(store.DefaultStore, name)
 	if err != nil {
 		return err
-	}
-	runs := map[string]bool{}
-	for _, k := range keys {
-		parts := strings.Split(k, "/")
-		if len(parts) >= 2 {
-			runs[parts[1]] = true
-		}
 	}
 	if len(runs) == 0 {
 		fmt.Printf("  No runs recorded for agent %q.\n", name)
 		return nil
 	}
-	ids := make([]string, 0, len(runs))
-	for id := range runs {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
 	fmt.Println("  Runs:")
-	for _, id := range ids {
-		fmt.Printf("    %s\n", id)
+	for _, run := range runs {
+		line := fmt.Sprintf("    %s  events=%d  last=%s  updated=%s", run.RunID, run.Events, run.LastKind, run.UpdatedAt.Format("2006-01-02 15:04:05"))
+		if run.LastError != "" {
+			line += "  error=" + run.LastError
+		}
+		fmt.Println(line)
 	}
 	return nil
 }


### PR DESCRIPTION
### Motivation
- Provide a compact, deterministic index of recorded agent runs so callers can inspect run IDs along with counts, timestamps, last event kind, and any terminal error without loading full timelines. 
- Make the CLI `micro runs` / `micro agent history` output more informative for quick inspection of runs. 
- Keep the change focused and reversible: surface summaries for discovery while leaving per-run timeline detail unchanged.

### Description
- Add `RunSummary` and `ListRunSummaries(s store.Store, agentName string)` in `agent/otel.go` to enumerate recorded runs deterministically with `RunID`, `Agent`, `ParentID`, `StartedAt`, `UpdatedAt`, `Events`, `LastKind`, and `LastError`.
- Update the CLI index in `cmd/micro/cli/agent/agent.go` so `micro runs` and `micro agent history` call `ListRunSummaries` and print a one-line summary per run including event count, last kind, updated timestamp, and last error.
- Add `TestListRunSummaries` in `agent/otel_test.go` to verify deterministic ordering, event counts, parent propagation, last kind, and last-error propagation from a store-backed timeline.
- This PR includes the new tests and CLI changes and closes the tracker: Closes #3046.

### Testing
- Ran `go test ./agent`, and the agent package tests (including the new `TestListRunSummaries`) passed.
- Ran `go build ./...`, which completed successfully.
- Ran `go test ./...`; several unrelated integration/transport tests failed in this sandboxed environment due to loopback/network restrictions (examples: `client/grpc`, `gateway/a2a`, `internal/harness/*`, and `transport/grpc` reported connection/reset or "Loopback targets forbidden").
- Ran `golangci-lint run ./...` which reported `0 issues`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c6d2cfe9c8330bf58d83ea7b3304a)