### PR TITLE
agent: correlate run timelines with OpenTelemetry traces

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -41,6 +41,8 @@ type RunEvent struct {
 	Time      time.Time `json:"time"`
 	RunID     string    `json:"run_id"`
 	ParentID  string    `json:"parent_id,omitempty"`
+	TraceID   string    `json:"trace_id,omitempty"`
+	SpanID    string    `json:"span_id,omitempty"`
 	Agent     string    `json:"agent"`
 	Kind      string    `json:"kind"`
 	Name      string    `json:"name,omitempty"`
@@ -59,6 +61,8 @@ type RunSummary struct {
 	RunID     string    `json:"run_id"`
 	Agent     string    `json:"agent"`
 	ParentID  string    `json:"parent_id,omitempty"`
+	TraceID   string    `json:"trace_id,omitempty"`
+	SpanID    string    `json:"span_id,omitempty"`
 	StartedAt time.Time `json:"started_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 	Events    int       `json:"events"`
@@ -78,17 +82,17 @@ func (a *agentImpl) startRun(ctx context.Context, message string) (context.Conte
 	ctx, span := a.tracer().Start(ctx, spanNameRun, trace.WithSpanKind(trace.SpanKindInternal), trace.WithAttributes(
 		attribute.String(AttrRunID, info.RunID), attribute.String(AttrParentRunID, info.ParentID), attribute.String(AttrAgentName, info.Agent)))
 	start := time.Now()
-	a.recordRunEvent(RunEvent{Time: start, RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "run", Name: message})
+	a.recordSpanEvent(span, RunEvent{Time: start, RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "run", Name: message})
 	return ctx, func(err error) {
 		latency := time.Since(start).Milliseconds()
 		span.SetAttributes(attribute.Int64(AttrLatencyMS, latency))
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "error", LatencyMS: latency, Error: err.Error()})
+			a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "error", LatencyMS: latency, Error: err.Error()})
 		} else {
 			span.SetStatus(codes.Ok, "")
-			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "done", LatencyMS: latency})
+			a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "done", LatencyMS: latency})
 		}
 		span.End()
 	}
@@ -129,7 +133,7 @@ func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.
 	if err != nil {
 		e.Error = err.Error()
 	}
-	m.a.recordRunEvent(e)
+	m.a.recordSpanEvent(span, e)
 	return resp, err
 }
 
@@ -170,7 +174,7 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 			span.SetStatus(codes.Ok, "")
 		}
 		span.End()
-		a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, LatencyMS: dur, Refused: res.Refused, Error: resErr})
+		a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, LatencyMS: dur, Refused: res.Refused, Error: resErr})
 		return res
 	}
 }
@@ -185,6 +189,14 @@ func resultError(res ai.ToolResult) string {
 		}
 	}
 	return ""
+}
+
+func (a *agentImpl) recordSpanEvent(span trace.Span, e RunEvent) {
+	if sc := span.SpanContext(); sc.IsValid() {
+		e.TraceID = sc.TraceID().String()
+		e.SpanID = sc.SpanID().String()
+	}
+	a.recordRunEvent(e)
 }
 
 func (a *agentImpl) recordRunEvent(e RunEvent) {
@@ -231,6 +243,8 @@ func ListRunSummaries(s store.Store, agentName string) ([]RunSummary, error) {
 			RunID:     id,
 			Agent:     first.Agent,
 			ParentID:  first.ParentID,
+			TraceID:   first.TraceID,
+			SpanID:    first.SpanID,
 			StartedAt: first.Time,
 			UpdatedAt: last.Time,
 			Events:    len(events),
@@ -243,6 +257,12 @@ func ListRunSummaries(s store.Store, agentName string) ([]RunSummary, error) {
 			}
 			if e.ParentID != "" {
 				summary.ParentID = e.ParentID
+			}
+			if e.TraceID != "" {
+				summary.TraceID = e.TraceID
+			}
+			if e.SpanID != "" {
+				summary.SpanID = e.SpanID
 			}
 			if e.Error != "" {
 				summary.LastError = e.Error

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -73,6 +73,16 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	if summaries[0].LastKind != "done" {
 		t.Fatalf("LastKind = %q, want done", summaries[0].LastKind)
 	}
+	if summaries[0].TraceID == "" || summaries[0].SpanID == "" {
+		t.Fatalf("summary missing trace correlation: %#v", summaries[0])
+	}
+	events, err := LoadRunEvents(st, "runner", summaries[0].RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 || events[0].TraceID == "" || events[0].SpanID == "" {
+		t.Fatalf("events missing trace correlation: %#v", events)
+	}
 }
 
 func TestAgentOpenTelemetryNoopWhenUnconfigured(t *testing.T) {
@@ -131,7 +141,7 @@ func TestListRunSummaries(t *testing.T) {
 	st := store.NewMemoryStore()
 	scoped := store.Scope(st, "agent", "runner")
 	events := []RunEvent{
-		{Time: time.Unix(0, 1), RunID: "run-a", Agent: "runner", Kind: "run", Name: "first"},
+		{Time: time.Unix(0, 1), RunID: "run-a", Agent: "runner", TraceID: "trace-a", SpanID: "span-a", Kind: "run", Name: "first"},
 		{Time: time.Unix(0, 2), RunID: "run-a", Agent: "runner", Kind: "tool", Name: "probe"},
 		{Time: time.Unix(0, 3), RunID: "run-b", Agent: "runner", ParentID: "parent", Kind: "run", Name: "second"},
 		{Time: time.Unix(0, 4), RunID: "run-b", Agent: "runner", ParentID: "parent", Kind: "error", Error: "boom"},
@@ -154,7 +164,7 @@ func TestListRunSummaries(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("got %d summaries, want 2: %#v", len(got), got)
 	}
-	if got[0].RunID != "run-a" || got[0].Events != 2 || got[0].LastKind != "tool" || !got[0].UpdatedAt.Equal(time.Unix(0, 2)) {
+	if got[0].RunID != "run-a" || got[0].TraceID != "trace-a" || got[0].SpanID != "span-a" || got[0].Events != 2 || got[0].LastKind != "tool" || !got[0].UpdatedAt.Equal(time.Unix(0, 2)) {
 		t.Fatalf("unexpected run-a summary: %#v", got[0])
 	}
 	if got[1].RunID != "run-b" || got[1].ParentID != "parent" || got[1].Events != 2 || got[1].LastKind != "error" || got[1].LastError != "boom" {

--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -156,6 +156,9 @@ func writeRunIndex(w io.Writer, name string, runs []goagent.RunSummary, asJSON b
 	fmt.Fprintln(w, "  Runs:")
 	for _, run := range runs {
 		line := fmt.Sprintf("    %s  events=%d  last=%s  updated=%s", run.RunID, run.Events, run.LastKind, run.UpdatedAt.Format("2006-01-02 15:04:05"))
+		if run.TraceID != "" {
+			line += "  trace=" + shortTraceID(run.TraceID)
+		}
 		if run.LastError != "" {
 			line += "  error=" + run.LastError
 		}
@@ -196,6 +199,9 @@ func writeRunHistory(w io.Writer, name, runID string, events []goagent.RunEvent,
 		if e.Tokens.TotalTokens > 0 {
 			line += fmt.Sprintf(" tokens=%d", e.Tokens.TotalTokens)
 		}
+		if e.TraceID != "" {
+			line += " trace=" + shortTraceID(e.TraceID)
+		}
 		if e.Refused != "" {
 			line += " refused=" + e.Refused
 		}
@@ -205,4 +211,11 @@ func writeRunHistory(w io.Writer, name, runID string, events []goagent.RunEvent,
 		fmt.Fprintln(w, line)
 	}
 	return nil
+}
+
+func shortTraceID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:12]
 }

--- a/cmd/micro/cli/agent/agent_test.go
+++ b/cmd/micro/cli/agent/agent_test.go
@@ -19,6 +19,7 @@ func TestWriteRunIndexJSON(t *testing.T) {
 		UpdatedAt: time.Unix(0, 2),
 		Events:    2,
 		LastKind:  "tool",
+		TraceID:   "1234567890abcdef",
 	}}
 	var out bytes.Buffer
 	if err := writeRunIndex(&out, "runner", runs, true); err != nil {
@@ -44,6 +45,7 @@ func TestWriteRunHistoryHumanAndJSON(t *testing.T) {
 		Model:     "unit-model",
 		LatencyMS: 42,
 		Tokens:    ai.Usage{TotalTokens: 5},
+		TraceID:   "1234567890abcdef",
 	}}
 
 	var human bytes.Buffer
@@ -51,7 +53,7 @@ func TestWriteRunHistoryHumanAndJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	line := human.String()
-	for _, want := range []string{"12:34:56.007 tool", "probe", "oteltest/unit-model", "42ms", "tokens=5"} {
+	for _, want := range []string{"12:34:56.007 tool", "probe", "oteltest/unit-model", "42ms", "tokens=5", "trace=1234567890ab"} {
 		if !strings.Contains(line, want) {
 			t.Fatalf("human output %q missing %q", line, want)
 		}


### PR DESCRIPTION
### Motivation
- Make durable agent run timelines linkable to exported OpenTelemetry traces so operators can correlate persisted events with trace data. 
- Improve observability for model calls and tool executions without changing public APIs or behavior.

### Description
- Add `TraceID` and `SpanID` fields to `RunEvent` and `RunSummary` and persist them with run timeline events. 
- Capture span context with `recordSpanEvent(span, RunEvent)` and use it when recording run start/completion, model calls, and tool calls. 
- Populate run summaries in `ListRunSummaries` from the first event and propagate trace/span IDs from events. 
- Update the CLI (`cmd/micro/cli/agent`) to show a short trace ID in human-readable `micro runs` / `micro agent history` output while keeping full IDs in JSON. 
- Extend unit tests to assert trace/span presence in persisted events and CLI output. 
- PR description includes `Closes #3056` to link the change to the tracker.

### Testing
- Ran `go build ./...` successfully. 
- Ran targeted tests `go test -run 'TestAgentOpenTelemetry|TestListRunSummaries|TestWriteRun' ./agent ./cmd/micro/cli/agent` and they passed. 
- Ran `go test ./...` which showed unrelated environment/network failures in grpc/A2A/harness tests (loopback/Envoy restrictions) while unrelated packages and the new tests passed. 
- Ran `golangci-lint run ./...` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cc1c0a9188330949efe9a4e81750f)