### PR TITLE
Require live provider conformance keys

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -2,8 +2,9 @@ name: Harness (E2E)
 
 # Runs the end-to-end harnesses for agents, services, flows, and provider
 # conformance. The default job uses deterministic mock LLMs and needs no
-# secrets. A second job runs the same harnesses against any live providers
-# whose API key secrets are configured.
+# secrets. A second job runs the same harnesses against the live provider set and
+# fails if any selected provider secret is missing, so scheduled conformance
+# cannot silently degrade.
 
 on:
   push:
@@ -34,7 +35,7 @@ jobs:
         run: go run ./internal/harness/plan-delegate
 
   harness-live:
-    name: Provider harnesses (live LLM, if keys present)
+    name: Provider harnesses (live LLM conformance)
     runs-on: ubuntu-latest
     # Only on the daily schedule or a manual run — never automatically on
     # every push/PR, so changes don't quietly burn API credits. Trigger it
@@ -47,7 +48,7 @@ jobs:
         with:
           go-version: stable
           cache: true
-      - name: Provider conformance against configured live models
+      - name: Provider conformance against live models
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -56,4 +57,4 @@ jobs:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           ATLASCLOUD_API_KEY: ${{ secrets.ATLASCLOUD_API_KEY }}
-        run: go run ./internal/harness/provider-conformance
+        run: go run ./internal/harness/provider-conformance -require-configured

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -38,6 +38,7 @@ func main() {
 	providersFlag := flag.String("providers", "anthropic,openai,gemini,groq,mistral,together,atlascloud", "comma-separated providers to check; use mock for deterministic local checks")
 	harnessesFlag := flag.String("harnesses", "universe,agent-flow,plan-delegate", "comma-separated harness names under internal/harness")
 	timeoutFlag := flag.Duration("timeout", 10*time.Minute, "timeout per provider/harness run")
+	requireConfiguredFlag := flag.Bool("require-configured", false, "fail when a selected live provider is missing an API key")
 	flag.Parse()
 
 	providers := splitCSV(*providersFlag)
@@ -50,8 +51,14 @@ func main() {
 	var ran, skipped, failed int
 	for _, provider := range providers {
 		if provider != "mock" && providerKey(provider) == "" {
-			fmt.Printf("- %s: skipped (set MICRO_AI_API_KEY or %s)\n", provider, providerEnv[provider])
-			skipped++
+			msg := fmt.Sprintf("set MICRO_AI_API_KEY or %s", providerEnv[provider])
+			if *requireConfiguredFlag {
+				fmt.Printf("FAIL %s: missing API key (%s)\n", provider, msg)
+				failed++
+			} else {
+				fmt.Printf("- %s: skipped (%s)\n", provider, msg)
+				skipped++
+			}
 			continue
 		}
 


### PR DESCRIPTION
Summary:
- Add a -require-configured mode to the provider conformance runner so selected live providers without API keys fail instead of silently skipping.
- Use that mode in the scheduled/manual Harness live-provider job so cross-provider conformance cannot silently degrade.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback targets are forbidden by the proxy, affecting grpc/a2a/harness tests)
- golangci-lint run ./...

Closes #3071