### PR TITLE
Add AI provider capability command

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -188,6 +188,16 @@ type Response struct {
 - `ToolCalls`: List of tools the model requested (if any)
 - `Answer`: The final answer after tools are executed (only set if ToolHandler is provided)
 
+## Provider capability matrix
+
+The CLI can print the provider capabilities registered in the current build:
+
+```bash
+micro ai providers
+```
+
+It reports support from Go Micro's provider registry, so the matrix reflects the model, image, and video interfaces available to this binary rather than external provider marketing claims.
+
 ## Supported Providers
 
 ### Anthropic Claude

--- a/cmd/micro/ai/ai.go
+++ b/cmd/micro/ai/ai.go
@@ -1,0 +1,55 @@
+package ai
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/urfave/cli/v2"
+	goai "go-micro.dev/v6/ai"
+	_ "go-micro.dev/v6/ai/anthropic"
+	_ "go-micro.dev/v6/ai/atlascloud"
+	_ "go-micro.dev/v6/ai/gemini"
+	_ "go-micro.dev/v6/ai/groq"
+	_ "go-micro.dev/v6/ai/mistral"
+	_ "go-micro.dev/v6/ai/openai"
+	_ "go-micro.dev/v6/ai/together"
+	"go-micro.dev/v6/cmd"
+)
+
+func init() {
+	cmd.Register(&cli.Command{
+		Name:  "ai",
+		Usage: "Inspect AI provider support",
+		Subcommands: []*cli.Command{{
+			Name:   "providers",
+			Usage:  "Print the registered AI provider capability matrix",
+			Action: providersAction,
+		}},
+	})
+}
+
+func providersAction(c *cli.Context) error {
+	writeProviderMatrix(c.App.Writer, goai.CapabilityRows())
+	return nil
+}
+
+func writeProviderMatrix(w io.Writer, rows []goai.CapabilityRow) {
+	const check = "✓"
+	fmt.Fprintln(w, "Provider    Model  Image  Video")
+	fmt.Fprintln(w, "--------    -----  -----  -----")
+	for _, row := range rows {
+		fmt.Fprintf(w, "%-11s %-6s %-6s %-6s\n",
+			row.Provider,
+			mark(row.Model, check),
+			mark(row.Image, check),
+			mark(row.Video, check),
+		)
+	}
+}
+
+func mark(ok bool, value string) string {
+	if ok {
+		return value
+	}
+	return "-"
+}

--- a/cmd/micro/ai/ai_test.go
+++ b/cmd/micro/ai/ai_test.go
@@ -1,0 +1,30 @@
+package ai
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	goai "go-micro.dev/v6/ai"
+)
+
+func TestWriteProviderMatrix(t *testing.T) {
+	rows := []goai.CapabilityRow{
+		{Provider: "atlascloud", Capabilities: goai.Capabilities{Model: true, Image: true, Video: true}},
+		{Provider: "openai", Capabilities: goai.Capabilities{Model: true, Image: true}},
+	}
+
+	var out bytes.Buffer
+	writeProviderMatrix(&out, rows)
+	got := out.String()
+
+	for _, want := range []string{
+		"Provider    Model  Image  Video",
+		"atlascloud  ✓      ✓      ✓",
+		"openai      ✓      ✓      -",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("matrix output missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/cmd/micro/main.go
+++ b/cmd/micro/main.go
@@ -5,6 +5,7 @@ import (
 	"go-micro.dev/v6/cmd"
 
 	_ "go-micro.dev/v6/cmd/micro/a2a"
+	_ "go-micro.dev/v6/cmd/micro/ai"
 	_ "go-micro.dev/v6/cmd/micro/api"
 	_ "go-micro.dev/v6/cmd/micro/chat"
 	_ "go-micro.dev/v6/cmd/micro/cli"


### PR DESCRIPTION
Summary:\n- Add micro ai providers to print the registered model/image/video provider capability matrix.\n- Register the command in the micro binary and document how to use it from the AI package README.\n- Add unit coverage for the matrix renderer.\n\nTesting:\n- go build ./...\n- go test ./cmd/micro/ai ./ai\n- golangci-lint run ./...\n- go test ./... (environment warning: loopback targets forbidden in grpc transport/client tests; gateway/a2a task state failures observed during full suite)\n\nCloses #3103