### PR TITLE
Stop agent tools after context cancellation

### DIFF
--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -108,11 +108,27 @@ func (a *agentImpl) toolHandler() ai.ToolHandler {
 	h = a.loopWrap(h)
 	h = a.stepWrap(h)
 	h = a.planWrap(h)
+	h = contextWrap(h)
 	h = a.traceTool(h)
 	for i := len(a.opts.wrappers) - 1; i >= 0; i-- {
 		h = a.opts.wrappers[i](h)
 	}
 	return h
+}
+
+// contextWrap stops tool execution promptly when the Ask context has
+// already been canceled or its deadline has expired. This keeps guardrail
+// bookkeeping and side-effecting tools from running after the caller has
+// abandoned the agent run.
+func contextWrap(next ai.ToolHandler) ai.ToolHandler {
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		select {
+		case <-ctx.Done():
+			return errResult(call.ID, ctx.Err().Error())
+		default:
+		}
+		return next(ctx, call)
+	}
 }
 
 // baseHandler executes a tool call: a developer custom tool, the built-in

--- a/agent/resilience_test.go
+++ b/agent/resilience_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,5 +74,31 @@ func TestAskRetriesTransientErrorsThenSurfacesStructuredError(t *testing.T) {
 	}
 	if attempts != 2 {
 		t.Fatalf("model attempts = %d, want 2", attempts)
+	}
+}
+
+func TestCanceledAskContextSkipsToolExecution(t *testing.T) {
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if opts.ToolHandler == nil {
+			t.Fatal("missing tool handler")
+		}
+		canceled, cancel := context.WithCancel(ctx)
+		cancel()
+		res := opts.ToolHandler(canceled, ai.ToolCall{ID: "call-1", Name: toolPlan, Input: map[string]any{
+			"steps": []any{map[string]any{"task": "should not persist", "status": "pending"}},
+		}})
+		if !strings.Contains(res.Content, context.Canceled.Error()) {
+			t.Fatalf("tool result = %q, want cancellation error", res.Content)
+		}
+		return &ai.Response{Reply: "ok"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("cancel-tools"))
+	if _, err := a.Ask(context.Background(), "try a canceled tool"); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if plan := a.loadPlan(); plan != "" {
+		t.Fatalf("plan persisted after canceled tool context: %q", plan)
 	}
 }


### PR DESCRIPTION
Summary:
- Add an agent tool-handler context gate so canceled/deadline-expired Ask contexts stop before plan bookkeeping or side-effecting tool calls.
- Add a regression test proving a canceled tool context returns cancellation and does not persist plan state.

Testing:
- go build ./... (pass)
- go test -run TestCanceledAskContextSkipsToolExecution -v ./agent (pass)
- go test ./... (fails in sandbox: loopback targets forbidden in grpc/a2a/transport tests)
- golangci-lint run ./... (pass)

Closes #3095