### PR TITLE
Propagate A2A request cancellation

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -415,7 +415,7 @@ func (d *dispatcher) serve(w http.ResponseWriter, r *http.Request, invoke Invoke
 
 	switch req.Method {
 	case "message/send":
-		d.send(w, req, invoke)
+		d.send(requestContext(r.Context()), w, req, invoke)
 	case "tasks/get":
 		d.get(w, req)
 	case "tasks/cancel":
@@ -432,7 +432,7 @@ type sendParams struct {
 	Message Message `json:"message"`
 }
 
-func (d *dispatcher) send(w http.ResponseWriter, req rpcRequest, invoke Invoke) {
+func (d *dispatcher) send(ctx context.Context, w http.ResponseWriter, req rpcRequest, invoke Invoke) {
 	var p sendParams
 	if err := json.Unmarshal(req.Params, &p); err != nil {
 		writeRPC(w, req.ID, nil, &rpcError{Code: errInvalidParams, Message: "invalid params"})
@@ -444,7 +444,7 @@ func (d *dispatcher) send(w http.ResponseWriter, req rpcRequest, invoke Invoke) 
 		return
 	}
 
-	reply, err := invoke(r2ctx(), text)
+	reply, err := invoke(ctx, text)
 	contextID := p.Message.ContextID
 	if contextID == "" {
 		contextID = uuid.New().String()
@@ -542,6 +542,29 @@ func textArtifact(text string) Artifact {
 	}
 }
 
+// requestContext carries request cancellation and deadlines into the downstream
+// agent call without leaking HTTP transport context values into the go-micro
+// client stack.
+func requestContext(parent context.Context) context.Context {
+	if err := parent.Err(); err != nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	if deadline, ok := parent.Deadline(); ok {
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	go func() {
+		<-parent.Done()
+		cancel()
+	}()
+	return ctx
+}
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -554,7 +577,3 @@ func writeRPC(w http.ResponseWriter, id json.RawMessage, result any, e *rpcError
 	}
 	writeJSON(w, http.StatusOK, rpcResponse{JSONRPC: "2.0", ID: id, Result: result, Error: e})
 }
-
-// r2ctx returns a background context for the agent call. (Kept as a seam
-// so request-scoped context/deadlines can be threaded later.)
-func r2ctx() context.Context { return context.Background() }

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -109,6 +109,42 @@ func TestMessageSendAndGet(t *testing.T) {
 	}
 }
 
+func TestMessageSendUsesRequestContext(t *testing.T) {
+	d := newDispatcher()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{
+		"jsonrpc":"2.0","id":1,"method":"message/send",
+		"params":{"message":{"role":"user","kind":"message","messageId":"m1",
+			"parts":[{"kind":"text","text":"ping"}]}}}`))
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	d.serve(rr, req, func(ctx context.Context, text string) (string, error) {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		return "unexpected success", nil
+	})
+
+	var resp struct {
+		Result Task      `json:"result"`
+		Error  *rpcError `json:"error"`
+	}
+	if err := json.NewDecoder(rr.Result().Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("rpc error: %+v", resp.Error)
+	}
+	if resp.Result.Status.State != stateFailed {
+		t.Fatalf("task state = %q, want failed", resp.Result.Status.State)
+	}
+	if len(resp.Result.Artifacts) != 1 || textOf(resp.Result.Artifacts[0].Parts) != "error: context canceled" {
+		t.Fatalf("artifact = %+v, want context cancellation", resp.Result.Artifacts)
+	}
+}
+
 func TestUnknownMethod(t *testing.T) {
 	ts, cleanup := newGatewayWithAgent(t)
 	defer cleanup()


### PR DESCRIPTION
Summary:
- Thread A2A message/send request cancellation and deadlines into downstream agent calls without leaking HTTP transport context values.
- Add coverage for canceled request contexts returning a failed A2A task.

Testing:
- go build ./...
- go test ./gateway/a2a -run TestMessageSendUsesRequestContext -v
- golangci-lint run ./...
- go test ./... (fails in this sandbox because loopback targets are forbidden by the environment; see client/grpc, gateway/a2a, internal harness, and transport/grpc failures)

Closes #3073