### PR TITLE
docs: AGENTS.md — open PRs via gh, not the make_pr stub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,22 @@ These instructions apply to the entire repository.
 When a Codex task makes repository changes and the requested outcome is a PR:
 
 1. Keep the change focused on the assigned issue or prompt.
-2. Run the relevant verification commands and capture their results.
+2. Run the relevant verification commands and capture their results
+   (`go build ./...`, `go test ./...`, `golangci-lint run ./...`).
 3. Check `git status --short` and review the diff before finishing.
-4. Stage the intended files and create a local git commit on the current branch.
-5. Use the Codex `make_pr` tool to open the pull request with a concise title and a body that summarizes the change and testing.
+4. Stage the intended files and create a local git commit on the current branch
+   (not `master`).
+5. Open the pull request yourself with the GitHub CLI, which is installed in the
+   environment and whose `origin` points at this repository:
 
-Do not just say that a PR was opened. If local changes exist, the task is not complete until the changes are committed and the `make_pr` tool has been called. A GitHub token in the shell environment is not a substitute for the Codex `make_pr` tool in this environment.
+   ```sh
+   git push -u origin HEAD
+   gh pr create --base master \
+     --title "<concise title>" \
+     --body "<summary of the change and testing, including 'Closes #<issue>'>"
+   ```
+
+Do not just say that a PR was opened, and do **not** rely on the `make_pr` tool:
+in this environment `make_pr` only records the title/body and never pushes a
+branch or creates a PR. The task is not complete until `gh pr create` has opened
+a real pull request and printed its URL.


### PR DESCRIPTION
`AGENTS.md` (added in #3058) instructs Codex tasks to open PRs with the `make_pr` tool and states that "a GitHub token in the shell environment is not a substitute for the Codex `make_pr` tool." But `make_pr` in the Codex sandbox is a **no-op stub** — it records the title/body and returns them for the downstream "Create PR" click; it never pushes a branch or opens a PR. That guidance is the opposite of the fix that just made the loop autonomous (#3059), and as a repo-wide instruction it would steer every future run back into the broken path.

This rewrites the PR section to the working flow: push the branch and open the PR with the `gh` CLI (`git push -u origin HEAD` + `gh pr create --base master …`, including `Closes #<issue>`), and explicitly notes that `make_pr` does not create PRs in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_