### PR TITLE
Correlate agent trace spans

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -124,7 +124,13 @@ func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.
 	info, _ := ai.RunInfoFrom(ctx)
 	provider := m.String()
 	model := m.Options().Model
-	ctx, span := m.a.tracer().Start(ctx, spanNameModelCall, trace.WithAttributes(attribute.String(AttrProvider, provider), attribute.String(AttrModel, model)))
+	ctx, span := m.a.tracer().Start(ctx, spanNameModelCall, trace.WithAttributes(
+		attribute.String(AttrRunID, info.RunID),
+		attribute.String(AttrParentRunID, info.ParentID),
+		attribute.String(AttrAgentName, info.Agent),
+		attribute.String(AttrProvider, provider),
+		attribute.String(AttrModel, model),
+	))
 	start := time.Now()
 	resp, err := m.Model.Generate(ctx, req, opts...)
 	dur := time.Since(start).Milliseconds()
@@ -169,7 +175,13 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 	}
 	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
 		info, _ := ai.RunInfoFrom(ctx)
-		ctx, span := a.tracer().Start(ctx, spanNameToolCall, trace.WithAttributes(attribute.String(AttrToolName, call.Name), attribute.Bool(AttrDelegate, call.Name == toolDelegate)))
+		ctx, span := a.tracer().Start(ctx, spanNameToolCall, trace.WithAttributes(
+			attribute.String(AttrRunID, info.RunID),
+			attribute.String(AttrParentRunID, info.ParentID),
+			attribute.String(AttrAgentName, info.Agent),
+			attribute.String(AttrToolName, call.Name),
+			attribute.Bool(AttrDelegate, call.Name == toolDelegate),
+		))
 		start := time.Now()
 		res := next(ctx, call)
 		dur := time.Since(start).Milliseconds()

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/store"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
@@ -46,14 +47,31 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	}
 	spans := exp.GetSpans().Snapshots()
 	want := map[string]bool{spanNameRun: false, spanNameModelCall: false, spanNameToolCall: false}
+	var runID string
 	for _, s := range spans {
 		if _, ok := want[s.Name()]; ok {
 			want[s.Name()] = true
+		}
+		attrs := spanAttributes(s.Attributes())
+		if s.Name() == spanNameRun {
+			runID = attrs[AttrRunID]
 		}
 	}
 	for name, seen := range want {
 		if !seen {
 			t.Fatalf("span %s not emitted; got %d spans", name, len(spans))
+		}
+	}
+	if runID == "" {
+		t.Fatal("run span missing run id attribute")
+	}
+	for _, s := range spans {
+		if s.Name() != spanNameModelCall && s.Name() != spanNameToolCall {
+			continue
+		}
+		attrs := spanAttributes(s.Attributes())
+		if attrs[AttrRunID] != runID || attrs[AttrAgentName] != "runner" {
+			t.Fatalf("%s missing run correlation attributes: %#v", s.Name(), attrs)
 		}
 	}
 	keys, err := store.Scope(st, "agent", "runner").List(store.ListPrefix("runs/"))
@@ -89,6 +107,14 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	if len(events) == 0 || events[0].TraceID == "" || events[0].SpanID == "" {
 		t.Fatalf("events missing trace correlation: %#v", events)
 	}
+}
+
+func spanAttributes(attrs []attribute.KeyValue) map[string]string {
+	out := make(map[string]string, len(attrs))
+	for _, attr := range attrs {
+		out[string(attr.Key)] = attr.Value.AsString()
+	}
+	return out
 }
 
 func TestAgentOpenTelemetryNoopWhenUnconfigured(t *testing.T) {


### PR DESCRIPTION
Summary:
- Add agent run correlation attributes to model and tool spans so traces can be joined by run id and agent name.
- Extend OpenTelemetry tests to verify child spans carry the same run id as the run span.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback targets are forbidden by envoy in grpc/a2a tests)
- golangci-lint run ./...

Closes #3093