### PR TITLE
Record full agent timelines without tracing

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -136,7 +136,7 @@ func (a *agentImpl) setup() {
 	a.tools = ai.NewTools(a.opts.Registry, ai.ToolClient(a.opts.Client))
 	modelOpts = append(modelOpts, ai.WithToolHandler(a.toolHandler()))
 	a.model = ai.New(a.opts.Provider, modelOpts...)
-	if a.opts.TraceProvider != nil && a.model != nil {
+	if a.model != nil {
 		a.model = a.tracedModel(a.model)
 	}
 

--- a/agent/options.go
+++ b/agent/options.go
@@ -250,8 +250,9 @@ func WithTool(name, description string, properties map[string]any, handler ToolF
 	}
 }
 
-// TraceProvider enables OpenTelemetry tracing for agent runs. When nil,
-// agent tracing and run timeline recording are disabled.
+// TraceProvider enables OpenTelemetry tracing for agent runs. The persisted
+// run timeline is recorded even when TraceProvider is nil; trace/span IDs are
+// added only when a provider is configured.
 func TraceProvider(tp trace.TracerProvider) Option {
 	return func(o *Options) { o.TraceProvider = tp }
 }

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -132,12 +132,26 @@ type tracedModel struct {
 
 func (a *agentImpl) tracedModel(m ai.Model) ai.Model { return &tracedModel{Model: m, a: a} }
 func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (*ai.Response, error) {
-	if m.a.opts.TraceProvider == nil {
-		return m.Model.Generate(ctx, req, opts...)
-	}
 	info, _ := ai.RunInfoFrom(ctx)
 	provider := m.String()
 	model := m.Options().Model
+	start := time.Now()
+
+	if m.a.opts.TraceProvider == nil {
+		resp, err := m.Model.Generate(ctx, req, opts...)
+		dur := time.Since(start).Milliseconds()
+		usage := ai.Usage{}
+		if resp != nil {
+			usage = resp.Usage
+		}
+		e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "model", Provider: provider, Model: model, LatencyMS: dur, Tokens: usage}
+		if err != nil {
+			e.Error = err.Error()
+		}
+		m.a.recordRunEvent(e)
+		return resp, err
+	}
+
 	ctx, span := m.a.tracer().Start(ctx, spanNameModelCall, trace.WithAttributes(
 		attribute.String(AttrRunID, info.RunID),
 		attribute.String(AttrParentRunID, info.ParentID),
@@ -145,7 +159,6 @@ func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.
 		attribute.String(AttrProvider, provider),
 		attribute.String(AttrModel, model),
 	))
-	start := time.Now()
 	resp, err := m.Model.Generate(ctx, req, opts...)
 	dur := time.Since(start).Milliseconds()
 	attrs := []attribute.KeyValue{attribute.Int64(AttrLatencyMS, dur)}
@@ -184,11 +197,17 @@ func appendUsage(attrs []attribute.KeyValue, u ai.Usage) []attribute.KeyValue {
 }
 
 func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
-	if a.opts.TraceProvider == nil {
-		return next
-	}
 	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
 		info, _ := ai.RunInfoFrom(ctx)
+		start := time.Now()
+
+		if a.opts.TraceProvider == nil {
+			res := next(ctx, call)
+			dur := time.Since(start).Milliseconds()
+			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, LatencyMS: dur, Refused: res.Refused, Error: resultError(res)})
+			return res
+		}
+
 		ctx, span := a.tracer().Start(ctx, spanNameToolCall, trace.WithAttributes(
 			attribute.String(AttrRunID, info.RunID),
 			attribute.String(AttrParentRunID, info.ParentID),
@@ -196,7 +215,6 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 			attribute.String(AttrToolName, call.Name),
 			attribute.Bool(AttrDelegate, call.Name == toolDelegate),
 		))
-		start := time.Now()
 		res := next(ctx, call)
 		dur := time.Since(start).Milliseconds()
 		attrs := []attribute.KeyValue{attribute.Int64(AttrLatencyMS, dur)}

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -117,7 +117,7 @@ func spanAttributes(attrs []attribute.KeyValue) map[string]string {
 	return out
 }
 
-func TestAgentRunTimelineRecordedWithoutTraceProvider(t *testing.T) {
+func TestAgentRunTimelineRecordsModelAndToolWithoutTraceProvider(t *testing.T) {
 	st := store.NewMemoryStore()
 	a := New(Name("runner-noop"), Provider("oteltest"), WithStore(st), WithTool("probe", "probe", nil, func(context.Context, map[string]any) (string, error) { return "ok", nil }))
 	if _, err := a.Ask(context.Background(), "hello"); err != nil {
@@ -143,8 +143,21 @@ func TestAgentRunTimelineRecordedWithoutTraceProvider(t *testing.T) {
 	if summaries[0].TraceID != "" || summaries[0].SpanID != "" {
 		t.Fatalf("unexpected trace correlation without TraceProvider: %#v", summaries[0])
 	}
-	if _, ok := a.(*agentImpl).model.(*tracedModel); ok {
-		t.Fatal("model should not be wrapped when TraceProvider is nil")
+	events, err := LoadRunEvents(st, "runner-noop", summaries[0].RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{"run": false, "model": false, "tool": false, "done": false}
+	for _, e := range events {
+		seen[e.Kind] = true
+		if e.TraceID != "" || e.SpanID != "" {
+			t.Fatalf("event has trace correlation without TraceProvider: %#v", e)
+		}
+	}
+	for kind, ok := range seen {
+		if !ok {
+			t.Fatalf("missing %s event in timeline: %#v", kind, events)
+		}
 	}
 }
 


### PR DESCRIPTION
Summary:
- Record agent model-call and tool-call timeline events even when OpenTelemetry tracing is not configured.
- Keep trace/span correlation only when a TraceProvider is configured.
- Update tests for no-trace timelines to require run/model/tool/done events.

Testing:
- go build ./...
- go test ./agent
- go test ./... (fails in this environment because loopback targets are forbidden for grpc/a2a tests)
- golangci-lint run ./...

Closes #3117