### PR TITLE
Add AGENTS.md with repository agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Repository agent instructions
+
+These instructions apply to the entire repository.
+
+## Pull requests from Codex tasks
+
+When a Codex task makes repository changes and the requested outcome is a PR:
+
+1. Keep the change focused on the assigned issue or prompt.
+2. Run the relevant verification commands and capture their results.
+3. Check `git status --short` and review the diff before finishing.
+4. Stage the intended files and create a local git commit on the current branch.
+5. Use the Codex `make_pr` tool to open the pull request with a concise title and a body that summarizes the change and testing.
+
+Do not just say that a PR was opened. If local changes exist, the task is not complete until the changes are committed and the `make_pr` tool has been called. A GitHub token in the shell environment is not a substitute for the Codex `make_pr` tool in this environment.


### PR DESCRIPTION
### Motivation
- Provide a single, repository-wide reference for autonomous agent behavior and PR workflow when Codex tasks modify the repo.
- Clarify required verification steps and tool usage so PRs opened by tasks follow a consistent process.

### Description
- Add a new `AGENTS.md` file at the repository root that defines repository agent instructions and expectations.
- The document outlines steps for PRs created from Codex tasks, including running verification commands, checking the working tree, staging intended files, and using the Codex `make_pr` tool, and it notes that a GitHub token is not a substitute for `make_pr`.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cc943b6cc83308240560ed3dcdce1)