### PR TITLE
Harden agent harness contracts

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -261,6 +261,7 @@ func (a *agentImpl) Run() error {
 
 	a.server = server.NewServer(
 		server.Name(a.opts.Name),
+		server.Address(a.opts.Address),
 		server.Registry(a.opts.Registry),
 		server.Metadata(map[string]string{
 			"type":     "agent",

--- a/agent/options.go
+++ b/agent/options.go
@@ -39,6 +39,7 @@ type Options struct {
 	Provider     string
 	Model        string
 	APIKey       string
+	Address      string
 	Registry     registry.Registry
 	Client       client.Client
 	Store        store.Store
@@ -133,6 +134,13 @@ func Model(m string) Option {
 // APIKey sets the API key for the LLM provider.
 func APIKey(k string) Option {
 	return func(o *Options) { o.APIKey = k }
+}
+
+// Address sets the network address for the agent's service endpoint.
+// Use "127.0.0.1:0" in local harnesses/tests to bind an ephemeral loopback
+// port and avoid advertising the default service address.
+func Address(addr string) Option {
+	return func(o *Options) { o.Address = addr }
 }
 
 // WithRegistry sets the service registry.

--- a/internal/harness/agent-flow/main.go
+++ b/internal/harness/agent-flow/main.go
@@ -207,18 +207,19 @@ func main() {
 	mem := store.NewMemoryStore()
 
 	wsSvc := new(WorkspaceService)
-	ws := service.New(service.Name("workspace"), service.Registry(reg), service.Client(cl))
+	ws := service.New(service.Name("workspace"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	ws.Handle(wsSvc)
 	go ws.Run()
 
 	ntSvc := new(NotifyService)
-	nt := service.New(service.Name("notify"), service.Registry(reg), service.Client(cl))
+	nt := service.New(service.Name("notify"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	nt.Handle(ntSvc)
 	go nt.Run()
 
 	// The onboarder agent, registered so the flow can reach it over RPC.
 	onboarder := agent.New(
 		agent.Name("onboarder"),
+		agent.Address("127.0.0.1:0"),
 		agent.Services("workspace", "notify"),
 		agent.Prompt("You onboard new users. Create their workspace and send a welcome message."),
 		agent.Provider(*provider),

--- a/internal/harness/agent-flow/main_test.go
+++ b/internal/harness/agent-flow/main_test.go
@@ -36,14 +36,14 @@ func TestEventTriggersAgentNoPrompt(t *testing.T) {
 	mem := store.NewMemoryStore()
 
 	wsSvc := new(WorkspaceService)
-	ws := service.New(service.Name("workspace"), service.Registry(reg), service.Client(cl))
+	ws := service.New(service.Name("workspace"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	if err := ws.Handle(wsSvc); err != nil {
 		t.Fatalf("handle workspace: %v", err)
 	}
 	go ws.Run()
 
 	ntSvc := new(NotifyService)
-	nt := service.New(service.Name("notify"), service.Registry(reg), service.Client(cl))
+	nt := service.New(service.Name("notify"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	if err := nt.Handle(ntSvc); err != nil {
 		t.Fatalf("handle notify: %v", err)
 	}
@@ -51,6 +51,7 @@ func TestEventTriggersAgentNoPrompt(t *testing.T) {
 
 	onboarder := agent.New(
 		agent.Name("onboarder"),
+		agent.Address("127.0.0.1:0"),
 		agent.Services("workspace", "notify"),
 		agent.Prompt("You onboard new users. Create their workspace and send a welcome message."),
 		agent.Provider("mock"),

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -47,14 +47,14 @@ func TestPlanDelegateEndToEnd(t *testing.T) {
 
 	// Real services on the shared registry/client.
 	taskSvc := new(TaskService)
-	task := service.New(service.Name("task"), service.Registry(reg), service.Client(cl))
+	task := service.New(service.Name("task"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	if err := task.Handle(taskSvc); err != nil {
 		t.Fatalf("handle task: %v", err)
 	}
 	go task.Run()
 
 	notifySvc := new(NotifyService)
-	notify := service.New(service.Name("notify"), service.Registry(reg), service.Client(cl))
+	notify := service.New(service.Name("notify"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	if err := notify.Handle(notifySvc); err != nil {
 		t.Fatalf("handle notify: %v", err)
 	}
@@ -63,6 +63,7 @@ func TestPlanDelegateEndToEnd(t *testing.T) {
 	// Real comms agent (owns notify), registered so delegate reaches it over RPC.
 	comms := agent.New(
 		agent.Name("comms"),
+		agent.Address("127.0.0.1:0"),
 		agent.Services("notify"),
 		agent.Prompt("You handle outbound notifications."),
 		agent.Provider("mock"),
@@ -80,6 +81,7 @@ func TestPlanDelegateEndToEnd(t *testing.T) {
 	// Real conductor agent (owns task), driven programmatically.
 	conductor := agent.New(
 		agent.Name("conductor"),
+		agent.Address("127.0.0.1:0"),
 		agent.Services("task"),
 		agent.Prompt("Plan first, create tasks, delegate notifications to the comms agent."),
 		agent.Provider("mock"),
@@ -128,14 +130,14 @@ func TestFlowDispatchesToAgentEndToEnd(t *testing.T) {
 	mem := store.NewMemoryStore()
 
 	taskSvc := new(TaskService)
-	task := service.New(service.Name("task"), service.Registry(reg), service.Client(cl))
+	task := service.New(service.Name("task"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	if err := task.Handle(taskSvc); err != nil {
 		t.Fatalf("handle task: %v", err)
 	}
 	go task.Run()
 
 	notifySvc := new(NotifyService)
-	notify := service.New(service.Name("notify"), service.Registry(reg), service.Client(cl))
+	notify := service.New(service.Name("notify"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	if err := notify.Handle(notifySvc); err != nil {
 		t.Fatalf("handle notify: %v", err)
 	}
@@ -143,6 +145,7 @@ func TestFlowDispatchesToAgentEndToEnd(t *testing.T) {
 
 	comms := agent.New(
 		agent.Name("comms"),
+		agent.Address("127.0.0.1:0"),
 		agent.Services("notify"),
 		agent.Prompt("You handle outbound notifications."),
 		agent.Provider("mock"),
@@ -157,6 +160,7 @@ func TestFlowDispatchesToAgentEndToEnd(t *testing.T) {
 	// so the flow can reach it over RPC.
 	conductor := agent.New(
 		agent.Name("conductor"),
+		agent.Address("127.0.0.1:0"),
 		agent.Services("task"),
 		agent.Prompt("Plan first, create tasks, delegate notifications to the comms agent."),
 		agent.Provider("mock"),

--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -207,23 +207,27 @@ func waitFor(reg registry.Registry, names ...string) {
 func main() {
 	provider := flag.String("provider", "mock", "LLM provider: mock (default), anthropic, openai, ...")
 	flag.Parse()
+	os.Exit(runUniverse(*provider))
+}
 
+func runUniverse(provider string) int {
+	failures = 0
 	apiKey := ""
-	if *provider == "mock" {
+	if provider == "mock" {
 		ai.Register("mock", newMock)
-	} else if apiKey = providerKey(*provider); apiKey == "" {
-		fmt.Printf("no API key for provider %q — set MICRO_AI_API_KEY or the provider's key env\n", *provider)
-		os.Exit(2)
+	} else if apiKey = providerKey(provider); apiKey == "" {
+		fmt.Printf("no API key for provider %q — set MICRO_AI_API_KEY or the provider's key env\n", provider)
+		return 2
 	}
 
-	fmt.Printf("\n\033[1mUNIVERSE — booting a mini go-micro world (provider: %s)\033[0m\n\n", *provider)
+	fmt.Printf("\n\033[1mUNIVERSE — booting a mini go-micro world (provider: %s)\033[0m\n\n", provider)
 
 	// Infrastructure — all in-memory, all real.
 	reg := registry.NewMemoryRegistry()
 	br := broker.NewMemoryBroker()
 	if err := br.Connect(); err != nil {
 		fmt.Println("broker connect:", err)
-		os.Exit(2)
+		return 2
 	}
 	cl := client.NewClient(client.Registry(reg), client.Selector(selector.NewSelector(selector.Registry(reg))))
 	st := store.NewMemoryStore()
@@ -231,7 +235,7 @@ func main() {
 	// Services.
 	inv, pay, ord, ntf := new(Inventory), new(Payment), new(Orders), new(Notify)
 	for name, h := range map[string]any{"inventory": inv, "payment": pay, "orders": ord, "notify": ntf} {
-		svc := service.New(service.Name(name), service.Registry(reg), service.Client(cl))
+		svc := service.New(service.Name(name), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 		svc.Handle(h)
 		go svc.Run()
 	}
@@ -243,7 +247,8 @@ func main() {
 		agent.Name("concierge"),
 		agent.Services("notify"),
 		agent.Prompt("You notify buyers when their order is confirmed."),
-		agent.Provider(*provider), agent.APIKey(apiKey),
+		agent.Address("127.0.0.1:0"),
+		agent.Provider(provider), agent.APIKey(apiKey),
 		agent.MaxSteps(5),
 		agent.WrapTool(func(next ai.ToolHandler) ai.ToolHandler {
 			return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
@@ -272,7 +277,7 @@ func main() {
 	)
 	if err := checkout.Register(reg, br, cl); err != nil {
 		fmt.Println("flow register:", err)
-		os.Exit(2)
+		return 2
 	}
 	defer checkout.Stop()
 
@@ -282,7 +287,7 @@ func main() {
 	fmt.Println("\033[1m> event:\033[0m events.order.placed {\"order\":\"order-1\"}")
 	if err := br.Publish("events.order.placed", &broker.Message{Body: []byte(`{"order":"order-1"}`)}); err != nil {
 		fmt.Println("publish:", err)
-		os.Exit(2)
+		return 2
 	}
 
 	// Wait for the run to be checkpointed as failed at "charge".
@@ -352,7 +357,8 @@ func main() {
 
 	if failures > 0 {
 		fmt.Printf("\n\033[31m✗ universe failed: %d assertion(s)\033[0m\n", failures)
-		os.Exit(1)
+		return 1
 	}
 	fmt.Println("\n\033[32m✓ universe: booted, survived a crash, resumed, and shut down cleanly\033[0m")
+	return 0
 }

--- a/internal/harness/universe/main_test.go
+++ b/internal/harness/universe/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestUniverseHarnessContract makes the 0→hero harness part of the ordinary
+// Go test contract. The harness boots real services, a durable workflow, an
+// agent, scoped state, and the A2A gateway with only the LLM mocked; running it
+// here prevents the full services → agents → workflows lifecycle from silently
+// drifting while developers rely on `go test ./...`.
+func TestUniverseHarnessContract(t *testing.T) {
+	if testing.Short() {
+		t.Skip("universe harness boots an end-to-end system; skipped with -short")
+	}
+
+	if code := runUniverse("mock"); code != 0 {
+		t.Fatalf("universe harness exited with code %d", code)
+	}
+}


### PR DESCRIPTION
Summary:
- Add an agent service Address option and wire it into agent.Run so harnesses can bind deterministic loopback addresses.
- Bind the agent-flow, plan-delegate, and universe harness services/agents to 127.0.0.1:0.
- Add a Go test contract for the universe 0→hero harness.

Testing:
- go build ./...
- go test ./... (fails in this sandbox where loopback GRPC/A2A tests are blocked by envoy; harness contract packages pass)
- golangci-lint run ./...

Closes #3079