### PR TITLE
Finish constructor example cleanup

### DIFF
--- a/internal/website/docs/guides/comparison.md
+++ b/internal/website/docs/guides/comparison.md
@@ -140,7 +140,7 @@ import (
     grpcClient "go-micro.dev/v6/client/grpc"
 )
 
-svc := micro.NewService(
+svc := micro.NewService("myservice",
     micro.Server(grpcServer.NewServer()),
     micro.Client(grpcClient.NewClient()),
 )

--- a/internal/website/docs/guides/grpc-compatibility.md
+++ b/internal/website/docs/guides/grpc-compatibility.md
@@ -232,7 +232,7 @@ ERROR:
 ```go
 // Wrong - uses transport
 t := grpc.NewTransport()
-service := micro.NewService(
+service := micro.NewService("helloworld",
     micro.Transport(t),
 )
 ```

--- a/internal/website/docs/guides/migration/from-grpc.md
+++ b/internal/website/docs/guides/migration/from-grpc.md
@@ -290,7 +290,7 @@ svc.Run()
 import "go-micro.dev/v6/selector"
 
 // Client-side load balancing built-in
-svc := micro.NewService(
+svc := micro.NewService("greeter",
     micro.Selector(selector.NewSelector(
         selector.SetStrategy(selector.RoundRobin),
     )),
@@ -386,7 +386,7 @@ Ensure both use protobuf:
 ```go
 import "go-micro.dev/v6/codec/proto"
 
-svc := micro.NewService(
+svc := micro.NewService("greeter",
     micro.Codec("application/protobuf", proto.Marshaler{}),
 )
 ```

--- a/internal/website/docs/performance.md
+++ b/internal/website/docs/performance.md
@@ -98,7 +98,7 @@ Choose based on your deployment:
 import "go-micro.dev/v6/server/grpc"
 
 // Use gRPC for better performance
-service := micro.NewService(
+service := micro.NewService("performance-example",
     micro.Server(grpc.NewServer()),
 )
 ```

--- a/internal/website/docs/plugins.md
+++ b/internal/website/docs/plugins.md
@@ -26,7 +26,7 @@ import (
 
 func main() {
     reg := consul.NewConsulRegistry()
-    svc := micro.NewService(
+    svc := micro.NewService("plugin-example",
         micro.Registry(reg),
     )
     svc.Init()
@@ -108,7 +108,7 @@ import (
 )
 
 func main() {
-    svc := micro.NewService(
+    svc := micro.NewService("plugin-example",
         micro.Server(grpcServer.NewServer()),
         micro.Client(grpcClient.NewClient()),
     )

--- a/internal/website/docs/registry.md
+++ b/internal/website/docs/registry.md
@@ -53,7 +53,7 @@ import (
 
 func main() {
     reg := consul.NewRegistry()
-    service := micro.NewService(
+    service := micro.NewService("registry-example",
         micro.Registry(reg),
     )
     service.Init()

--- a/internal/website/docs/transport.md
+++ b/internal/website/docs/transport.md
@@ -57,7 +57,7 @@ import (
 
 func main() {
     t := grpc.NewTransport()
-    service := micro.NewService(
+    service := micro.NewService("transport-example",
         micro.Transport(t),
     )
     service.Init()


### PR DESCRIPTION
Summary:
- Complete remaining public docs cleanup for v6 `micro.NewService("name", opts...)` constructor examples.

Testing:
- rg -n -U "micro\.NewService\(\s*\n\s*micro\.|micro\.NewService\(\)|micro\.NewService\(micro\." internal/website/docs README.md internal/website/index.html

Closes #3109