### PR TITLE
provider conformance: publish capability matrix

### DIFF
--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -22,6 +22,15 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"go-micro.dev/v6/ai"
+	_ "go-micro.dev/v6/ai/anthropic"
+	_ "go-micro.dev/v6/ai/atlascloud"
+	_ "go-micro.dev/v6/ai/gemini"
+	_ "go-micro.dev/v6/ai/groq"
+	_ "go-micro.dev/v6/ai/mistral"
+	_ "go-micro.dev/v6/ai/openai"
+	_ "go-micro.dev/v6/ai/together"
 )
 
 var providerEnv = map[string]string{
@@ -39,6 +48,7 @@ func main() {
 	harnessesFlag := flag.String("harnesses", "universe,agent-flow,plan-delegate", "comma-separated harness names under internal/harness")
 	timeoutFlag := flag.Duration("timeout", 10*time.Minute, "timeout per provider/harness run")
 	requireConfiguredFlag := flag.Bool("require-configured", false, "fail when a selected live provider is missing an API key")
+	capabilitiesFlag := flag.Bool("capabilities", true, "print the registered provider capability matrix before running conformance")
 	flag.Parse()
 
 	providers := splitCSV(*providersFlag)
@@ -46,6 +56,10 @@ func main() {
 	if err := validateSelection(providers, harnesses); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
+	}
+
+	if *capabilitiesFlag {
+		printCapabilityMatrix()
 	}
 
 	var ran, skipped, failed int
@@ -77,6 +91,22 @@ func main() {
 	if failed > 0 {
 		os.Exit(1)
 	}
+}
+
+func printCapabilityMatrix() {
+	fmt.Println("Provider capability matrix:")
+	fmt.Println("provider     model  image  video")
+	for _, row := range ai.CapabilityRows() {
+		fmt.Printf("%-12s %-5s  %-5s  %-5s\n", row.Provider, yesNo(row.Model), yesNo(row.Image), yesNo(row.Video))
+	}
+	fmt.Println()
+}
+
+func yesNo(ok bool) string {
+	if ok {
+		return "yes"
+	}
+	return "no"
 }
 
 func validateSelection(providers, harnesses []string) error {

--- a/internal/harness/provider-conformance/main_test.go
+++ b/internal/harness/provider-conformance/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"go-micro.dev/v6/ai"
 )
 
 func TestValidateSelectionAcceptsKnownProviderAndHarness(t *testing.T) {
@@ -28,5 +30,25 @@ func TestValidateSelectionRejectsUnsafeHarnessName(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `invalid harness name "../agent-flow"`) {
 		t.Fatalf("validateSelection error = %q, want invalid harness message", err)
+	}
+}
+
+func TestCapabilityMatrixHasRegisteredProviders(t *testing.T) {
+	rows := ai.CapabilityRows()
+	if len(rows) == 0 {
+		t.Fatal("CapabilityRows returned no providers")
+	}
+
+	var foundOpenAI bool
+	for _, row := range rows {
+		if row.Provider == "openai" {
+			foundOpenAI = true
+			if !row.Model || !row.Image || row.Video {
+				t.Fatalf("openai capabilities = %#v, want model+image only", row.Capabilities)
+			}
+		}
+	}
+	if !foundOpenAI {
+		t.Fatalf("CapabilityRows = %#v, want openai row", rows)
 	}
 }


### PR DESCRIPTION
Summary:
- Print the registered provider capability matrix before provider-conformance runs so conformance output shows model/image/video support.
- Register built-in AI providers in the conformance command so the matrix reflects this build.
- Add a unit check that the conformance command sees registered provider capabilities.

Testing:
- go build ./...
- go test ./internal/harness/provider-conformance
- go test ./... (fails in this environment: cache expiry timing and loopback targets forbidden for grpc/a2a/transport tests)
- golangci-lint run ./...

Closes #3091