### PR TITLE
Expose agent chat run identifiers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -241,6 +241,8 @@ func (a *agentImpl) Chat(ctx context.Context, req *pb.ChatRequest, rsp *pb.ChatR
 	}
 	rsp.Reply = resp.Reply
 	rsp.Agent = resp.Agent
+	rsp.RunId = resp.RunID
+	rsp.ParentId = resp.ParentID
 	for _, tc := range resp.ToolCalls {
 		input, _ := json.Marshal(tc.Input)
 		rsp.ToolCalls = append(rsp.ToolCalls, &pb.ToolCall{

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,7 +1,11 @@
 package agent
 
 import (
+	"context"
 	"testing"
+
+	pb "go-micro.dev/v6/agent/proto"
+	"go-micro.dev/v6/ai"
 )
 
 func TestNew(t *testing.T) {
@@ -31,6 +35,28 @@ func TestNew(t *testing.T) {
 	}
 	if opts.HistoryLimit != 50 {
 		t.Errorf("HistoryLimit = %d, want 50", opts.HistoryLimit)
+	}
+}
+
+func TestChatResponseIncludesRunIDs(t *testing.T) {
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		return &ai.Response{Reply: "ok"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("chat-run"))
+	var rsp pb.ChatResponse
+	if err := a.Chat(context.Background(), &pb.ChatRequest{Message: "hello"}, &rsp); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if rsp.RunId == "" {
+		t.Fatal("Chat response RunId is empty")
+	}
+	if rsp.Agent != "chat-run" {
+		t.Errorf("Agent = %q, want chat-run", rsp.Agent)
+	}
+	if rsp.ParentId != "" {
+		t.Errorf("ParentId = %q, want empty", rsp.ParentId)
 	}
 }
 

--- a/agent/proto/agent.pb.go
+++ b/agent/proto/agent.pb.go
@@ -66,10 +66,14 @@ func (x *ChatRequest) GetMessage() string {
 }
 
 type ChatResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Reply         string                 `protobuf:"bytes,1,opt,name=reply,proto3" json:"reply,omitempty"`
-	Agent         string                 `protobuf:"bytes,2,opt,name=agent,proto3" json:"agent,omitempty"`
-	ToolCalls     []*ToolCall            `protobuf:"bytes,3,rep,name=tool_calls,json=toolCalls,proto3" json:"tool_calls,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Reply     string                 `protobuf:"bytes,1,opt,name=reply,proto3" json:"reply,omitempty"`
+	Agent     string                 `protobuf:"bytes,2,opt,name=agent,proto3" json:"agent,omitempty"`
+	ToolCalls []*ToolCall            `protobuf:"bytes,3,rep,name=tool_calls,json=toolCalls,proto3" json:"tool_calls,omitempty"`
+	// run_id correlates this chat response with tool calls, traces, and run history.
+	RunId string `protobuf:"bytes,4,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	// parent_id is set when this response belongs to a delegated sub-agent run.
+	ParentId      string `protobuf:"bytes,5,opt,name=parent_id,json=parentId,proto3" json:"parent_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -123,6 +127,20 @@ func (x *ChatResponse) GetToolCalls() []*ToolCall {
 		return x.ToolCalls
 	}
 	return nil
+}
+
+func (x *ChatResponse) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+func (x *ChatResponse) GetParentId() string {
+	if x != nil {
+		return x.ParentId
+	}
+	return ""
 }
 
 type ToolCall struct {
@@ -199,12 +217,14 @@ const file_proto_agent_proto_rawDesc = "" +
 	"\n" +
 	"\x11proto/agent.proto\x12\x05agent\"'\n" +
 	"\vChatRequest\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage\"j\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"\x9e\x01\n" +
 	"\fChatResponse\x12\x14\n" +
 	"\x05reply\x18\x01 \x01(\tR\x05reply\x12\x14\n" +
 	"\x05agent\x18\x02 \x01(\tR\x05agent\x12.\n" +
 	"\n" +
-	"tool_calls\x18\x03 \x03(\v2\x0f.agent.ToolCallR\ttoolCalls\"\\\n" +
+	"tool_calls\x18\x03 \x03(\v2\x0f.agent.ToolCallR\ttoolCalls\x12\x15\n" +
+	"\x06run_id\x18\x04 \x01(\tR\x05runId\x12\x1b\n" +
+	"\tparent_id\x18\x05 \x01(\tR\bparentId\"\\\n" +
 	"\bToolCall\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +

--- a/agent/proto/agent.proto
+++ b/agent/proto/agent.proto
@@ -17,6 +17,11 @@ message ChatResponse {
 	string reply = 1;
 	string agent = 2;
 	repeated ToolCall tool_calls = 3;
+
+	// run_id correlates this chat response with tool calls, traces, and run history.
+	string run_id = 4;
+	// parent_id is set when this response belongs to a delegated sub-agent run.
+	string parent_id = 5;
 }
 
 message ToolCall {


### PR DESCRIPTION
Summary:
- Add run_id and parent_id to agent ChatResponse so RPC callers can correlate chat responses with tool calls, traces, and run history.
- Populate those fields from existing Ask run metadata.
- Add a regression test for Chat response run IDs.

Testing:
- go build ./...
- go test ./agent
- go test ./... (environment failures: loopback targets forbidden in grpc/a2a transport tests)
- golangci-lint run ./...

Closes #3107