### PR TITLE
Add pending filter for flow run history

### DIFF
--- a/cmd/micro/flow/flow.go
+++ b/cmd/micro/flow/flow.go
@@ -75,6 +75,7 @@ Examples:
 				ArgsUsage: "[name]",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{Name: "json", Usage: "Print durable run history as JSON for automation"},
+					&cli.BoolFlag{Name: "pending", Usage: "Only show runs that have not completed"},
 				},
 				Action: flowRuns,
 			},
@@ -129,11 +130,31 @@ func flowRuns(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	if c.Bool("pending") {
+		runs = pendingFlowRuns(runs)
+	}
 	if len(runs) == 0 {
+		if c.Bool("pending") {
+			fmt.Printf("  No pending runs recorded for flow %q.\n", name)
+			return nil
+		}
 		fmt.Printf("  No runs recorded for flow %q.\n", name)
 		return nil
 	}
 	return writeFlowRuns(os.Stdout, runs, c.Bool("json"))
+}
+
+func pendingFlowRuns(runs []aiflow.Run) []aiflow.Run {
+	if len(runs) == 0 {
+		return nil
+	}
+	pending := make([]aiflow.Run, 0, len(runs))
+	for _, run := range runs {
+		if run.Status != "done" {
+			pending = append(pending, run)
+		}
+	}
+	return pending
 }
 
 func writeFlowRuns(w io.Writer, runs []aiflow.Run, asJSON bool) error {

--- a/cmd/micro/flow/flow_test.go
+++ b/cmd/micro/flow/flow_test.go
@@ -55,3 +55,19 @@ func TestWriteFlowRunsJSON(t *testing.T) {
 		t.Fatalf("decoded runs = %+v", got)
 	}
 }
+
+func TestPendingFlowRunsFiltersCompletedRuns(t *testing.T) {
+	runs := []aiflow.Run{
+		{ID: "run-1", Status: "done"},
+		{ID: "run-2", Status: "failed"},
+		{ID: "run-3", Status: "running"},
+	}
+
+	got := pendingFlowRuns(runs)
+	if len(got) != 2 {
+		t.Fatalf("pendingFlowRuns returned %d runs, want 2: %+v", len(got), got)
+	}
+	if got[0].ID != "run-2" || got[1].ID != "run-3" {
+		t.Fatalf("pending runs = %+v", got)
+	}
+}


### PR DESCRIPTION
Summary:
- Add a --pending flag to micro flow runs so operators can focus durable workflow history on incomplete runs.
- Add coverage for filtering completed runs out of the durable flow history view.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- go test ./cmd/micro/flow
- golangci-lint run ./...

Closes #3099