### PR TITLE
Filter agent runs by trace ID

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -62,6 +62,10 @@ type RunListOptions struct {
 	// Status, when set, keeps only runs with the matching status
 	// (for example "running", "done", "error", or "refused").
 	Status string
+	// TraceID, when set, keeps only runs correlated with this trace id.
+	// A prefix is accepted so operators can paste the shortened trace id
+	// printed by `micro runs`.
+	TraceID string
 	// Limit, when positive, returns the most recently updated runs up to
 	// the limit. Limited results are ordered newest first.
 	Limit int
@@ -302,6 +306,9 @@ func ListRunSummariesWithOptions(s store.Store, agentName string, opts RunListOp
 			}
 		}
 		if opts.Status != "" && summary.Status != opts.Status {
+			continue
+		}
+		if opts.TraceID != "" && !strings.HasPrefix(summary.TraceID, opts.TraceID) {
 			continue
 		}
 		summaries = append(summaries, summary)

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -210,7 +210,7 @@ func TestListRunSummariesWithOptionsFiltersAndLimits(t *testing.T) {
 	events := []RunEvent{
 		{Time: time.Unix(0, 1), RunID: "run-old", Agent: "runner", Kind: "run"},
 		{Time: time.Unix(0, 2), RunID: "run-old", Agent: "runner", Kind: "done"},
-		{Time: time.Unix(0, 3), RunID: "run-new", Agent: "runner", Kind: "run"},
+		{Time: time.Unix(0, 3), RunID: "run-new", Agent: "runner", TraceID: "abcdef1234567890", Kind: "run"},
 		{Time: time.Unix(0, 4), RunID: "run-new", Agent: "runner", Kind: "error", Error: "boom"},
 	}
 	for _, e := range events {
@@ -223,7 +223,7 @@ func TestListRunSummariesWithOptionsFiltersAndLimits(t *testing.T) {
 		}
 	}
 
-	got, err := ListRunSummariesWithOptions(st, "runner", RunListOptions{Status: "error", Limit: 1})
+	got, err := ListRunSummariesWithOptions(st, "runner", RunListOptions{Status: "error", TraceID: "abcdef", Limit: 1})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -135,12 +135,13 @@ func runFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{Name: "json", Usage: "Print run data as JSON for automation"},
 		&cli.StringFlag{Name: "status", Usage: "Only show runs with this status (running, done, error, refused)"},
+		&cli.StringFlag{Name: "trace", Usage: "Only show runs whose trace id matches this full id or prefix"},
 		&cli.IntFlag{Name: "limit", Usage: "Show the most recently updated N runs"},
 	}
 }
 
 func runOptions(c *cli.Context) goagent.RunListOptions {
-	return goagent.RunListOptions{Status: c.String("status"), Limit: c.Int("limit")}
+	return goagent.RunListOptions{Status: c.String("status"), TraceID: c.String("trace"), Limit: c.Int("limit")}
 }
 
 func printRunIndex(name string, opts goagent.RunListOptions, asJSON bool) error {


### PR DESCRIPTION
Summary:
- Add a trace-id filter to agent run listing options, accepting full trace IDs or prefixes printed by the CLI.
- Expose the filter as `micro runs --trace` / `micro agent history --trace`.
- Extend run summary option coverage for trace filtering with status and limit.

Testing:
- go test ./agent ./cmd/micro/cli/agent
- go build ./...
- go test ./... (fails in this sandbox because loopback targets are forbidden for grpc/a2a/transport grpc tests)
- golangci-lint run ./...

Closes #3113