### PR TITLE
Record agent run timelines without tracing

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -92,13 +92,23 @@ func (a *agentImpl) tracer() trace.Tracer {
 }
 
 func (a *agentImpl) startRun(ctx context.Context, message string) (context.Context, func(error)) {
-	if a.opts.TraceProvider == nil {
-		return ctx, func(error) {}
-	}
 	info, _ := ai.RunInfoFrom(ctx)
+	start := time.Now()
+
+	if a.opts.TraceProvider == nil {
+		a.recordRunEvent(RunEvent{Time: start, RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "run", Name: message})
+		return ctx, func(err error) {
+			latency := time.Since(start).Milliseconds()
+			if err != nil {
+				a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "error", LatencyMS: latency, Error: err.Error()})
+				return
+			}
+			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "done", LatencyMS: latency})
+		}
+	}
+
 	ctx, span := a.tracer().Start(ctx, spanNameRun, trace.WithSpanKind(trace.SpanKindInternal), trace.WithAttributes(
 		attribute.String(AttrRunID, info.RunID), attribute.String(AttrParentRunID, info.ParentID), attribute.String(AttrAgentName, info.Agent)))
-	start := time.Now()
 	a.recordSpanEvent(span, RunEvent{Time: start, RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "run", Name: message})
 	return ctx, func(err error) {
 		latency := time.Since(start).Milliseconds()
@@ -229,7 +239,7 @@ func (a *agentImpl) recordSpanEvent(span trace.Span, e RunEvent) {
 }
 
 func (a *agentImpl) recordRunEvent(e RunEvent) {
-	if a.opts.TraceProvider == nil || e.RunID == "" {
+	if e.RunID == "" {
 		return
 	}
 	b, _ := json.Marshal(e)

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -117,7 +117,7 @@ func spanAttributes(attrs []attribute.KeyValue) map[string]string {
 	return out
 }
 
-func TestAgentOpenTelemetryNoopWhenUnconfigured(t *testing.T) {
+func TestAgentRunTimelineRecordedWithoutTraceProvider(t *testing.T) {
 	st := store.NewMemoryStore()
 	a := New(Name("runner-noop"), Provider("oteltest"), WithStore(st), WithTool("probe", "probe", nil, func(context.Context, map[string]any) (string, error) { return "ok", nil }))
 	if _, err := a.Ask(context.Background(), "hello"); err != nil {
@@ -127,8 +127,21 @@ func TestAgentOpenTelemetryNoopWhenUnconfigured(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(keys) != 0 {
-		t.Fatalf("expected no run timeline without TraceProvider, got %v", keys)
+	if len(keys) == 0 {
+		t.Fatal("expected run timeline without TraceProvider")
+	}
+	summaries, err := ListRunSummaries(st, "runner-noop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("got %d summaries, want 1", len(summaries))
+	}
+	if summaries[0].Status != "done" || summaries[0].LastKind != "done" {
+		t.Fatalf("unexpected summary without TraceProvider: %#v", summaries[0])
+	}
+	if summaries[0].TraceID != "" || summaries[0].SpanID != "" {
+		t.Fatalf("unexpected trace correlation without TraceProvider: %#v", summaries[0])
 	}
 	if _, ok := a.(*agentImpl).model.(*tracedModel); ok {
 		t.Fatal("model should not be wrapped when TraceProvider is nil")


### PR DESCRIPTION
Summary:
- Record basic agent run start/done/error timeline events even when OpenTelemetry tracing is not configured.
- Keep trace/span correlation empty in no-trace mode while preserving the existing traced behavior.

Testing:
- go test ./agent
- go build ./...
- go test ./... (fails in this environment due loopback-forbidden gRPC/A2A transport tests)
- golangci-lint run ./...

Closes #3115