### PR TITLE
website: refresh Developer Experience copy for the harness DX

### DIFF
--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -247,7 +247,7 @@
       <div class="two-col">
         <div class="two-col-text">
           <h2>Developer Experience</h2>
-          <p><code>micro run</code> starts your services with hot reload, an API gateway, and an interactive console for talking to them. <code>micro deploy</code> pushes to production via SSH.</p>
+          <p><code>micro new</code> scaffolds a service or an agent — every endpoint is automatically an MCP tool. <code>micro run</code> starts everything with hot reload, an API gateway, and an interactive console, and <code>micro chat</code> talks to your agents and services from the terminal.</p>
         </div>
         <div>
           <img src="/images/generated/developer-experience.jpg" alt="Terminal showing micro run and micro chat" />


### PR DESCRIPTION
Refreshes the dated "Developer Experience" section on the landing page. It previously only mentioned `micro run` (services) and `micro deploy` (SSH), missing the agent/MCP surface.

New copy: `micro new` scaffolds a service or an agent (every endpoint is automatically an MCP tool); `micro run` starts everything with hot reload, an API gateway, and an interactive console; `micro chat` talks to your agents and services from the terminal. Drops the `micro deploy` mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_