### PR TITLE
Add OpenTelemetry spans for stepped flows

### DIFF
--- a/flow/options.go
+++ b/flow/options.go
@@ -1,6 +1,10 @@
 package flow
 
-import "time"
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/trace"
+)
 
 // Options configures a Flow.
 type Options struct {
@@ -40,6 +44,8 @@ type Options struct {
 	// Checkpoint is the durability backend for stepped runs. Nil with
 	// steps present means a store-backed default; set it to swap backends.
 	Checkpoint Checkpoint
+	// TraceProvider emits OpenTelemetry spans for stepped flow runs.
+	TraceProvider trace.TracerProvider
 	// DeleteOnSuccess removes a run's checkpoint when it completes
 	// successfully. Failed runs are always retained. Default: retain all.
 	DeleteOnSuccess bool
@@ -131,4 +137,9 @@ func WithCheckpoint(c Checkpoint) Option {
 // successfully. Failed runs are always retained. Default: retain all.
 func DeleteOnSuccess() Option {
 	return func(o *Options) { o.DeleteOnSuccess = true }
+}
+
+// TraceProvider enables OpenTelemetry spans for stepped flow runs and steps.
+func TraceProvider(tp trace.TracerProvider) Option {
+	return func(o *Options) { o.TraceProvider = tp }
 }

--- a/flow/otel.go
+++ b/flow/otel.go
@@ -1,0 +1,80 @@
+package flow
+
+import (
+	"context"
+	"time"
+
+	"go-micro.dev/v6/ai"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const flowInstrumentationName = "go-micro.dev/v6/flow"
+
+const (
+	spanNameFlowRun  = "flow.run"
+	spanNameFlowStep = "flow.step"
+
+	AttrFlowRunID     = "flow.run.id"
+	AttrFlowName      = "flow.name"
+	AttrFlowStepName  = "flow.step.name"
+	AttrFlowStatus    = "flow.status"
+	AttrFlowAttempts  = "flow.step.attempts"
+	AttrFlowLatencyMS = "flow.latency_ms"
+)
+
+func (f *Flow) tracer() trace.Tracer {
+	return f.opts.TraceProvider.Tracer(flowInstrumentationName)
+}
+
+func (f *Flow) startRunSpan(ctx context.Context, run Run) (context.Context, func(Run, error)) {
+	if f.opts.TraceProvider == nil {
+		return ctx, func(Run, error) {}
+	}
+	ctx, span := f.tracer().Start(ctx, spanNameFlowRun, trace.WithSpanKind(trace.SpanKindInternal), trace.WithAttributes(
+		attribute.String(AttrFlowRunID, run.ID),
+		attribute.String(AttrFlowName, f.name),
+		attribute.String(AttrFlowStatus, run.Status),
+	))
+	start := time.Now()
+	return ctx, func(done Run, err error) {
+		span.SetAttributes(
+			attribute.String(AttrFlowStatus, done.Status),
+			attribute.Int64(AttrFlowLatencyMS, time.Since(start).Milliseconds()),
+		)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		} else {
+			span.SetStatus(codes.Ok, "")
+		}
+		span.End()
+	}
+}
+
+func (f *Flow) runStepSpan(ctx context.Context, step Step, in State) (State, int, error) {
+	if f.opts.TraceProvider == nil {
+		return f.runStep(ctx, step, in)
+	}
+	info, _ := ai.RunInfoFrom(ctx)
+	ctx, span := f.tracer().Start(ctx, spanNameFlowStep, trace.WithAttributes(
+		attribute.String(AttrFlowRunID, info.RunID),
+		attribute.String(AttrFlowName, f.name),
+		attribute.String(AttrFlowStepName, step.Name),
+	))
+	start := time.Now()
+	out, attempts, err := f.runStep(ctx, step, in)
+	span.SetAttributes(
+		attribute.Int(AttrFlowAttempts, attempts),
+		attribute.Int64(AttrFlowLatencyMS, time.Since(start).Milliseconds()),
+	)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	span.End()
+	return out, attempts, err
+}

--- a/flow/otel_test.go
+++ b/flow/otel_test.go
@@ -1,0 +1,70 @@
+package flow
+
+import (
+	"context"
+	"testing"
+
+	"go-micro.dev/v6/store"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestFlowOpenTelemetrySpans(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exp))
+
+	step := Step{Name: "inspect", Run: func(ctx context.Context, in State) (State, error) {
+		in.Data = []byte("done")
+		return in, nil
+	}}
+	f := New("observed", WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "observed")), TraceProvider(tp), Steps(step))
+	if err := f.Execute(context.Background(), "start"); err != nil {
+		t.Fatal(err)
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	seen := map[string]bool{spanNameFlowRun: false, spanNameFlowStep: false}
+	var runID string
+	for _, span := range spans {
+		attrs := flowSpanAttributes(span.Attributes())
+		switch span.Name() {
+		case spanNameFlowRun:
+			seen[spanNameFlowRun] = true
+			runID = attrs[AttrFlowRunID]
+			if attrs[AttrFlowName] != "observed" || attrs[AttrFlowStatus] != "done" {
+				t.Fatalf("run span attributes = %#v", attrs)
+			}
+		case spanNameFlowStep:
+			seen[spanNameFlowStep] = true
+			if attrs[AttrFlowName] != "observed" || attrs[AttrFlowStepName] != "inspect" {
+				t.Fatalf("step span attributes = %#v", attrs)
+			}
+		}
+	}
+	for name, ok := range seen {
+		if !ok {
+			t.Fatalf("span %s not emitted; got %d spans", name, len(spans))
+		}
+	}
+	if runID == "" {
+		t.Fatal("run span missing run id")
+	}
+	for _, span := range spans {
+		if span.Name() != spanNameFlowStep {
+			continue
+		}
+		attrs := flowSpanAttributes(span.Attributes())
+		if attrs[AttrFlowRunID] != runID {
+			t.Fatalf("step span run id = %q, want %q", attrs[AttrFlowRunID], runID)
+		}
+	}
+}
+
+func flowSpanAttributes(attrs []attribute.KeyValue) map[string]string {
+	out := make(map[string]string, len(attrs))
+	for _, attr := range attrs {
+		out[string(attr.Key)] = attr.Value.AsString()
+	}
+	return out
+}

--- a/flow/steps.go
+++ b/flow/steps.go
@@ -384,6 +384,9 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 	steps := f.opts.Steps
 	ctx = withDeps(ctx, &runDeps{client: f.client, model: f.model, tools: f.toolSet})
 	ctx = ai.WithRunInfo(ctx, ai.RunInfo{RunID: run.ID, Agent: f.name})
+	ctx, finishSpan := f.startRunSpan(ctx, run)
+	var spanErr error
+	defer func() { finishSpan(run, spanErr) }()
 
 	start := stepIndex(steps, run.State.Stage)
 	if start < 0 {
@@ -400,9 +403,10 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 		run.Steps[i].Status = "in_progress"
 		f.save(ctx, run)
 
-		out, attempts, err := f.runStep(ctx, step, run.State)
+		out, attempts, err := f.runStepSpan(ctx, step, run.State)
 		run.Steps[i].Attempts = attempts
 		if err != nil {
+			spanErr = err
 			run.Steps[i].Status = "failed"
 			run.Steps[i].Error = err.Error()
 			run.Status = "failed"

--- a/micro.go
+++ b/micro.go
@@ -12,6 +12,7 @@ import (
 	"go-micro.dev/v6/server"
 	"go-micro.dev/v6/service"
 	"go-micro.dev/v6/store"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type serviceKey struct{}
@@ -200,6 +201,9 @@ func FlowWithCheckpoint(c Checkpoint) FlowOption { return flow.WithCheckpoint(c)
 // FlowDeleteOnSuccess removes a run's checkpoint on success (failed runs
 // are always kept). Default: retain all.
 func FlowDeleteOnSuccess() FlowOption { return flow.DeleteOnSuccess() }
+
+// FlowTraceProvider enables OpenTelemetry spans for stepped flow runs and steps.
+func FlowTraceProvider(tp trace.TracerProvider) FlowOption { return flow.TraceProvider(tp) }
 
 // FlowCall is a step action: an RPC to a service endpoint, sending the
 // state data as the request and storing the response.


### PR DESCRIPTION
Adds OpenTelemetry tracing for durable stepped flow runs and individual steps, extending run observability from agents into workflows while keeping the API additive.

Testing:
- go build ./...
- go test ./flow
- go test ./... (fails in this environment: cache expiration timing, loopback-forbidden gRPC/A2A/transport tests)
- golangci-lint run ./...

Closes #3097