### PR TITLE
flow: honor canceled checkpoint contexts

### DIFF
--- a/flow/steps.go
+++ b/flow/steps.go
@@ -111,16 +111,25 @@ func StoreCheckpoint(s store.Store, scope string) Checkpoint {
 	return &storeCheckpoint{store: store.Scope(s, "flow", scope)}
 }
 
-func (c *storeCheckpoint) Save(_ context.Context, run Run) error {
+func (c *storeCheckpoint) Save(ctx context.Context, run Run) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	run.Updated = time.Now()
 	b, err := json.Marshal(run)
 	if err != nil {
 		return err
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	return c.store.Write(&store.Record{Key: run.ID, Value: b})
 }
 
-func (c *storeCheckpoint) Load(_ context.Context, runID string) (Run, bool, error) {
+func (c *storeCheckpoint) Load(ctx context.Context, runID string) (Run, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return Run{}, false, err
+	}
 	recs, err := c.store.Read(runID)
 	if err == store.ErrNotFound || len(recs) == 0 {
 		return Run{}, false, nil
@@ -135,11 +144,17 @@ func (c *storeCheckpoint) Load(_ context.Context, runID string) (Run, bool, erro
 	return run, true, nil
 }
 
-func (c *storeCheckpoint) Delete(_ context.Context, runID string) error {
+func (c *storeCheckpoint) Delete(ctx context.Context, runID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	return c.store.Delete(runID)
 }
 
 func (c *storeCheckpoint) List(ctx context.Context) ([]Run, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	keys, err := c.store.List()
 	if err != nil {
 		return nil, err

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -333,6 +333,27 @@ func TestStoreCheckpointListReturnsRunsInStartedOrder(t *testing.T) {
 	}
 }
 
+func TestStoreCheckpointHonorsCanceledContext(t *testing.T) {
+	cp := StoreCheckpoint(store.NewMemoryStore(), "canceled")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	run := Run{ID: "canceled", Started: time.Now()}
+
+	if err := cp.Save(ctx, run); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Save error = %v, want context.Canceled", err)
+	}
+	if _, ok, err := cp.Load(ctx, run.ID); !errors.Is(err, context.Canceled) || ok {
+		t.Fatalf("Load ok, error = %v, %v; want false, context.Canceled", ok, err)
+	}
+	if err := cp.Delete(ctx, run.ID); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Delete error = %v, want context.Canceled", err)
+	}
+	if _, err := cp.List(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("List error = %v, want context.Canceled", err)
+	}
+}
+
 func TestStateSetScan(t *testing.T) {
 	var s State
 	type payload struct {


### PR DESCRIPTION
Summary:
- Make store-backed flow checkpoints return canceled context errors before persisting, loading, deleting, or listing runs.
- Add coverage for canceled checkpoint contexts.

Testing:
- go build ./...
- go test ./flow
- go test ./... (fails in this environment because loopback targets are forbidden for existing grpc/a2a/transport tests)
- golangci-lint run ./...

Closes #3081