### PR TITLE
Add filtered agent run summaries

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -56,6 +56,17 @@ type RunEvent struct {
 
 type Usage = ai.Usage
 
+// RunListOptions controls how recorded agent run summaries are returned.
+// Zero values preserve the full deterministic run list.
+type RunListOptions struct {
+	// Status, when set, keeps only runs with the matching status
+	// (for example "running", "done", "error", or "refused").
+	Status string
+	// Limit, when positive, returns the most recently updated runs up to
+	// the limit. Limited results are ordered newest first.
+	Limit int
+}
+
 // RunSummary is a compact index entry for a recorded agent run.
 type RunSummary struct {
 	RunID      string    `json:"run_id"`
@@ -212,6 +223,12 @@ func (a *agentImpl) recordRunEvent(e RunEvent) {
 
 // ListRunSummaries returns a deterministic summary of recorded runs for agentName.
 func ListRunSummaries(s store.Store, agentName string) ([]RunSummary, error) {
+	return ListRunSummariesWithOptions(s, agentName, RunListOptions{})
+}
+
+// ListRunSummariesWithOptions returns summaries of recorded runs for agentName,
+// optionally filtered by status and limited to the most recently updated runs.
+func ListRunSummariesWithOptions(s store.Store, agentName string, opts RunListOptions) ([]RunSummary, error) {
 	st := store.Scope(s, "agent", agentName)
 	keys, err := st.List(store.ListPrefix("runs/"))
 	if err != nil {
@@ -272,7 +289,18 @@ func ListRunSummaries(s store.Store, agentName string) ([]RunSummary, error) {
 				summary.LastError = e.Error
 			}
 		}
+		if opts.Status != "" && summary.Status != opts.Status {
+			continue
+		}
 		summaries = append(summaries, summary)
+	}
+	if opts.Limit > 0 {
+		sort.SliceStable(summaries, func(i, j int) bool {
+			return summaries[i].UpdatedAt.After(summaries[j].UpdatedAt)
+		})
+		if len(summaries) > opts.Limit {
+			summaries = summaries[:opts.Limit]
+		}
 	}
 	return summaries, nil
 }

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -177,3 +177,31 @@ func TestListRunSummaries(t *testing.T) {
 		t.Fatalf("unexpected run-b summary: %#v", got[1])
 	}
 }
+
+func TestListRunSummariesWithOptionsFiltersAndLimits(t *testing.T) {
+	st := store.NewMemoryStore()
+	scoped := store.Scope(st, "agent", "runner")
+	events := []RunEvent{
+		{Time: time.Unix(0, 1), RunID: "run-old", Agent: "runner", Kind: "run"},
+		{Time: time.Unix(0, 2), RunID: "run-old", Agent: "runner", Kind: "done"},
+		{Time: time.Unix(0, 3), RunID: "run-new", Agent: "runner", Kind: "run"},
+		{Time: time.Unix(0, 4), RunID: "run-new", Agent: "runner", Kind: "error", Error: "boom"},
+	}
+	for _, e := range events {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := scoped.Write(&store.Record{Key: "runs/" + e.RunID + "/" + e.Time.Format("20060102150405.000000000") + "-" + e.Kind, Value: b}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := ListRunSummariesWithOptions(st, "runner", RunListOptions{Status: "error", Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].RunID != "run-new" || got[0].Status != "error" {
+		t.Fatalf("filtered summaries = %#v", got)
+	}
+}

--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -19,9 +19,7 @@ func init() {
 		Name:      "runs",
 		Usage:     "Show recorded agent runs",
 		ArgsUsage: "[agent] [run-id]",
-		Flags: []cli.Flag{
-			&cli.BoolFlag{Name: "json", Usage: "Print run data as JSON for automation"},
-		},
+		Flags:     runFlags(),
 		Action: func(c *cli.Context) error {
 			name := c.Args().First()
 			if name == "" {
@@ -30,7 +28,7 @@ func init() {
 			if runID := c.Args().Get(1); runID != "" {
 				return printRunHistory(name, runID, c.Bool("json"))
 			}
-			return printRunIndex(name, c.Bool("json"))
+			return printRunIndex(name, runOptions(c), c.Bool("json"))
 		},
 	})
 
@@ -102,9 +100,7 @@ func init() {
 				Name:      "history",
 				Usage:     "Show an agent's stored conversation and run history",
 				ArgsUsage: "[name] [run-id]",
-				Flags: []cli.Flag{
-					&cli.BoolFlag{Name: "json", Usage: "Print run data as JSON for automation"},
-				},
+				Flags:     runFlags(),
 				Action: func(c *cli.Context) error {
 					name := c.Args().First()
 					if name == "" {
@@ -114,7 +110,7 @@ func init() {
 						return printRunHistory(name, runID, c.Bool("json"))
 					}
 					if c.Bool("json") {
-						return printRunIndex(name, true)
+						return printRunIndex(name, runOptions(c), true)
 					}
 					// Read from the agent's scoped state store (database
 					// "agent", table = name) — available whether or not the
@@ -128,15 +124,27 @@ func init() {
 							fmt.Printf("  \033[2m%s:\033[0m %v\n", m.Role, m.Content)
 						}
 					}
-					return printRunIndex(name, c.Bool("json"))
+					return printRunIndex(name, runOptions(c), c.Bool("json"))
 				},
 			},
 		},
 	})
 }
 
-func printRunIndex(name string, asJSON bool) error {
-	runs, err := goagent.ListRunSummaries(store.DefaultStore, name)
+func runFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{Name: "json", Usage: "Print run data as JSON for automation"},
+		&cli.StringFlag{Name: "status", Usage: "Only show runs with this status (running, done, error, refused)"},
+		&cli.IntFlag{Name: "limit", Usage: "Show the most recently updated N runs"},
+	}
+}
+
+func runOptions(c *cli.Context) goagent.RunListOptions {
+	return goagent.RunListOptions{Status: c.String("status"), Limit: c.Int("limit")}
+}
+
+func printRunIndex(name string, opts goagent.RunListOptions, asJSON bool) error {
+	runs, err := goagent.ListRunSummariesWithOptions(store.DefaultStore, name, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Summary:
- Add RunListOptions and ListRunSummariesWithOptions for filtering agent run summaries by status and limiting to the most recently updated runs.
- Add --status and --limit flags to micro runs and micro agent history so operators can focus run inspection output.
- Add coverage for filtered and limited run summaries.

Testing:
- go build ./...
- go test ./agent ./cmd/micro/cli/agent
- go test ./... (fails in this sandbox because loopback RPC targets are blocked by envoy; affected existing grpc/a2a/harness tests)
- golangci-lint run ./...

Closes #3069