### PR TITLE
Add JSON output for agent run inspection

### DIFF
--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -4,6 +4,8 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/urfave/cli/v2"
 	goagent "go-micro.dev/v6/agent"
@@ -17,15 +19,18 @@ func init() {
 		Name:      "runs",
 		Usage:     "Show recorded agent runs",
 		ArgsUsage: "[agent] [run-id]",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "json", Usage: "Print run data as JSON for automation"},
+		},
 		Action: func(c *cli.Context) error {
 			name := c.Args().First()
 			if name == "" {
 				return fmt.Errorf("usage: micro runs [agent] [run-id]")
 			}
 			if runID := c.Args().Get(1); runID != "" {
-				return printRunHistory(name, runID)
+				return printRunHistory(name, runID, c.Bool("json"))
 			}
-			return printRunIndex(name)
+			return printRunIndex(name, c.Bool("json"))
 		},
 	})
 
@@ -97,13 +102,19 @@ func init() {
 				Name:      "history",
 				Usage:     "Show an agent's stored conversation and run history",
 				ArgsUsage: "[name] [run-id]",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "json", Usage: "Print run data as JSON for automation"},
+				},
 				Action: func(c *cli.Context) error {
 					name := c.Args().First()
 					if name == "" {
 						return fmt.Errorf("usage: micro agent history [name] [run-id]")
 					}
 					if runID := c.Args().Get(1); runID != "" {
-						return printRunHistory(name, runID)
+						return printRunHistory(name, runID, c.Bool("json"))
+					}
+					if c.Bool("json") {
+						return printRunIndex(name, true)
 					}
 					// Read from the agent's scoped state store (database
 					// "agent", table = name) — available whether or not the
@@ -117,40 +128,58 @@ func init() {
 							fmt.Printf("  \033[2m%s:\033[0m %v\n", m.Role, m.Content)
 						}
 					}
-					return printRunIndex(name)
+					return printRunIndex(name, c.Bool("json"))
 				},
 			},
 		},
 	})
 }
 
-func printRunIndex(name string) error {
+func printRunIndex(name string, asJSON bool) error {
 	runs, err := goagent.ListRunSummaries(store.DefaultStore, name)
 	if err != nil {
 		return err
 	}
+	return writeRunIndex(os.Stdout, name, runs, asJSON)
+}
+
+func writeRunIndex(w io.Writer, name string, runs []goagent.RunSummary, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(runs)
+	}
 	if len(runs) == 0 {
-		fmt.Printf("  No runs recorded for agent %q.\n", name)
+		fmt.Fprintf(w, "  No runs recorded for agent %q.\n", name)
 		return nil
 	}
-	fmt.Println("  Runs:")
+	fmt.Fprintln(w, "  Runs:")
 	for _, run := range runs {
 		line := fmt.Sprintf("    %s  events=%d  last=%s  updated=%s", run.RunID, run.Events, run.LastKind, run.UpdatedAt.Format("2006-01-02 15:04:05"))
 		if run.LastError != "" {
 			line += "  error=" + run.LastError
 		}
-		fmt.Println(line)
+		fmt.Fprintln(w, line)
 	}
 	return nil
 }
 
-func printRunHistory(name, runID string) error {
+func printRunHistory(name, runID string, asJSON bool) error {
 	events, err := goagent.LoadRunEvents(store.DefaultStore, name, runID)
 	if err != nil {
 		return err
 	}
+	return writeRunHistory(os.Stdout, name, runID, events, asJSON)
+}
+
+func writeRunHistory(w io.Writer, name, runID string, events []goagent.RunEvent, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(events)
+	}
 	if len(events) == 0 {
-		fmt.Printf("  No run %q for agent %q.\n", runID, name)
+		fmt.Fprintf(w, "  No run %q for agent %q.\n", runID, name)
 		return nil
 	}
 	for _, e := range events {
@@ -173,7 +202,7 @@ func printRunHistory(name, runID string) error {
 		if e.Error != "" {
 			line += " error=" + e.Error
 		}
-		fmt.Println(line)
+		fmt.Fprintln(w, line)
 	}
 	return nil
 }

--- a/cmd/micro/cli/agent/agent_test.go
+++ b/cmd/micro/cli/agent/agent_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	goagent "go-micro.dev/v6/agent"
+	"go-micro.dev/v6/ai"
+)
+
+func TestWriteRunIndexJSON(t *testing.T) {
+	runs := []goagent.RunSummary{{
+		RunID:     "run-1",
+		Agent:     "runner",
+		StartedAt: time.Unix(0, 1),
+		UpdatedAt: time.Unix(0, 2),
+		Events:    2,
+		LastKind:  "tool",
+	}}
+	var out bytes.Buffer
+	if err := writeRunIndex(&out, "runner", runs, true); err != nil {
+		t.Fatal(err)
+	}
+	var got []goagent.RunSummary
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if len(got) != 1 || got[0].RunID != "run-1" || got[0].LastKind != "tool" {
+		t.Fatalf("decoded summaries = %#v", got)
+	}
+}
+
+func TestWriteRunHistoryHumanAndJSON(t *testing.T) {
+	events := []goagent.RunEvent{{
+		Time:      time.Date(2026, 6, 25, 12, 34, 56, 7_000_000, time.UTC),
+		RunID:     "run-1",
+		Agent:     "runner",
+		Kind:      "tool",
+		Name:      "probe",
+		Provider:  "oteltest",
+		Model:     "unit-model",
+		LatencyMS: 42,
+		Tokens:    ai.Usage{TotalTokens: 5},
+	}}
+
+	var human bytes.Buffer
+	if err := writeRunHistory(&human, "runner", "run-1", events, false); err != nil {
+		t.Fatal(err)
+	}
+	line := human.String()
+	for _, want := range []string{"12:34:56.007 tool", "probe", "oteltest/unit-model", "42ms", "tokens=5"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("human output %q missing %q", line, want)
+		}
+	}
+
+	var js bytes.Buffer
+	if err := writeRunHistory(&js, "runner", "run-1", events, true); err != nil {
+		t.Fatal(err)
+	}
+	var got []goagent.RunEvent
+	if err := json.Unmarshal(js.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, js.String())
+	}
+	if len(got) != 1 || got[0].Name != "probe" || got[0].Tokens.TotalTokens != 5 {
+		t.Fatalf("decoded events = %#v", got)
+	}
+}


### PR DESCRIPTION
### Motivation
- Make recorded agent run data consumable by automation by adding machine-readable output for CLI inspection commands.
- Prevent conversation text from polluting automation outputs when querying agent history by returning run timelines as JSON on demand.
- Reduce duplication and improve testability by factoring run rendering behind writer helpers that can emit either human-readable or indented JSON.

### Description
- Add a `--json` flag to `micro runs` and `micro agent history` to request indented JSON output for run indexes and run timelines.
- Introduce `writeRunIndex` and `writeRunHistory` helpers that accept an `io.Writer` and an `asJSON` flag and produce either human-friendly text or indented JSON.
- Update `cmd/micro/cli/agent/agent.go` to use the new writer helpers and adjust imports accordingly, and add unit tests in `cmd/micro/cli/agent/agent_test.go` covering both human and JSON output formats.
- Closes #3052

### Testing
- `go build ./...` completed successfully.
- `go test ./cmd/micro/cli/agent` passed (new CLI tests exercising human and JSON render paths succeeded).
- `go test ./...` was run; many packages passed but some integration/transport/harness tests failed due to environment/network limitations (gRPC loopback connections blocked by proxy and a transient `sum.golang.org` 502 during the generated-service contract), so those failures appear unrelated to the CLI changes.
- `golangci-lint run ./...` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ca3bbead8833082be7b8c1d00997d)