### PR TITLE
Add agent run status summaries

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -58,16 +58,18 @@ type Usage = ai.Usage
 
 // RunSummary is a compact index entry for a recorded agent run.
 type RunSummary struct {
-	RunID     string    `json:"run_id"`
-	Agent     string    `json:"agent"`
-	ParentID  string    `json:"parent_id,omitempty"`
-	TraceID   string    `json:"trace_id,omitempty"`
-	SpanID    string    `json:"span_id,omitempty"`
-	StartedAt time.Time `json:"started_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	Events    int       `json:"events"`
-	LastKind  string    `json:"last_kind,omitempty"`
-	LastError string    `json:"last_error,omitempty"`
+	RunID      string    `json:"run_id"`
+	Agent      string    `json:"agent"`
+	ParentID   string    `json:"parent_id,omitempty"`
+	TraceID    string    `json:"trace_id,omitempty"`
+	SpanID     string    `json:"span_id,omitempty"`
+	StartedAt  time.Time `json:"started_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	DurationMS int64     `json:"duration_ms,omitempty"`
+	Events     int       `json:"events"`
+	Status     string    `json:"status,omitempty"`
+	LastKind   string    `json:"last_kind,omitempty"`
+	LastError  string    `json:"last_error,omitempty"`
 }
 
 func (a *agentImpl) tracer() trace.Tracer {
@@ -240,16 +242,18 @@ func ListRunSummaries(s store.Store, agentName string) ([]RunSummary, error) {
 		first := events[0]
 		last := events[len(events)-1]
 		summary := RunSummary{
-			RunID:     id,
-			Agent:     first.Agent,
-			ParentID:  first.ParentID,
-			TraceID:   first.TraceID,
-			SpanID:    first.SpanID,
-			StartedAt: first.Time,
-			UpdatedAt: last.Time,
-			Events:    len(events),
-			LastKind:  last.Kind,
-			LastError: last.Error,
+			RunID:      id,
+			Agent:      first.Agent,
+			ParentID:   first.ParentID,
+			TraceID:    first.TraceID,
+			SpanID:     first.SpanID,
+			StartedAt:  first.Time,
+			UpdatedAt:  last.Time,
+			DurationMS: last.Time.Sub(first.Time).Milliseconds(),
+			Events:     len(events),
+			Status:     runStatus(events),
+			LastKind:   last.Kind,
+			LastError:  last.Error,
 		}
 		for _, e := range events {
 			if e.Agent != "" {
@@ -271,6 +275,30 @@ func ListRunSummaries(s store.Store, agentName string) ([]RunSummary, error) {
 		summaries = append(summaries, summary)
 	}
 	return summaries, nil
+}
+
+func runStatus(events []RunEvent) string {
+	if len(events) == 0 {
+		return ""
+	}
+	status := "running"
+	for _, e := range events {
+		if e.Error != "" {
+			status = "error"
+		}
+		if e.Refused != "" && status != "error" {
+			status = "refused"
+		}
+		switch e.Kind {
+		case "error":
+			status = "error"
+		case "done":
+			if status == "running" {
+				status = "done"
+			}
+		}
+	}
+	return status
 }
 
 func LoadRunEvents(s store.Store, agentName, runID string) ([]RunEvent, error) {

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -73,6 +73,12 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	if summaries[0].LastKind != "done" {
 		t.Fatalf("LastKind = %q, want done", summaries[0].LastKind)
 	}
+	if summaries[0].Status != "done" {
+		t.Fatalf("Status = %q, want done", summaries[0].Status)
+	}
+	if summaries[0].DurationMS < 0 {
+		t.Fatalf("DurationMS = %d, want non-negative", summaries[0].DurationMS)
+	}
 	if summaries[0].TraceID == "" || summaries[0].SpanID == "" {
 		t.Fatalf("summary missing trace correlation: %#v", summaries[0])
 	}
@@ -164,10 +170,10 @@ func TestListRunSummaries(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("got %d summaries, want 2: %#v", len(got), got)
 	}
-	if got[0].RunID != "run-a" || got[0].TraceID != "trace-a" || got[0].SpanID != "span-a" || got[0].Events != 2 || got[0].LastKind != "tool" || !got[0].UpdatedAt.Equal(time.Unix(0, 2)) {
+	if got[0].RunID != "run-a" || got[0].TraceID != "trace-a" || got[0].SpanID != "span-a" || got[0].Events != 2 || got[0].Status != "running" || got[0].DurationMS != 0 || got[0].LastKind != "tool" || !got[0].UpdatedAt.Equal(time.Unix(0, 2)) {
 		t.Fatalf("unexpected run-a summary: %#v", got[0])
 	}
-	if got[1].RunID != "run-b" || got[1].ParentID != "parent" || got[1].Events != 2 || got[1].LastKind != "error" || got[1].LastError != "boom" {
+	if got[1].RunID != "run-b" || got[1].ParentID != "parent" || got[1].Events != 2 || got[1].Status != "error" || got[1].DurationMS != 0 || got[1].LastKind != "error" || got[1].LastError != "boom" {
 		t.Fatalf("unexpected run-b summary: %#v", got[1])
 	}
 }

--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -155,7 +155,7 @@ func writeRunIndex(w io.Writer, name string, runs []goagent.RunSummary, asJSON b
 	}
 	fmt.Fprintln(w, "  Runs:")
 	for _, run := range runs {
-		line := fmt.Sprintf("    %s  events=%d  last=%s  updated=%s", run.RunID, run.Events, run.LastKind, run.UpdatedAt.Format("2006-01-02 15:04:05"))
+		line := fmt.Sprintf("    %s  status=%s  events=%d  duration=%s  last=%s  updated=%s", run.RunID, run.Status, run.Events, formatDurationMS(run.DurationMS), run.LastKind, run.UpdatedAt.Format("2006-01-02 15:04:05"))
 		if run.TraceID != "" {
 			line += "  trace=" + shortTraceID(run.TraceID)
 		}
@@ -211,6 +211,16 @@ func writeRunHistory(w io.Writer, name, runID string, events []goagent.RunEvent,
 		fmt.Fprintln(w, line)
 	}
 	return nil
+}
+
+func formatDurationMS(ms int64) string {
+	if ms <= 0 {
+		return "0ms"
+	}
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	return fmt.Sprintf("%.1fs", float64(ms)/1000)
 }
 
 func shortTraceID(id string) string {

--- a/cmd/micro/cli/agent/agent_test.go
+++ b/cmd/micro/cli/agent/agent_test.go
@@ -13,13 +13,15 @@ import (
 
 func TestWriteRunIndexJSON(t *testing.T) {
 	runs := []goagent.RunSummary{{
-		RunID:     "run-1",
-		Agent:     "runner",
-		StartedAt: time.Unix(0, 1),
-		UpdatedAt: time.Unix(0, 2),
-		Events:    2,
-		LastKind:  "tool",
-		TraceID:   "1234567890abcdef",
+		RunID:      "run-1",
+		Agent:      "runner",
+		StartedAt:  time.Unix(0, 1),
+		UpdatedAt:  time.Unix(0, 2),
+		DurationMS: 1234,
+		Events:     2,
+		Status:     "done",
+		LastKind:   "tool",
+		TraceID:    "1234567890abcdef",
 	}}
 	var out bytes.Buffer
 	if err := writeRunIndex(&out, "runner", runs, true); err != nil {
@@ -31,6 +33,28 @@ func TestWriteRunIndexJSON(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].RunID != "run-1" || got[0].LastKind != "tool" {
 		t.Fatalf("decoded summaries = %#v", got)
+	}
+}
+
+func TestWriteRunIndexHumanIncludesStatusAndDuration(t *testing.T) {
+	runs := []goagent.RunSummary{{
+		RunID:      "run-1",
+		Agent:      "runner",
+		UpdatedAt:  time.Date(2026, 6, 25, 12, 34, 56, 0, time.UTC),
+		DurationMS: 1234,
+		Events:     2,
+		Status:     "done",
+		LastKind:   "tool",
+	}}
+	var out bytes.Buffer
+	if err := writeRunIndex(&out, "runner", runs, false); err != nil {
+		t.Fatal(err)
+	}
+	line := out.String()
+	for _, want := range []string{"run-1", "status=done", "events=2", "duration=1.2s", "last=tool"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("human output %q missing %q", line, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add status and duration fields to recorded agent run summaries
- show status and duration in the human-readable micro runs / micro agent history index
- cover the new summary fields and CLI output with tests

Closes #3067

## Testing
- go build ./...
- go test ./... (fails in this sandbox because loopback transport is blocked and sum.golang.org returned 503 during generated-service tidy)
- golangci-lint run ./...