### PR TITLE
ci: run 0-to-1 scaffold contract in harness

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -27,6 +27,8 @@ jobs:
           cache: true
       - name: Build
         run: go build ./...
+      - name: 0→1 scaffold contract
+        run: go test ./cmd/micro/cli/new -run TestZeroToOneContract -count=1
       - name: Universe end-to-end (asserts; exits non-zero on failure)
         run: go run ./internal/harness/universe
       - name: Agent-flow harness


### PR DESCRIPTION
Summary:
- Add the existing 0→1 micro new scaffold contract to the Harness (E2E) workflow so the documented scaffold → build path is exercised alongside the 0→hero harnesses.

Testing:
- go build ./...
- env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY NO_PROXY=* go test ./...
- golangci-lint run ./...

Closes #3121