### PR TITLE
Add deterministic AI capability rows

### DIFF
--- a/ai/capabilities.go
+++ b/ai/capabilities.go
@@ -2,6 +2,13 @@ package ai
 
 import "sort"
 
+// CapabilityRow is one deterministic row in a provider capability matrix.
+type CapabilityRow struct {
+	// Provider is the registered provider name.
+	Provider string
+	Capabilities
+}
+
 // Capabilities describes the AI interfaces a provider has registered.
 // It is intentionally based on package registration rather than external
 // provider marketing claims, so it reflects what this build can actually use.
@@ -27,9 +34,10 @@ func ProviderCapabilities(provider string) Capabilities {
 	}
 }
 
-// CapabilityMatrix returns a stable snapshot of all registered AI providers and
-// the interfaces they support. The returned map is a copy and can be modified by
-// callers without mutating the registry.
+// CapabilityMatrix returns a snapshot of all registered AI providers and the
+// interfaces they support. The returned map is a copy and can be modified by
+// callers without mutating the registry. Use CapabilityRows when rendering a
+// deterministic table or report.
 func CapabilityMatrix() map[string]Capabilities {
 	names := map[string]struct{}{}
 	for name := range providers {
@@ -47,6 +55,21 @@ func CapabilityMatrix() map[string]Capabilities {
 		matrix[name] = ProviderCapabilities(name)
 	}
 	return matrix
+}
+
+// CapabilityRows returns a deterministic capability support matrix for every
+// registered AI provider. It is the ordered form of CapabilityMatrix, intended
+// for CLIs, docs generators, and conformance reports that need stable output.
+func CapabilityRows() []CapabilityRow {
+	names := RegisteredProviders("")
+	rows := make([]CapabilityRow, 0, len(names))
+	for _, name := range names {
+		rows = append(rows, CapabilityRow{
+			Provider:     name,
+			Capabilities: ProviderCapabilities(name),
+		})
+	}
+	return rows
 }
 
 // RegisteredProviders returns the registered provider names in sorted order.

--- a/ai/capabilities_test.go
+++ b/ai/capabilities_test.go
@@ -34,6 +34,22 @@ func TestRegisteredProviders(t *testing.T) {
 	}
 }
 
+func TestCapabilityRows(t *testing.T) {
+	got := ai.CapabilityRows()
+	want := []ai.CapabilityRow{
+		{Provider: "anthropic", Capabilities: ai.Capabilities{Model: true}},
+		{Provider: "atlascloud", Capabilities: ai.Capabilities{Model: true, Image: true, Video: true}},
+		{Provider: "gemini", Capabilities: ai.Capabilities{Model: true}},
+		{Provider: "groq", Capabilities: ai.Capabilities{Model: true}},
+		{Provider: "mistral", Capabilities: ai.Capabilities{Model: true}},
+		{Provider: "openai", Capabilities: ai.Capabilities{Model: true, Image: true}},
+		{Provider: "together", Capabilities: ai.Capabilities{Model: true}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CapabilityRows() = %#v, want %#v", got, want)
+	}
+}
+
 func TestCapabilityMatrix(t *testing.T) {
 	matrix := ai.CapabilityMatrix()
 

--- a/internal/website/docs/guides/ai-provider-guide.md
+++ b/internal/website/docs/guides/ai-provider-guide.md
@@ -29,9 +29,8 @@ runtime tooling and docs can report what is actually available after blank
 imports are linked in:
 
 ```go
-matrix := ai.CapabilityMatrix()
-for provider, caps := range matrix {
-    fmt.Printf("%s: chat=%t image=%t video=%t\n", provider, caps.Model, caps.Image, caps.Video)
+for _, row := range ai.CapabilityRows() {
+    fmt.Printf("%s: chat=%t image=%t video=%t\n", row.Provider, row.Model, row.Image, row.Video)
 }
 ```
 


### PR DESCRIPTION
Summary:
- Add ordered AI provider capability rows for stable tooling/docs output.
- Cover the deterministic provider matrix with tests.
- Update the provider guide to use the ordered row API.

Testing:
- go build ./...
- go test ./... (fails in this sandbox because loopback targets are forbidden for grpc/a2a tests)
- golangci-lint run ./...

Closes #3086