### PR TITLE
ai: expose unsupported streaming sentinel

### DIFF
--- a/ai/anthropic/anthropic.go
+++ b/ai/anthropic/anthropic.go
@@ -161,7 +161,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 
 // Stream generates a streaming response (not yet implemented)
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
-	return nil, fmt.Errorf("streaming not yet implemented for anthropic provider")
+	return nil, fmt.Errorf("%w: anthropic provider", ai.ErrStreamingUnsupported)
 }
 
 // callAPI makes an HTTP request to the Anthropic API

--- a/ai/anthropic/anthropic_test.go
+++ b/ai/anthropic/anthropic_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go-micro.dev/v6/ai"
@@ -88,7 +89,7 @@ func TestProvider_Stream_NotImplemented(t *testing.T) {
 	}
 
 	_, err := p.Stream(context.Background(), req)
-	if err == nil {
-		t.Error("Expected error for unimplemented streaming, got nil")
+	if !errors.Is(err, ai.ErrStreamingUnsupported) {
+		t.Fatalf("Stream error = %v, want ErrStreamingUnsupported", err)
 	}
 }

--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -143,7 +143,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 }
 
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
-	return nil, fmt.Errorf("streaming not yet implemented for atlascloud provider")
+	return nil, fmt.Errorf("%w: atlascloud provider", ai.ErrStreamingUnsupported)
 }
 
 func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Response, map[string]any, error) {

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -2,6 +2,7 @@ package atlascloud
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go-micro.dev/v6/ai"
@@ -88,8 +89,8 @@ func TestProvider_Stream_NotImplemented(t *testing.T) {
 	}
 
 	_, err := p.Stream(context.Background(), req)
-	if err == nil {
-		t.Error("Expected error for unimplemented streaming, got nil")
+	if !errors.Is(err, ai.ErrStreamingUnsupported) {
+		t.Fatalf("Stream error = %v, want ErrStreamingUnsupported", err)
 	}
 }
 

--- a/ai/gemini/gemini.go
+++ b/ai/gemini/gemini.go
@@ -135,7 +135,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 }
 
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
-	return nil, fmt.Errorf("streaming not yet implemented for gemini provider")
+	return nil, fmt.Errorf("%w: gemini provider", ai.ErrStreamingUnsupported)
 }
 
 func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Response, []map[string]any, error) {

--- a/ai/gemini/gemini_test.go
+++ b/ai/gemini/gemini_test.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go-micro.dev/v6/ai"
@@ -88,8 +89,8 @@ func TestProvider_Stream_NotImplemented(t *testing.T) {
 	}
 
 	_, err := p.Stream(context.Background(), req)
-	if err == nil {
-		t.Error("Expected error for unimplemented streaming, got nil")
+	if !errors.Is(err, ai.ErrStreamingUnsupported) {
+		t.Fatalf("Stream error = %v, want ErrStreamingUnsupported", err)
 	}
 }
 

--- a/ai/groq/groq.go
+++ b/ai/groq/groq.go
@@ -119,7 +119,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 }
 
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
-	return nil, fmt.Errorf("streaming not yet implemented for groq provider")
+	return nil, fmt.Errorf("%w: groq provider", ai.ErrStreamingUnsupported)
 }
 
 func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Response, map[string]any, error) {

--- a/ai/groq/groq_test.go
+++ b/ai/groq/groq_test.go
@@ -2,6 +2,7 @@ package groq
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go-micro.dev/v6/ai"
@@ -40,8 +41,8 @@ func TestProvider_Generate_NoAPIKey(t *testing.T) {
 }
 
 func TestProvider_Stream_NotImplemented(t *testing.T) {
-	if _, err := NewProvider().Stream(context.Background(), &ai.Request{Prompt: "hi"}); err == nil {
-		t.Error("expected error")
+	if _, err := NewProvider().Stream(context.Background(), &ai.Request{Prompt: "hi"}); !errors.Is(err, ai.ErrStreamingUnsupported) {
+		t.Fatalf("Stream error = %v, want ErrStreamingUnsupported", err)
 	}
 }
 

--- a/ai/mistral/mistral.go
+++ b/ai/mistral/mistral.go
@@ -119,7 +119,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 }
 
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
-	return nil, fmt.Errorf("streaming not yet implemented for mistral provider")
+	return nil, fmt.Errorf("%w: mistral provider", ai.ErrStreamingUnsupported)
 }
 
 func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Response, map[string]any, error) {

--- a/ai/mistral/mistral_test.go
+++ b/ai/mistral/mistral_test.go
@@ -2,6 +2,7 @@ package mistral
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go-micro.dev/v6/ai"
@@ -40,8 +41,8 @@ func TestProvider_Generate_NoAPIKey(t *testing.T) {
 }
 
 func TestProvider_Stream_NotImplemented(t *testing.T) {
-	if _, err := NewProvider().Stream(context.Background(), &ai.Request{Prompt: "hi"}); err == nil {
-		t.Error("expected error")
+	if _, err := NewProvider().Stream(context.Background(), &ai.Request{Prompt: "hi"}); !errors.Is(err, ai.ErrStreamingUnsupported) {
+		t.Fatalf("Stream error = %v, want ErrStreamingUnsupported", err)
 	}
 }
 

--- a/ai/model.go
+++ b/ai/model.go
@@ -4,6 +4,7 @@ package ai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 )
 
@@ -133,7 +134,12 @@ func RunInfoFrom(ctx context.Context) (RunInfo, bool) {
 	return r, ok
 }
 
-// Stream is the interface for streaming responses (future implementation)
+// ErrStreamingUnsupported is returned by providers that implement the Model
+// interface but do not yet support token streaming. Use errors.Is so callers
+// can distinguish an unsupported capability from transient provider failures.
+var ErrStreamingUnsupported = errors.New("ai: streaming unsupported")
+
+// Stream is the interface for streaming responses.
 type Stream interface {
 	// Recv receives the next chunk of the response
 	Recv() (*Response, error)

--- a/ai/openai/openai.go
+++ b/ai/openai/openai.go
@@ -142,7 +142,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 
 // Stream generates a streaming response (not yet implemented)
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
-	return nil, fmt.Errorf("streaming not yet implemented for openai provider")
+	return nil, fmt.Errorf("%w: openai provider", ai.ErrStreamingUnsupported)
 }
 
 // callAPI makes an HTTP request to the OpenAI API

--- a/ai/openai/openai_test.go
+++ b/ai/openai/openai_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go-micro.dev/v6/ai"
@@ -88,8 +89,8 @@ func TestProvider_Stream_NotImplemented(t *testing.T) {
 	}
 
 	_, err := p.Stream(context.Background(), req)
-	if err == nil {
-		t.Error("Expected error for unimplemented streaming, got nil")
+	if !errors.Is(err, ai.ErrStreamingUnsupported) {
+		t.Fatalf("Stream error = %v, want ErrStreamingUnsupported", err)
 	}
 }
 

--- a/ai/together/together.go
+++ b/ai/together/together.go
@@ -119,7 +119,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 }
 
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
-	return nil, fmt.Errorf("streaming not yet implemented for together provider")
+	return nil, fmt.Errorf("%w: together provider", ai.ErrStreamingUnsupported)
 }
 
 func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Response, map[string]any, error) {

--- a/ai/together/together_test.go
+++ b/ai/together/together_test.go
@@ -2,6 +2,7 @@ package together
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go-micro.dev/v6/ai"
@@ -40,8 +41,8 @@ func TestProvider_Generate_NoAPIKey(t *testing.T) {
 }
 
 func TestProvider_Stream_NotImplemented(t *testing.T) {
-	if _, err := NewProvider().Stream(context.Background(), &ai.Request{Prompt: "hi"}); err == nil {
-		t.Error("expected error")
+	if _, err := NewProvider().Stream(context.Background(), &ai.Request{Prompt: "hi"}); !errors.Is(err, ai.ErrStreamingUnsupported) {
+		t.Fatalf("Stream error = %v, want ErrStreamingUnsupported", err)
 	}
 }
 


### PR DESCRIPTION
Summary:\n- Add ai.ErrStreamingUnsupported so callers can reliably distinguish unsupported streaming from transient provider failures with errors.Is.\n- Wrap all current provider Stream stubs with the sentinel and tighten provider tests around that contract.\n\nTesting:\n- go build ./...\n- go test ./ai/...\n- go test ./... (environment loopback restrictions caused existing networking/harness tests to fail)\n- golangci-lint run ./...\n\nCloses #3077