### PR TITLE
ci: pin Codex PRs to a unique codex/ branch + codex label

### DIFF
--- a/.github/workflows/continuous-improvement.yml
+++ b/.github/workflows/continuous-improvement.yml
@@ -52,11 +52,11 @@ jobs:
             echo "a user account Codex follows) to activate the loop."
             exit 0
           fi
-          # A unique issue per run → Codex derives a unique branch → no collisions.
+          # A unique issue per run → unique codex/ branch → no collisions.
           ISSUE_URL=$(gh issue create --repo "$REPO" \
             --title "Continuous improvement increment #$RUN_NUMBER" \
             --body "Autonomous continuous-improvement increment. North Star: internal/docs/THESIS.md; charter: internal/docs/CONTINUOUS_IMPROVEMENT.md. Tracker: #3024.")
           ISSUE_NUM="${ISSUE_URL##*/}"
           echo "Opened issue #$ISSUE_NUM — dispatching Codex."
           gh issue comment "$ISSUE_NUM" --repo "$REPO" --body \
-          "@codex Run one continuous-improvement increment per internal/docs/CONTINUOUS_IMPROVEMENT.md, aligned to the North Star in internal/docs/THESIS.md (the holistic services → agents → workflows lifecycle). Pick the single highest-value roadmap/issue/improvement-radar item that advances that thesis, implement it, and verify \`go build ./...\`, \`go test ./...\`, and \`golangci-lint run ./...\`. Then open the PR YOURSELF from the shell — do NOT use the make_pr tool (in this environment it only records metadata and never creates a PR). Run \`git push -u origin HEAD\` then \`gh pr create --base master --title \"<title>\" --body \"<body, including 'Closes #$ISSUE_NUM'>\"\`; the gh CLI is installed and authenticated and origin points to $REPO. One concern per PR; stay out of brand/positioning copy and breaking public API."
+          "@codex Run one continuous-improvement increment per internal/docs/CONTINUOUS_IMPROVEMENT.md, aligned to the North Star in internal/docs/THESIS.md (the holistic services → agents → workflows lifecycle). Pick the single highest-value roadmap/issue/improvement-radar item that advances that thesis, implement it, and verify \`go build ./...\`, \`go test ./...\`, and \`golangci-lint run ./...\`. Then open the PR YOURSELF from the shell — do NOT use the make_pr tool (in this environment it only records metadata and never creates a PR). Create a uniquely-named branch under the codex/ prefix and open the PR from it: \`git switch -c codex/increment-$ISSUE_NUM\`, then \`git push -u origin codex/increment-$ISSUE_NUM\`, then \`gh pr create --base master --label codex --title \"<title>\" --body \"<body, including 'Closes #$ISSUE_NUM'>\"\`. The branch MUST start with \`codex/\` and the PR MUST carry the \`codex\` label, or it will not be auto-merged. The gh CLI is installed and authenticated and origin points to $REPO. One concern per PR; stay out of brand/positioning copy and breaking public API."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,17 +10,26 @@ When a Codex task makes repository changes and the requested outcome is a PR:
 2. Run the relevant verification commands and capture their results
    (`go build ./...`, `go test ./...`, `golangci-lint run ./...`).
 3. Check `git status --short` and review the diff before finishing.
-4. Stage the intended files and create a local git commit on the current branch
-   (not `master`).
-5. Open the pull request yourself with the GitHub CLI, which is installed in the
+4. Create a uniquely-named branch under the `codex/` prefix (do not work on
+   `master`, and do not use a generic name like `work`):
+
+   ```sh
+   git switch -c codex/<issue-number>-<short-slug>
+   ```
+5. Stage the intended files and commit on that branch.
+6. Open the pull request yourself with the GitHub CLI, which is installed in the
    environment and whose `origin` points at this repository:
 
    ```sh
    git push -u origin HEAD
-   gh pr create --base master \
+   gh pr create --base master --label codex \
      --title "<concise title>" \
      --body "<summary of the change and testing, including 'Closes #<issue>'>"
    ```
+
+The branch **must** start with `codex/` and the PR **must** carry the `codex`
+label — the auto-merge sweep only matches PRs that satisfy both, so a branch
+named `work` (or any non-`codex/` branch) will never be merged.
 
 Do not just say that a PR was opened, and do **not** rely on the `make_pr` tool:
 in this environment `make_pr` only records the title/body and never pushes a


### PR DESCRIPTION
Codex opened a PR on a generic branch named `work`. Two problems:

1. **The auto-merge sweep ignores it** — `auto-merge-codex.yml` only merges PRs whose branch starts with `codex/` and that carry the `codex` label. A `work` branch matches neither.
2. **It collides every run** — `work` is a fixed name, so the next increment reuses it, reviving the branch-collision failure the per-issue change fixed.

Root cause: the dispatch said `git push -u origin HEAD`, which pushes whatever branch Codex happens to be on, without forcing a unique `codex/`-prefixed name or the label.

This updates the dispatch and `AGENTS.md` to instruct Codex to:
- `git switch -c codex/increment-<issue>` (unique branch, `codex/` prefix), and
- `gh pr create --base master --label codex …`

so every increment is isolated and actually swept by auto-merge. Both files now state plainly that a non-`codex/` branch will never be merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_