### PR TITLE
Finish v6 constructor docs alignment

### DIFF
--- a/internal/website/docs/architecture.md
+++ b/internal/website/docs/architecture.md
@@ -66,8 +66,7 @@ import (
 )
 
 func main() {
-    service := micro.NewService(
-        micro.Name("example"),
+    service := micro.NewService("example",
     )
     service.Init()
     if err := service.Run(); err != nil {

--- a/internal/website/docs/architecture/adr-004-mdns-default-registry.md
+++ b/internal/website/docs/architecture/adr-004-mdns-default-registry.md
@@ -31,12 +31,11 @@ Use **mDNS as the default registry** for service discovery.
 
 ```go
 // Default - uses mDNS automatically
-svc := micro.NewService(micro.Name("myservice"))
+svc := micro.NewService("myservice")
 
 // Production - swap to Consul
 reg := consul.NewConsulRegistry()
-svc := micro.NewService(
-    micro.Name("myservice"),
+svc := micro.NewService("myservice",
     micro.Registry(reg),
 )
 ```

--- a/internal/website/docs/architecture/adr-009-progressive-configuration.md
+++ b/internal/website/docs/architecture/adr-009-progressive-configuration.md
@@ -29,7 +29,7 @@ Implement **progressive configuration** where:
 
 ### Level 1: Zero Config (Development)
 ```go
-svc := micro.NewService(micro.Name("hello"))
+svc := micro.NewService("hello")
 svc.Run()
 ```
 
@@ -62,8 +62,7 @@ b := nats.NewNatsBroker(
     nats.DrainConnection(),
 )
 
-svc := micro.NewService(
-    micro.Name("myservice"),
+svc := micro.NewService("myservice",
     micro.Version("1.2.3"),
     micro.Registry(reg),
     micro.Broker(b),

--- a/internal/website/docs/broker.md
+++ b/internal/website/docs/broker.md
@@ -38,7 +38,7 @@ import (
 )
 
 func main() {
-    service := micro.NewService()
+    service := micro.NewService("publisher")
     service.Init()
 
     // Publish a message
@@ -73,7 +73,7 @@ import (
 
 func main() {
     b := bnats.NewNatsBroker()
-    svc := micro.NewService(micro.Broker(b))
+    svc := micro.NewService("publisher", micro.Broker(b))
     svc.Init()
     svc.Run()
 }
@@ -88,7 +88,7 @@ import (
 
 func main() {
     b := rabbitmq.NewBroker()
-    svc := micro.NewService(micro.Broker(b))
+    svc := micro.NewService("publisher", micro.Broker(b))
     svc.Init()
     svc.Run()
 }

--- a/internal/website/docs/client-server.md
+++ b/internal/website/docs/client-server.md
@@ -35,8 +35,7 @@ func (g *Greeter) Hello(ctx context.Context, req *struct{}, rsp *struct{Msg stri
 }
 
 func main() {
-    service := micro.NewService(
-        micro.Name("greeter"),
+    service := micro.NewService("greeter",
     )
     service.Init()
     micro.RegisterHandler(service.Server(), new(Greeter))

--- a/internal/website/docs/config.md
+++ b/internal/website/docs/config.md
@@ -53,8 +53,7 @@ No code changes required. The framework internally wires the selected implementa
 ## Equivalent Code Configuration
 
 ```go
-service := micro.NewService(
-    micro.Name("helloworld"),
+service := micro.NewService("helloworld",
     micro.Broker(nats.NewBroker()),
     micro.Transport(natstransport.NewTransport()),
     micro.Registry(consul.NewRegistry(registry.Addrs("127.0.0.1:8500"))),

--- a/internal/website/docs/examples/hello-service.md
+++ b/internal/website/docs/examples/hello-service.md
@@ -54,8 +54,7 @@ curl -XPOST \
 Set a fixed address:
 
 ```go
-svc := micro.NewService(
-    micro.Name("helloworld"),
+svc := micro.NewService("helloworld",
     micro.Address(":8080"),
 )
 ```

--- a/internal/website/docs/examples/pubsub-nats.md
+++ b/internal/website/docs/examples/pubsub-nats.md
@@ -20,7 +20,7 @@ import (
 
 func main() {
     b := bnats.NewNatsBroker()
-    svc := micro.NewService(micro.Broker(b))
+    svc := micro.NewService("nats-pubsub", micro.Broker(b))
     svc.Init()
 
     // subscribe

--- a/internal/website/docs/examples/realworld/api-gateway.md
+++ b/internal/website/docs/examples/realworld/api-gateway.md
@@ -79,8 +79,7 @@ func main() {
     }
     defer db.Close()
 
-    svc := micro.NewService(
-        micro.Name("users"),
+    svc := micro.NewService("users",
         micro.Version("1.0.0"),
     )
 
@@ -172,8 +171,7 @@ func main() {
     }
     defer db.Close()
 
-    svc := micro.NewService(
-        micro.Name("orders"),
+    svc := micro.NewService("orders",
         micro.Version("1.0.0"),
     )
 
@@ -254,8 +252,7 @@ func (g *Gateway) CreateOrder(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-    svc := micro.NewService(
-        micro.Name("api.gateway"),
+    svc := micro.NewService("api.gateway",
     )
     svc.Init()
 

--- a/internal/website/docs/examples/realworld/graceful-shutdown.md
+++ b/internal/website/docs/examples/realworld/graceful-shutdown.md
@@ -34,8 +34,7 @@ import (
 )
 
 func main() {
-    svc := micro.NewService(
-        micro.Name("myservice"),
+    svc := micro.NewService("myservice",
         micro.BeforeStop(func() error {
             logger.Info("Service stopping, running cleanup...")
             return cleanup()
@@ -233,8 +232,7 @@ func main() {
     app.AddWorker(&Worker{name: "cleanup"})
     app.AddWorker(&Worker{name: "metrics"})
     
-    svc := micro.NewService(
-        micro.Name("myservice"),
+    svc := micro.NewService("myservice",
         micro.BeforeStop(func() error {
             ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
             defer cancel()

--- a/internal/website/docs/examples/registry-consul.md
+++ b/internal/website/docs/examples/registry-consul.md
@@ -18,7 +18,7 @@ import (
 
 func main() {
     reg := consul.NewConsulRegistry()
-    svc := micro.NewService(micro.Registry(reg))
+    svc := micro.NewService("consul-registry", micro.Registry(reg))
     svc.Init()
     svc.Run()
 }

--- a/internal/website/docs/examples/store-postgres.md
+++ b/internal/website/docs/examples/store-postgres.md
@@ -20,7 +20,7 @@ import (
 
 func main() {
     st := postgres.NewStore()
-    svc := micro.NewService(micro.Store(st))
+    svc := micro.NewService("postgres-store", micro.Store(st))
     svc.Init()
 
     _ = store.Write(&store.Record{Key: "foo", Value: []byte("bar")})

--- a/internal/website/docs/examples/transport-nats.md
+++ b/internal/website/docs/examples/transport-nats.md
@@ -18,7 +18,7 @@ import (
 
 func main() {
     t := tnats.NewTransport()
-    svc := micro.NewService(micro.Transport(t))
+    svc := micro.NewService("nats-transport", micro.Transport(t))
     svc.Init()
     svc.Run()
 }

--- a/internal/website/docs/guides/comparison.md
+++ b/internal/website/docs/guides/comparison.md
@@ -97,7 +97,7 @@ func (s *MyService) DoThing(ctx context.Context, req *Request, rsp *Response) er
 }
 
 func main() {
-    svc := micro.NewService(micro.Name("myservice"))
+    svc := micro.NewService("myservice")
     svc.Init()
     svc.Handle(new(MyService))
     svc.Run()
@@ -234,11 +234,11 @@ mesh / runtime and let ADK (or any A2A agent) plug into it.
 **Go Micro**: Built-in with plugins
 ```go
 // Zero-config for dev
-svc := micro.NewService(micro.Name("myservice"))
+svc := micro.NewService("myservice")
 
 // Consul for production
 reg := consul.NewRegistry()
-svc := micro.NewService(micro.Registry(reg))
+svc := micro.NewService("myservice", micro.Registry(reg))
 ```
 
 **go-kit**: Bring your own

--- a/internal/website/docs/guides/grpc-compatibility.md
+++ b/internal/website/docs/guides/grpc-compatibility.md
@@ -19,8 +19,7 @@ The gRPC **transport** uses the gRPC protocol as a communication layer, similar 
 import "go-micro.dev/v6/transport/grpc"
 
 t := grpc.NewTransport()
-service := micro.NewService(
-    micro.Name("helloworld"),
+service := micro.NewService("helloworld",
     micro.Transport(t),
 )
 ```
@@ -42,14 +41,11 @@ import (
     grpcClient "go-micro.dev/v6/client/grpc"
 )
 
-service := micro.NewService(
-    micro.Server(grpcServer.NewServer()),  // Server must come before Name
+service := micro.NewService("helloworld",
+    micro.Server(grpcServer.NewServer()),
     micro.Client(grpcClient.NewClient()),
-    micro.Name("helloworld"),
 )
 ```
-
-> **Important**: The `micro.Server()` option must be specified **before** `micro.Name()`. This is because `micro.Name()` sets the name on the current server, and if `micro.Server()` comes after, it replaces the server with a new one that has no name set.
 
 ## When to Use Which
 
@@ -123,9 +119,8 @@ func (s *Say) Hello(ctx context.Context, req *pb.Request, rsp *pb.Response) erro
 func main() {
     // Create service with gRPC server for native gRPC compatibility
     // Note: Server must be set before Name to ensure the name is applied to the gRPC server
-    service := micro.NewService(
+    service := micro.NewService("helloworld",
         micro.Server(grpcServer.NewServer()),
-        micro.Name("helloworld"),
         micro.Address(":8080"),
     )
 
@@ -158,9 +153,8 @@ import (
 
 func main() {
     // Create service with gRPC client
-    service := micro.NewService(
+    service := micro.NewService("helloworld.client",
         micro.Client(grpcClient.NewClient()),
-        micro.Name("helloworld.client"),
     )
     service.Init()
 
@@ -207,10 +201,9 @@ import (
 )
 
 func main() {
-    service := micro.NewService(
-        micro.Server(grpcServer.NewServer()),  // Server first
+    service := micro.NewService("helloworld",
+        micro.Server(grpcServer.NewServer()),
         micro.Client(grpcClient.NewClient()),
-        micro.Name("helloworld"),              // Name after Server
         micro.Address(":8080"),
     )
 
@@ -250,7 +243,7 @@ To:
 // Correct - uses server
 import grpcServer "go-micro.dev/v6/server/grpc"
 
-service := micro.NewService(
+service := micro.NewService("helloworld",
     micro.Server(grpcServer.NewServer()),
 )
 ```
@@ -270,36 +263,12 @@ import "go-micro.dev/v6/server/grpc"
 import "go-micro.dev/v6/client/grpc"
 ```
 
-### Option Ordering Issue
-
-If the gRPC server is working but your service has no name or is not being found in the registry:
-
-**Cause**: The `micro.Server()` option is specified **after** `micro.Name()`.
-
-When options are processed, `micro.Name()` sets the name on the current server. If `micro.Server()` comes later, it replaces the server with a new one that doesn't have the name set.
-
-**Solution**: Always specify `micro.Server()` **before** `micro.Name()`:
-
-```go
-// Wrong - server replaces the one with the name set
-service := micro.NewService(
-    micro.Name("helloworld"),              // Sets name on default server
-    micro.Server(grpcServer.NewServer()),  // Replaces server, name is lost!
-)
-
-// Correct - name is set on the gRPC server
-service := micro.NewService(
-    micro.Server(grpcServer.NewServer()),  // Set server first
-    micro.Name("helloworld"),              // Name is now applied to gRPC server
-)
-```
-
 ### Service Name vs Package Name
 
-When creating a client to call another service, use the **service name** (set via `micro.Name()`), not the proto package name:
+When creating a client to call another service, use the **service name** passed to `micro.NewService`, not the proto package name:
 
 ```go
-// If the server was started with micro.Name("helloworld")
+// If the server was started with micro.NewService("helloworld", ...)
 sayService := pb.NewSayService("helloworld", service.Client())  // Use service name
 
 // NOT the package name from the proto file

--- a/internal/website/docs/guides/mcp-security.md
+++ b/internal/website/docs/guides/mcp-security.md
@@ -319,8 +319,7 @@ import (
 )
 
 func main() {
-    service := micro.NewService(
-        micro.Name("tasks"),
+    service := micro.NewService("tasks",
         micro.Address(":8081"),
     )
     service.Init()

--- a/internal/website/docs/guides/migration/from-grpc.md
+++ b/internal/website/docs/guides/migration/from-grpc.md
@@ -128,8 +128,7 @@ func (s *Greeter) SayHello(ctx context.Context, req *pb.HelloRequest, rsp *pb.He
 }
 
 func main() {
-    svc := micro.NewService(
-        micro.Name("greeter"),
+    svc := micro.NewService("greeter",
     )
     svc.Init()
 
@@ -159,7 +158,7 @@ rsp, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: "John"}
 
 **Go Micro client:**
 ```go
-svc := micro.NewService(micro.Name("client"))
+svc := micro.NewService("client")
 svc.Init()
 
 client := pb.NewGreeterService("greeter", svc.Client())
@@ -185,8 +184,7 @@ import (
     grpcserver "go-micro.dev/v6/server/grpc"
 )
 
-svc := micro.NewService(
-    micro.Name("greeter"),
+svc := micro.NewService("greeter",
     micro.Client(grpcclient.NewClient()),
     micro.Server(grpcserver.NewServer()),
 )
@@ -268,8 +266,7 @@ defer client.Agent().ServiceDeregister("greeter-1")
 import "go-micro.dev/v6/registry/consul"
 
 reg := consul.NewConsulRegistry()
-svc := micro.NewService(
-    micro.Name("greeter"),
+svc := micro.NewService("greeter",
     micro.Registry(reg),
 )
 
@@ -362,11 +359,10 @@ lis, _ := net.Listen("tcp", ":50051")
 **Go Micro**: Automatic or explicit
 ```go
 // Let Go Micro choose
-svc := micro.NewService(micro.Name("greeter"))
+svc := micro.NewService("greeter")
 
 // Or specify
-svc := micro.NewService(
-    micro.Name("greeter"),
+svc := micro.NewService("greeter",
     micro.Address(":50051"),
 )
 ```

--- a/internal/website/docs/plugins.md
+++ b/internal/website/docs/plugins.md
@@ -43,7 +43,7 @@ import (
 
 func main() {
     reg := etcd.NewRegistry()
-    svc := micro.NewService(micro.Registry(reg))
+    svc := micro.NewService("plugin-example", micro.Registry(reg))
     svc.Init()
     svc.Run()
 }
@@ -60,7 +60,7 @@ import (
 
 func main() {
     b := bnats.NewNatsBroker()
-    svc := micro.NewService(micro.Broker(b))
+    svc := micro.NewService("plugin-example", micro.Broker(b))
     svc.Init()
     svc.Run()
 }
@@ -75,7 +75,7 @@ import (
 
 func main() {
     b := rabbitmq.NewBroker()
-    svc := micro.NewService(micro.Broker(b))
+    svc := micro.NewService("plugin-example", micro.Broker(b))
     svc.Init()
     svc.Run()
 }
@@ -90,7 +90,7 @@ import (
 
 func main() {
     t := tnats.NewTransport()
-    svc := micro.NewService(micro.Transport(t))
+    svc := micro.NewService("plugin-example", micro.Transport(t))
     svc.Init()
     svc.Run()
 }
@@ -130,7 +130,7 @@ import (
 
 func main() {
     st := postgres.NewStore()
-    svc := micro.NewService(micro.Store(st))
+    svc := micro.NewService("plugin-example", micro.Store(st))
     svc.Init()
     svc.Run()
 }
@@ -145,7 +145,7 @@ import (
 
 func main() {
     st := natsjskv.NewStore()
-    svc := micro.NewService(micro.Store(st))
+    svc := micro.NewService("plugin-example", micro.Store(st))
     svc.Init()
     svc.Run()
 }

--- a/internal/website/docs/store.md
+++ b/internal/website/docs/store.md
@@ -36,7 +36,7 @@ import (
 )
 
 func main() {
-    service := micro.NewService()
+    service := micro.NewService("store-example")
     service.Init()
 
     // Write a record
@@ -64,7 +64,7 @@ import (
 
 func main() {
     st := postgres.NewStore()
-    svc := micro.NewService(micro.Store(st))
+    svc := micro.NewService("store-example", micro.Store(st))
     svc.Init()
     svc.Run()
 }
@@ -79,7 +79,7 @@ import (
 
 func main() {
     st := natsjskv.NewStore()
-    svc := micro.NewService(micro.Store(st))
+    svc := micro.NewService("store-example", micro.Store(st))
     svc.Init()
     svc.Run()
 }

--- a/internal/website/docs/transport.md
+++ b/internal/website/docs/transport.md
@@ -31,11 +31,9 @@ import (
     grpcClient "go-micro.dev/v6/client/grpc"
 )
 
-// Important: Server must be specified before Name
-service := micro.NewService(
+service := micro.NewService("myservice",
     micro.Server(grpcServer.NewServer()),
     micro.Client(grpcClient.NewClient()),
-    micro.Name("myservice"),
 )
 ```
 
@@ -76,7 +74,7 @@ import (
 
 func main() {
     t := tnats.NewTransport()
-    service := micro.NewService(micro.Transport(t))
+    service := micro.NewService("transport-example", micro.Transport(t))
     service.Init()
     service.Run()
 }


### PR DESCRIPTION
Summary:
- Complete the public docs alignment for v6 `micro.NewService("name", opts...)` examples, including gRPC compatibility and remaining plugin/config/migration snippets.

Testing:
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in grpc/a2a/transport tests)
- golangci-lint run ./...

Closes #3109