### PR TITLE
Add flow run correlation to step contexts

### DIFF
--- a/flow/steps.go
+++ b/flow/steps.go
@@ -383,6 +383,7 @@ func (f *Flow) Pending(ctx context.Context) ([]Run, error) {
 func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 	steps := f.opts.Steps
 	ctx = withDeps(ctx, &runDeps{client: f.client, model: f.model, tools: f.toolSet})
+	ctx = ai.WithRunInfo(ctx, ai.RunInfo{RunID: run.ID, Agent: f.name})
 
 	start := stepIndex(steps, run.State.Stage)
 	if start < 0 {

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/store"
 )
 
@@ -83,6 +84,33 @@ func TestFlowCheckpointResume(t *testing.T) {
 	}
 	if pend, _ := f.Pending(context.Background()); len(pend) != 0 {
 		t.Errorf("expected no pending runs after a successful resume, got %d", len(pend))
+	}
+}
+
+func TestFlowStepContextIncludesRunInfo(t *testing.T) {
+	var got ai.RunInfo
+	step := Step{Name: "inspect", Run: func(ctx context.Context, in State) (State, error) {
+		var ok bool
+		got, ok = ai.RunInfoFrom(ctx)
+		if !ok {
+			t.Fatal("RunInfo missing from step context")
+		}
+		in.Data = []byte("ok")
+		return in, nil
+	}}
+
+	f := New("correlated",
+		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "correlated")),
+		Steps(step),
+	)
+	if err := f.Execute(context.Background(), "start"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got.Agent != "correlated" {
+		t.Fatalf("RunInfo.Agent = %q, want correlated", got.Agent)
+	}
+	if got.RunID == "" {
+		t.Fatal("RunInfo.RunID is empty")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Attach ai.RunInfo to checkpointed flow step contexts using the durable flow run ID and flow name.
- Add coverage that a flow step can read the run correlation metadata from context.

## Testing
- go build ./...
- go test ./flow
- go test ./... (fails in this environment due loopback targets forbidden for grpc/a2a tests)
- golangci-lint run ./...

Closes #3088