### PR TITLE
agent: mark successful run timelines complete

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -80,13 +80,15 @@ func (a *agentImpl) startRun(ctx context.Context, message string) (context.Conte
 	start := time.Now()
 	a.recordRunEvent(RunEvent{Time: start, RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "run", Name: message})
 	return ctx, func(err error) {
-		span.SetAttributes(attribute.Int64(AttrLatencyMS, time.Since(start).Milliseconds()))
+		latency := time.Since(start).Milliseconds()
+		span.SetAttributes(attribute.Int64(AttrLatencyMS, latency))
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "error", Error: err.Error()})
+			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "error", LatencyMS: latency, Error: err.Error()})
 		} else {
 			span.SetStatus(codes.Ok, "")
+			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "done", LatencyMS: latency})
 		}
 		span.End()
 	}

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -63,6 +63,16 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	if len(keys) == 0 {
 		t.Fatal("expected run events to be recorded")
 	}
+	summaries, err := ListRunSummaries(st, "runner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("got %d summaries, want 1", len(summaries))
+	}
+	if summaries[0].LastKind != "done" {
+		t.Fatalf("LastKind = %q, want done", summaries[0].LastKind)
+	}
 }
 
 func TestAgentOpenTelemetryNoopWhenUnconfigured(t *testing.T) {


### PR DESCRIPTION
### Motivation
- Ensure instrumented agent runs record a clear terminal event and latency so run timelines and summaries reflect a completed outcome for successful and failed Ask calls.
- Improve observability for the services → agents → workflows lifecycle by making run summaries deterministic about terminal state.

### Description
- Record a terminal `done` RunEvent with `LatencyMS` when an instrumented `Ask` completes successfully in `agent/otel.go`.
- Preserve and attach the measured `LatencyMS` to terminal `error` RunEvents so both success and failure paths include latency in the timeline in `agent/otel.go`.
- Add a unit assertion that a successful instrumented run yields a `RunSummary` whose `LastKind` is `done` in `agent/otel_test.go`.
- Files changed: `agent/otel.go`, `agent/otel_test.go`.
- Closes #3051.

### Testing
- Ran `go test ./agent` which passed.
- Ran `go build ./...` which completed successfully.
- Ran `go test ./...` which failed in this environment due to unrelated loopback/Envoy restrictions affecting existing gRPC/A2A/harness tests (test failures and transport errors observed), not the changes in this PR.
- Ran `golangci-lint run ./...` which reported `0 issues`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c8f257fec8330a86eff65c9373a7e)