### PR TITLE
Add AI provider capability matrix

### DIFF
--- a/ai/capabilities.go
+++ b/ai/capabilities.go
@@ -1,0 +1,93 @@
+package ai
+
+import "sort"
+
+// Capabilities describes the AI interfaces a provider has registered.
+// It is intentionally based on package registration rather than external
+// provider marketing claims, so it reflects what this build can actually use.
+type Capabilities struct {
+	// Model reports whether ai.New can construct a chat/text model provider.
+	Model bool
+	// Image reports whether ai.NewImage can construct an image model provider.
+	Image bool
+	// Video reports whether ai.NewVideo can construct a video model provider.
+	Video bool
+}
+
+// ProviderCapabilities reports the capabilities registered for provider.
+func ProviderCapabilities(provider string) Capabilities {
+	_, hasModel := providers[provider]
+	_, hasImage := imageProviders[provider]
+	_, hasVideo := videoProviders[provider]
+
+	return Capabilities{
+		Model: hasModel,
+		Image: hasImage,
+		Video: hasVideo,
+	}
+}
+
+// CapabilityMatrix returns a stable snapshot of all registered AI providers and
+// the interfaces they support. The returned map is a copy and can be modified by
+// callers without mutating the registry.
+func CapabilityMatrix() map[string]Capabilities {
+	names := map[string]struct{}{}
+	for name := range providers {
+		names[name] = struct{}{}
+	}
+	for name := range imageProviders {
+		names[name] = struct{}{}
+	}
+	for name := range videoProviders {
+		names[name] = struct{}{}
+	}
+
+	matrix := make(map[string]Capabilities, len(names))
+	for name := range names {
+		matrix[name] = ProviderCapabilities(name)
+	}
+	return matrix
+}
+
+// RegisteredProviders returns the registered provider names in sorted order.
+// kind may be "model", "image", "video", or empty for the union of all
+// provider registries.
+func RegisteredProviders(kind string) []string {
+	names := map[string]struct{}{}
+	add := func(registry any) {
+		switch r := registry.(type) {
+		case map[string]NewFunc:
+			for name := range r {
+				names[name] = struct{}{}
+			}
+		case map[string]NewImageFunc:
+			for name := range r {
+				names[name] = struct{}{}
+			}
+		case map[string]NewVideoFunc:
+			for name := range r {
+				names[name] = struct{}{}
+			}
+		}
+	}
+
+	switch kind {
+	case "model":
+		add(providers)
+	case "image":
+		add(imageProviders)
+	case "video":
+		add(videoProviders)
+	default:
+		add(providers)
+		add(imageProviders)
+		add(videoProviders)
+	}
+
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/ai/capabilities_test.go
+++ b/ai/capabilities_test.go
@@ -1,0 +1,59 @@
+package ai_test
+
+import (
+	"reflect"
+	"testing"
+
+	"go-micro.dev/v6/ai"
+	_ "go-micro.dev/v6/ai/anthropic"
+	_ "go-micro.dev/v6/ai/atlascloud"
+	_ "go-micro.dev/v6/ai/gemini"
+	_ "go-micro.dev/v6/ai/groq"
+	_ "go-micro.dev/v6/ai/mistral"
+	_ "go-micro.dev/v6/ai/openai"
+	_ "go-micro.dev/v6/ai/together"
+)
+
+func TestRegisteredProviders(t *testing.T) {
+	got := ai.RegisteredProviders("")
+	want := []string{"anthropic", "atlascloud", "gemini", "groq", "mistral", "openai", "together"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RegisteredProviders() = %#v, want %#v", got, want)
+	}
+
+	got = ai.RegisteredProviders("image")
+	want = []string{"atlascloud", "openai"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RegisteredProviders(image) = %#v, want %#v", got, want)
+	}
+
+	got = ai.RegisteredProviders("video")
+	want = []string{"atlascloud"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RegisteredProviders(video) = %#v, want %#v", got, want)
+	}
+}
+
+func TestCapabilityMatrix(t *testing.T) {
+	matrix := ai.CapabilityMatrix()
+
+	for _, provider := range []string{"anthropic", "atlascloud", "gemini", "groq", "mistral", "openai", "together"} {
+		caps, ok := matrix[provider]
+		if !ok {
+			t.Fatalf("CapabilityMatrix missing %q", provider)
+		}
+		if !caps.Model {
+			t.Fatalf("CapabilityMatrix(%s).Model = false, want true", provider)
+		}
+	}
+
+	if caps := ai.ProviderCapabilities("openai"); caps != (ai.Capabilities{Model: true, Image: true}) {
+		t.Fatalf("ProviderCapabilities(openai) = %#v", caps)
+	}
+	if caps := ai.ProviderCapabilities("atlascloud"); caps != (ai.Capabilities{Model: true, Image: true, Video: true}) {
+		t.Fatalf("ProviderCapabilities(atlascloud) = %#v", caps)
+	}
+	if caps := ai.ProviderCapabilities("missing"); caps != (ai.Capabilities{}) {
+		t.Fatalf("ProviderCapabilities(missing) = %#v", caps)
+	}
+}

--- a/internal/website/docs/guides/ai-provider-guide.md
+++ b/internal/website/docs/guides/ai-provider-guide.md
@@ -21,6 +21,32 @@ ai/
     └── yourprovider_test.go  # Unit tests
 ```
 
+
+## Discover registered provider capabilities
+
+Go Micro exposes the provider interfaces registered in the current build, so
+runtime tooling and docs can report what is actually available after blank
+imports are linked in:
+
+```go
+matrix := ai.CapabilityMatrix()
+for provider, caps := range matrix {
+    fmt.Printf("%s: chat=%t image=%t video=%t\n", provider, caps.Model, caps.Image, caps.Video)
+}
+```
+
+The built-in providers currently register these capability interfaces:
+
+| Provider | Chat/text (`ai.Model`) | Image (`ai.ImageModel`) | Video (`ai.VideoModel`) |
+| --- | --- | --- | --- |
+| `anthropic` | Yes | No | No |
+| `atlascloud` | Yes | Yes | Yes |
+| `gemini` | Yes | No | No |
+| `groq` | Yes | No | No |
+| `mistral` | Yes | No | No |
+| `openai` | Yes | Yes | No |
+| `together` | Yes | No | No |
+
 ## Step 1: Implement the `ai.Model` Interface
 
 Every provider must satisfy `ai.Model`:


### PR DESCRIPTION
Summary:
- Add runtime APIs for reporting registered AI provider chat, image, and video capabilities.
- Add tests covering the built-in provider matrix.
- Document the current built-in provider capability matrix in the AI provider guide.

Testing:
- go build ./...
- go test ./ai
- go test ./... (fails in this environment: loopback targets are forbidden for grpc/a2a/harness tests)
- golangci-lint run ./...

Closes #3075