### PR TITLE
Show parent runs in agent CLI history

### DIFF
--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -164,6 +164,9 @@ func writeRunIndex(w io.Writer, name string, runs []goagent.RunSummary, asJSON b
 	fmt.Fprintln(w, "  Runs:")
 	for _, run := range runs {
 		line := fmt.Sprintf("    %s  status=%s  events=%d  duration=%s  last=%s  updated=%s", run.RunID, run.Status, run.Events, formatDurationMS(run.DurationMS), run.LastKind, run.UpdatedAt.Format("2006-01-02 15:04:05"))
+		if run.ParentID != "" {
+			line += "  parent=" + run.ParentID
+		}
 		if run.TraceID != "" {
 			line += "  trace=" + shortTraceID(run.TraceID)
 		}
@@ -206,6 +209,9 @@ func writeRunHistory(w io.Writer, name, runID string, events []goagent.RunEvent,
 		}
 		if e.Tokens.TotalTokens > 0 {
 			line += fmt.Sprintf(" tokens=%d", e.Tokens.TotalTokens)
+		}
+		if e.ParentID != "" {
+			line += " parent=" + e.ParentID
 		}
 		if e.TraceID != "" {
 			line += " trace=" + shortTraceID(e.TraceID)

--- a/cmd/micro/cli/agent/agent_test.go
+++ b/cmd/micro/cli/agent/agent_test.go
@@ -45,13 +45,14 @@ func TestWriteRunIndexHumanIncludesStatusAndDuration(t *testing.T) {
 		Events:     2,
 		Status:     "done",
 		LastKind:   "tool",
+		ParentID:   "parent-run",
 	}}
 	var out bytes.Buffer
 	if err := writeRunIndex(&out, "runner", runs, false); err != nil {
 		t.Fatal(err)
 	}
 	line := out.String()
-	for _, want := range []string{"run-1", "status=done", "events=2", "duration=1.2s", "last=tool"} {
+	for _, want := range []string{"run-1", "status=done", "events=2", "duration=1.2s", "last=tool", "parent=parent-run"} {
 		if !strings.Contains(line, want) {
 			t.Fatalf("human output %q missing %q", line, want)
 		}
@@ -70,6 +71,7 @@ func TestWriteRunHistoryHumanAndJSON(t *testing.T) {
 		LatencyMS: 42,
 		Tokens:    ai.Usage{TotalTokens: 5},
 		TraceID:   "1234567890abcdef",
+		ParentID:  "parent-run",
 	}}
 
 	var human bytes.Buffer
@@ -77,7 +79,7 @@ func TestWriteRunHistoryHumanAndJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	line := human.String()
-	for _, want := range []string{"12:34:56.007 tool", "probe", "oteltest/unit-model", "42ms", "tokens=5", "trace=1234567890ab"} {
+	for _, want := range []string{"12:34:56.007 tool", "probe", "oteltest/unit-model", "42ms", "tokens=5", "parent=parent-run", "trace=1234567890ab"} {
 		if !strings.Contains(line, want) {
 			t.Fatalf("human output %q missing %q", line, want)
 		}


### PR DESCRIPTION
Summary:
- Show parent run IDs in human-readable agent run indexes and event history so delegated agent runs are easier to correlate.
- Update CLI agent history tests to cover parent run output.

Testing:
- go build ./...
- go test ./... (fails in this sandbox: loopback targets forbidden for grpc/a2a transport tests)
- go test ./cmd/micro/cli/agent
- golangci-lint run ./...

Closes #3083