### PR TITLE
ci: add DevRel + Architect overseer passes to the loop

### DIFF
--- a/.github/workflows/architecture-review.yml
+++ b/.github/workflows/architecture-review.yml
@@ -1,0 +1,48 @@
+name: Architecture Review
+
+# Periodic high-altitude review of the whole framework and harness against the
+# North Star (internal/docs/THESIS.md) — part of the autonomous loop
+# (internal/docs/CONTINUOUS_IMPROVEMENT.md). Where DevRel watches the public
+# story, the architect watches the system: API coherence, lifecycle gaps, and
+# whether recent increments are converging on the thesis or sprawling.
+#
+# The architect's OUTPUT is an assessment plus scoped follow-up issues that feed
+# the hourly increment loop — NOT large refactors. Breaking public-API and
+# architectural changes stay with the human (see CONTINUOUS_IMPROVEMENT.md).
+#
+# Opens a fresh issue and dispatches Codex via CODEX_TRIGGER_TOKEN.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 8 */3 * *" # roughly every 3 days, 08:00 UTC (tunable)
+
+permissions:
+  issues: write
+
+concurrency:
+  group: architecture-review
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open an architecture review issue and dispatch Codex
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_TRIGGER_TOKEN || github.token }}
+          HAS_TRIGGER_TOKEN: ${{ secrets.CODEX_TRIGGER_TOKEN != '' }}
+          REPO: ${{ github.repository }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          if [ "$HAS_TRIGGER_TOKEN" != "true" ]; then
+            echo "CODEX_TRIGGER_TOKEN is not set — skipping (Codex ignores Actions-bot comments)."
+            exit 0
+          fi
+          ISSUE_URL=$(gh issue create --repo "$REPO" \
+            --title "Architecture review #$RUN_NUMBER" \
+            --body "Periodic architecture / harness review against the North Star in internal/docs/THESIS.md. Output: an assessment plus scoped follow-up issues for the increment loop.")
+          ISSUE_NUM="${ISSUE_URL##*/}"
+          echo "Opened issue #$ISSUE_NUM — dispatching Codex (Architect)."
+          gh issue comment "$ISSUE_NUM" --repo "$REPO" --body \
+          "@codex Act as the architect for go-micro. Review the overall framework and harness against the North Star in internal/docs/THESIS.md (services → agents → workflows as one runtime) and the roadmap in ROADMAP.md. Assess: API coherence and consistency across the core packages (agent, ai, flow, gateway/mcp, gateway/a2a, model, server, store, registry), gaps or missing pieces in the services → agents → workflows lifecycle, duplication or drift, and whether recent increments (scan recently merged PRs) are converging on the thesis or sprawling. Then: (A) post a concise architectural assessment as a comment on this issue (#$ISSUE_NUM) — strengths, the top risks/gaps, and a recommended direction for the next increments; (B) file concrete, scoped follow-up issues for the highest-value gaps so the hourly increment loop can pick them up — \`gh issue create --label codex --label enhancement --title \"<scoped task>\" --body \"<goal, scope, acceptance criteria>\"\` (each must be a single, self-contained, CI-verifiable chunk). Do NOT make breaking public-API or architectural changes yourself — your output is the assessment and the issues. A small, safe doc/comment correction may be a PR (\`git switch -c codex/architect-$ISSUE_NUM\` … \`gh pr create --base master --label codex …\` … \`gh pr merge --squash --auto --delete-branch\`). Do not use the make_pr tool (it is a no-op stub)."

--- a/.github/workflows/devrel-review.yml
+++ b/.github/workflows/devrel-review.yml
@@ -1,0 +1,47 @@
+name: DevRel Review
+
+# Daily higher-altitude coherence pass over the PUBLIC surface — README,
+# website (landing + docs), and blog — part of the autonomous loop
+# (internal/docs/CONTINUOUS_IMPROVEMENT.md). The hourly increment loop ships
+# code; this keeps the story coherent: docs/website aligned, README crisp, and
+# a steady supply of things worth blogging about.
+#
+# Like the increment loop it opens a fresh issue and dispatches Codex via
+# CODEX_TRIGGER_TOKEN (Codex ignores Actions-bot comments). Autonomy boundary:
+# SAFE factual-alignment and crispness fixes auto-merge; brand/positioning copy
+# and blog drafts are surfaced in the report for the human, never auto-merged.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 7 * * *" # daily, 07:00 UTC (tunable)
+
+permissions:
+  issues: write
+
+concurrency:
+  group: devrel-review
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open a DevRel review issue and dispatch Codex
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_TRIGGER_TOKEN || github.token }}
+          HAS_TRIGGER_TOKEN: ${{ secrets.CODEX_TRIGGER_TOKEN != '' }}
+          REPO: ${{ github.repository }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          if [ "$HAS_TRIGGER_TOKEN" != "true" ]; then
+            echo "CODEX_TRIGGER_TOKEN is not set — skipping (Codex ignores Actions-bot comments)."
+            exit 0
+          fi
+          ISSUE_URL=$(gh issue create --repo "$REPO" \
+            --title "DevRel coherence review #$RUN_NUMBER" \
+            --body "Daily DevRel / coherence pass over README, website (landing + docs), and the blog. North Star: internal/docs/THESIS.md.")
+          ISSUE_NUM="${ISSUE_URL##*/}"
+          echo "Opened issue #$ISSUE_NUM — dispatching Codex (DevRel)."
+          gh issue comment "$ISSUE_NUM" --repo "$REPO" --body \
+          "@codex Act as DevRel for go-micro. Audit the PUBLIC surface — \`README.md\`, \`internal/website/\` (landing \`index.html\` + \`docs/\`), and the blog under \`internal/website/blog/\` — for coherence with the North Star in internal/docs/THESIS.md (an agent harness and service framework; the services → agents → workflows lifecycle). Look for: (1) places where README / website / docs contradict each other, are stale, or describe behavior that has since changed (cross-check against the code and recent merged PRs / CHANGELOG.md); (2) whether the README is crisp and leads with the harness positioning; (3) one to three genuinely blog-worthy items from recently shipped work. Then do BOTH of these: (A) post a concise findings report as a comment on this issue (#$ISSUE_NUM) — what is aligned, what drifted, what you fixed, and the blog ideas; (B) for SAFE factual-alignment and crispness fixes only (NOT brand/marketing/positioning rewrites), open one PR: \`git switch -c codex/devrel-$ISSUE_NUM\`, \`git push -u origin codex/devrel-$ISSUE_NUM\`, \`gh pr create --base master --label codex --title \"<title>\" --body \"<summary, including 'Closes #$ISSUE_NUM'>\"\`, then \`gh pr merge --squash --auto --delete-branch\`. Leave brand/positioning copy and blog drafts for the human — describe them in the report, do NOT open auto-merging PRs for them. Do not use the make_pr tool (it is a no-op stub). If you touch code, verify go build/test/golangci-lint. Stay out of breaking public-API changes."

--- a/internal/docs/CONTINUOUS_IMPROVEMENT.md
+++ b/internal/docs/CONTINUOUS_IMPROVEMENT.md
@@ -121,6 +121,29 @@ merged PRs. Each scheduled run:
   actually appears). Re-doing it creates duplicate PRs and stale branches that
   then block the next run. Wait for the PR, or let it ride.
 
+## Overseer passes (DevRel + Architect)
+
+The hourly loop ships increments; two periodic passes keep the *whole* heading in
+the right direction. Both use the same mechanism (fresh issue → `@codex` →
+output) but produce direction and coherence, not just code.
+
+- **DevRel — daily** (`.github/workflows/devrel-review.yml`). Audits the public
+  surface (README, website landing + docs, blog) for coherence with the North
+  Star, README crispness, and blog-worthy material. **Autonomy boundary:** safe
+  factual-alignment and crispness fixes auto-merge like any increment;
+  brand/positioning copy and blog drafts are *surfaced in a report* for the
+  human, never auto-merged.
+- **Architect — every few days** (`.github/workflows/architecture-review.yml`).
+  Reviews the framework/harness against the thesis: API coherence, lifecycle
+  gaps, drift/sprawl. **Its output is an assessment plus scoped follow-up
+  issues** that feed the hourly increment loop — it does **not** make breaking or
+  architectural changes itself (those stay with the human).
+
+Together they close the loop: the architect decides *what* should change and files
+issues, the increment loop *builds* them, and DevRel keeps the public story
+honest. Cadence is tunable in each workflow's `cron`. Codex is serial, so these
+passes queue behind any in-flight increment rather than running concurrently.
+
 ## Stop / redirect
 
 - In-session: `CronDelete <id>` (or end the session).


### PR DESCRIPTION
The hourly loop ships increments, but nothing watches the **whole**. This adds two periodic, higher-altitude overseer passes — same dispatch mechanism (fresh issue → `@codex` → output), with autonomy boundaries that respect the existing guardrails (brand/positioning and architecture stay human-gated).

**`devrel-review.yml` (daily):** audits the public surface — README, website landing + docs, blog — for coherence with the North Star, README crispness, and blog-worthy material. Posts a findings report on its issue; opens an auto-merging PR **only** for safe factual-alignment/crispness fixes. Brand/positioning copy and blog drafts are surfaced in the report for you, never auto-merged.

**`architecture-review.yml` (~every 3 days):** reviews the framework/harness against the thesis (API coherence, lifecycle gaps, drift/sprawl), posts an assessment, and **files scoped follow-up issues** that feed the hourly increment loop. It does not make breaking/architectural changes itself.

Together: the architect decides *what* should change and files issues, the increment loop *builds* them, DevRel keeps the public story honest. Documented under "Overseer passes" in `CONTINUOUS_IMPROVEMENT.md`. Cadence is tunable per workflow `cron`; Codex is serial so these queue behind in-flight increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_