### PR TITLE
Add flow retry backoff

### DIFF
--- a/flow/options.go
+++ b/flow/options.go
@@ -1,5 +1,7 @@
 package flow
 
+import "time"
+
 // Options configures a Flow.
 type Options struct {
 	// TriggerTopic is the broker topic that triggers this flow.
@@ -32,6 +34,9 @@ type Options struct {
 	// Retry is the flow-level retry count applied to each step (0 = no
 	// retry). A Step's own Retry field overrides this.
 	Retry int
+	// RetryBackoff is the delay between failed step attempts. Zero means
+	// retry immediately; cancellation/deadline stops the wait early.
+	RetryBackoff time.Duration
 	// Checkpoint is the durability backend for stepped runs. Nil with
 	// steps present means a store-backed default; set it to swap backends.
 	Checkpoint Checkpoint
@@ -106,6 +111,13 @@ func Steps(steps ...Step) Option {
 // retry). A Step's own Retry field overrides this.
 func Retry(n int) Option {
 	return func(o *Options) { o.Retry = n }
+}
+
+// RetryBackoff sets the delay between failed step attempts. A zero
+// duration preserves immediate retries. If the run context is canceled
+// while waiting, the context error is returned instead of retrying.
+func RetryBackoff(d time.Duration) Option {
+	return func(o *Options) { o.RetryBackoff = d }
 }
 
 // WithCheckpoint sets the durability backend. With a checkpoint, a run is

--- a/flow/steps.go
+++ b/flow/steps.go
@@ -441,6 +441,13 @@ func (f *Flow) runStep(ctx context.Context, step Step, in State) (State, int, er
 			return out, attempt, nil
 		}
 		lastErr = err
+		if attempt <= retries && f.opts.RetryBackoff > 0 {
+			select {
+			case <-time.After(f.opts.RetryBackoff):
+			case <-ctx.Done():
+				return in, attempt, ctx.Err()
+			}
+		}
 	}
 	return in, retries + 1, lastErr
 }

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -204,6 +204,62 @@ func TestFlowStepRetryOverride(t *testing.T) {
 	}
 }
 
+func TestFlowStepRetryBackoffWaitsBetweenAttempts(t *testing.T) {
+	var attempts int
+	step := Step{Name: "transient", Run: func(_ context.Context, in State) (State, error) {
+		attempts++
+		if attempts == 1 {
+			return in, errors.New("transient")
+		}
+		in.Data = []byte("ok")
+		return in, nil
+	}}
+
+	f := New("retry-backoff",
+		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "retry-backoff")),
+		Retry(1),
+		RetryBackoff(10*time.Millisecond),
+		Steps(step),
+	)
+	start := time.Now()
+	if err := f.Execute(context.Background(), ""); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("want 2 attempts, got %d", attempts)
+	}
+	if elapsed := time.Since(start); elapsed < 10*time.Millisecond {
+		t.Fatalf("retry backoff was not observed; elapsed %s", elapsed)
+	}
+}
+
+func TestFlowStepRetryBackoffStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var attempts int
+	step := Step{Name: "cancelbackoff", Run: func(_ context.Context, in State) (State, error) {
+		attempts++
+		cancel()
+		return in, errors.New("transient")
+	}}
+
+	f := New("cancel-backoff",
+		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "cancel-backoff")),
+		Retry(1),
+		RetryBackoff(time.Hour),
+		Steps(step),
+	)
+	err := f.Execute(ctx, "")
+	if err == nil {
+		t.Fatal("expected the canceled run to fail")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("want a context.Canceled error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("cancellation should stop during backoff before retrying, got %d attempts", attempts)
+	}
+}
+
 // A canceled run stops retrying immediately instead of burning the whole
 // retry budget, and surfaces the context error.
 func TestFlowStepRetryStopsOnCancel(t *testing.T) {

--- a/micro.go
+++ b/micro.go
@@ -3,6 +3,7 @@ package micro
 
 import (
 	"context"
+	"time"
 
 	"go-micro.dev/v6/agent"
 	"go-micro.dev/v6/ai"
@@ -188,6 +189,9 @@ func FlowSteps(steps ...FlowStep) FlowOption { return flow.Steps(steps...) }
 // FlowRetry sets the flow-level retry count per step (a Step's own Retry
 // overrides it).
 func FlowRetry(n int) FlowOption { return flow.Retry(n) }
+
+// FlowRetryBackoff sets the delay between failed step attempts.
+func FlowRetryBackoff(d time.Duration) FlowOption { return flow.RetryBackoff(d) }
 
 // FlowWithCheckpoint sets the durability backend for stepped runs.
 // Stepped flows default to a store-backed checkpoint.


### PR DESCRIPTION
### Motivation
- Prevent tight immediate-retry loops in durable, stepped flows by adding a configurable backoff between step retry attempts so workflows are kinder to transient dependencies and easier to operate.
- Align the flow retry behavior with the project priorities around durable execution and resilience in `internal/docs/ROADMAP_2026.md` and `internal/docs/DURABLE_EXECUTION_DESIGN.md`.

### Description
- Add `RetryBackoff time.Duration` to `flow.Options` and a `flow.RetryBackoff` Option to configure the delay between failed step attempts (`flow/options.go`).
- Honor `RetryBackoff` in `runStep` so a failed attempt waits the configured duration before retrying, and aborts early if the run context is canceled (`flow/steps.go`).
- Expose a top-level helper `micro.FlowRetryBackoff` to configure backoff from the package-level API (`micro.go`).
- Add tests verifying a delayed successful retry and that cancellation during backoff stops retries (`flow/steps_test.go`).
- Closes #3050

### Testing
- `go build ./...` completed successfully.
- `go test ./flow` passed and the new backoff tests succeeded.
- `go test ./...` in this environment showed unrelated failures in some transport and harness tests due to loopback/proxy restrictions (environment-limited), while the flow package and unit tests passed.
- `golangci-lint run ./...` returned `0 issues`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c82f800e4833098ef8cd83bce1ba7)