### PR TITLE
Align public docs with v6 service constructor

### DIFF
--- a/internal/website/docs/architecture/adr-004-mdns-default-registry.md
+++ b/internal/website/docs/architecture/adr-004-mdns-default-registry.md
@@ -31,7 +31,7 @@ Use **mDNS as the default registry** for service discovery.
 
 ```go
 // Default - uses mDNS automatically
-svc := micro.NewService(micro.Name("myservice"))
+svc := micro.NewService("myservice")
 
 // Production - swap to Consul
 reg := consul.NewConsulRegistry()

--- a/internal/website/docs/architecture/adr-009-progressive-configuration.md
+++ b/internal/website/docs/architecture/adr-009-progressive-configuration.md
@@ -29,7 +29,7 @@ Implement **progressive configuration** where:
 
 ### Level 1: Zero Config (Development)
 ```go
-svc := micro.NewService(micro.Name("hello"))
+svc := micro.NewService("hello")
 svc.Run()
 ```
 

--- a/internal/website/docs/broker.md
+++ b/internal/website/docs/broker.md
@@ -38,7 +38,7 @@ import (
 )
 
 func main() {
-    service := micro.NewService()
+    service := micro.NewService("publisher")
     service.Init()
 
     // Publish a message
@@ -73,7 +73,7 @@ import (
 
 func main() {
     b := bnats.NewNatsBroker()
-    svc := micro.NewService(micro.Broker(b))
+    svc := micro.NewService("publisher", micro.Broker(b))
     svc.Init()
     svc.Run()
 }
@@ -88,7 +88,7 @@ import (
 
 func main() {
     b := rabbitmq.NewBroker()
-    svc := micro.NewService(micro.Broker(b))
+    svc := micro.NewService("publisher", micro.Broker(b))
     svc.Init()
     svc.Run()
 }

--- a/internal/website/docs/examples/pubsub-nats.md
+++ b/internal/website/docs/examples/pubsub-nats.md
@@ -20,7 +20,7 @@ import (
 
 func main() {
     b := bnats.NewNatsBroker()
-    svc := micro.NewService(micro.Broker(b))
+    svc := micro.NewService("nats-pubsub", micro.Broker(b))
     svc.Init()
 
     // subscribe

--- a/internal/website/docs/examples/registry-consul.md
+++ b/internal/website/docs/examples/registry-consul.md
@@ -18,7 +18,7 @@ import (
 
 func main() {
     reg := consul.NewConsulRegistry()
-    svc := micro.NewService(micro.Registry(reg))
+    svc := micro.NewService("consul-registry", micro.Registry(reg))
     svc.Init()
     svc.Run()
 }

--- a/internal/website/docs/examples/store-postgres.md
+++ b/internal/website/docs/examples/store-postgres.md
@@ -20,7 +20,7 @@ import (
 
 func main() {
     st := postgres.NewStore()
-    svc := micro.NewService(micro.Store(st))
+    svc := micro.NewService("postgres-store", micro.Store(st))
     svc.Init()
 
     _ = store.Write(&store.Record{Key: "foo", Value: []byte("bar")})

--- a/internal/website/docs/examples/transport-nats.md
+++ b/internal/website/docs/examples/transport-nats.md
@@ -18,7 +18,7 @@ import (
 
 func main() {
     t := tnats.NewTransport()
-    svc := micro.NewService(micro.Transport(t))
+    svc := micro.NewService("nats-transport", micro.Transport(t))
     svc.Init()
     svc.Run()
 }

--- a/internal/website/docs/guides/comparison.md
+++ b/internal/website/docs/guides/comparison.md
@@ -97,7 +97,7 @@ func (s *MyService) DoThing(ctx context.Context, req *Request, rsp *Response) er
 }
 
 func main() {
-    svc := micro.NewService(micro.Name("myservice"))
+    svc := micro.NewService("myservice")
     svc.Init()
     svc.Handle(new(MyService))
     svc.Run()
@@ -234,11 +234,11 @@ mesh / runtime and let ADK (or any A2A agent) plug into it.
 **Go Micro**: Built-in with plugins
 ```go
 // Zero-config for dev
-svc := micro.NewService(micro.Name("myservice"))
+svc := micro.NewService("myservice")
 
 // Consul for production
 reg := consul.NewRegistry()
-svc := micro.NewService(micro.Registry(reg))
+svc := micro.NewService("myservice", micro.Registry(reg))
 ```
 
 **go-kit**: Bring your own

--- a/internal/website/docs/guides/migration/from-grpc.md
+++ b/internal/website/docs/guides/migration/from-grpc.md
@@ -159,7 +159,7 @@ rsp, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: "John"}
 
 **Go Micro client:**
 ```go
-svc := micro.NewService(micro.Name("client"))
+svc := micro.NewService("client")
 svc.Init()
 
 client := pb.NewGreeterService("greeter", svc.Client())
@@ -362,7 +362,7 @@ lis, _ := net.Listen("tcp", ":50051")
 **Go Micro**: Automatic or explicit
 ```go
 // Let Go Micro choose
-svc := micro.NewService(micro.Name("greeter"))
+svc := micro.NewService("greeter")
 
 // Or specify
 svc := micro.NewService(

--- a/internal/website/docs/plugins.md
+++ b/internal/website/docs/plugins.md
@@ -43,7 +43,7 @@ import (
 
 func main() {
     reg := etcd.NewRegistry()
-    svc := micro.NewService(micro.Registry(reg))
+    svc := micro.NewService("plugin-example", micro.Registry(reg))
     svc.Init()
     svc.Run()
 }
@@ -60,7 +60,7 @@ import (
 
 func main() {
     b := bnats.NewNatsBroker()
-    svc := micro.NewService(micro.Broker(b))
+    svc := micro.NewService("plugin-example", micro.Broker(b))
     svc.Init()
     svc.Run()
 }
@@ -75,7 +75,7 @@ import (
 
 func main() {
     b := rabbitmq.NewBroker()
-    svc := micro.NewService(micro.Broker(b))
+    svc := micro.NewService("plugin-example", micro.Broker(b))
     svc.Init()
     svc.Run()
 }
@@ -90,7 +90,7 @@ import (
 
 func main() {
     t := tnats.NewTransport()
-    svc := micro.NewService(micro.Transport(t))
+    svc := micro.NewService("plugin-example", micro.Transport(t))
     svc.Init()
     svc.Run()
 }
@@ -130,7 +130,7 @@ import (
 
 func main() {
     st := postgres.NewStore()
-    svc := micro.NewService(micro.Store(st))
+    svc := micro.NewService("plugin-example", micro.Store(st))
     svc.Init()
     svc.Run()
 }
@@ -145,7 +145,7 @@ import (
 
 func main() {
     st := natsjskv.NewStore()
-    svc := micro.NewService(micro.Store(st))
+    svc := micro.NewService("plugin-example", micro.Store(st))
     svc.Init()
     svc.Run()
 }

--- a/internal/website/docs/store.md
+++ b/internal/website/docs/store.md
@@ -36,7 +36,7 @@ import (
 )
 
 func main() {
-    service := micro.NewService()
+    service := micro.NewService("store-example")
     service.Init()
 
     // Write a record
@@ -64,7 +64,7 @@ import (
 
 func main() {
     st := postgres.NewStore()
-    svc := micro.NewService(micro.Store(st))
+    svc := micro.NewService("store-example", micro.Store(st))
     svc.Init()
     svc.Run()
 }
@@ -79,7 +79,7 @@ import (
 
 func main() {
     st := natsjskv.NewStore()
-    svc := micro.NewService(micro.Store(st))
+    svc := micro.NewService("store-example", micro.Store(st))
     svc.Init()
     svc.Run()
 }

--- a/internal/website/docs/transport.md
+++ b/internal/website/docs/transport.md
@@ -76,7 +76,7 @@ import (
 
 func main() {
     t := tnats.NewTransport()
-    service := micro.NewService(micro.Transport(t))
+    service := micro.NewService("transport-example", micro.Transport(t))
     service.Init()
     service.Run()
 }


### PR DESCRIPTION
Summary:
- Update public website docs examples to use the v6 `micro.NewService("name", opts...)` constructor form instead of stale name-less or `micro.Name(...)` examples.

Testing:
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in grpc/a2a/transport tests)
- golangci-lint run ./...

Closes #3109