### PR TITLE
Add provider conformance JSON summary

### DIFF
--- a/ai/capabilities.go
+++ b/ai/capabilities.go
@@ -5,7 +5,7 @@ import "sort"
 // CapabilityRow is one deterministic row in a provider capability matrix.
 type CapabilityRow struct {
 	// Provider is the registered provider name.
-	Provider string
+	Provider string `json:"provider"`
 	Capabilities
 }
 
@@ -14,11 +14,11 @@ type CapabilityRow struct {
 // provider marketing claims, so it reflects what this build can actually use.
 type Capabilities struct {
 	// Model reports whether ai.New can construct a chat/text model provider.
-	Model bool
+	Model bool `json:"model"`
 	// Image reports whether ai.NewImage can construct an image model provider.
-	Image bool
+	Image bool `json:"image"`
 	// Video reports whether ai.NewVideo can construct a video model provider.
-	Video bool
+	Video bool `json:"video"`
 }
 
 // ProviderCapabilities reports the capabilities registered for provider.

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -49,6 +50,7 @@ func main() {
 	timeoutFlag := flag.Duration("timeout", 10*time.Minute, "timeout per provider/harness run")
 	requireConfiguredFlag := flag.Bool("require-configured", false, "fail when a selected live provider is missing an API key")
 	capabilitiesFlag := flag.Bool("capabilities", true, "print the registered provider capability matrix before running conformance")
+	summaryJSONFlag := flag.String("summary-json", "", "write a machine-readable conformance summary to this path")
 	flag.Parse()
 
 	providers := splitCSV(*providersFlag)
@@ -63,15 +65,18 @@ func main() {
 	}
 
 	var ran, skipped, failed int
+	var results []conformanceResult
 	for _, provider := range providers {
 		if provider != "mock" && providerKey(provider) == "" {
 			msg := fmt.Sprintf("set MICRO_AI_API_KEY or %s", providerEnv[provider])
 			if *requireConfiguredFlag {
 				fmt.Printf("FAIL %s: missing API key (%s)\n", provider, msg)
 				failed++
+				results = append(results, conformanceResult{Provider: provider, Status: statusFailed, Error: "missing API key: " + msg})
 			} else {
 				fmt.Printf("- %s: skipped (%s)\n", provider, msg)
 				skipped++
+				results = append(results, conformanceResult{Provider: provider, Status: statusSkipped, Error: msg})
 			}
 			continue
 		}
@@ -81,16 +86,65 @@ func main() {
 			if err := runHarness(provider, harness, *timeoutFlag); err != nil {
 				fmt.Printf("FAIL %s / %s: %v\n", provider, harness, err)
 				failed++
+				results = append(results, conformanceResult{Provider: provider, Harness: harness, Status: statusFailed, Error: err.Error()})
 				continue
 			}
 			ran++
+			results = append(results, conformanceResult{Provider: provider, Harness: harness, Status: statusPassed})
 		}
 	}
 
 	fmt.Printf("\nprovider conformance: %d passed, %d skipped providers, %d failed\n", ran, skipped, failed)
+	if *summaryJSONFlag != "" {
+		summary := conformanceSummary{
+			Providers:    providers,
+			Harnesses:    harnesses,
+			Capabilities: ai.CapabilityRows(),
+			Results:      results,
+			Passed:       ran,
+			Skipped:      skipped,
+			Failed:       failed,
+		}
+		if err := writeSummaryJSON(*summaryJSONFlag, summary); err != nil {
+			fmt.Fprintf(os.Stderr, "write summary: %v\n", err)
+			os.Exit(1)
+		}
+	}
 	if failed > 0 {
 		os.Exit(1)
 	}
+}
+
+const (
+	statusPassed  = "passed"
+	statusSkipped = "skipped"
+	statusFailed  = "failed"
+)
+
+type conformanceResult struct {
+	Provider string `json:"provider"`
+	Harness  string `json:"harness,omitempty"`
+	Status   string `json:"status"`
+	Error    string `json:"error,omitempty"`
+}
+
+type conformanceSummary struct {
+	Providers    []string            `json:"providers"`
+	Harnesses    []string            `json:"harnesses"`
+	Capabilities []ai.CapabilityRow  `json:"capabilities"`
+	Results      []conformanceResult `json:"results"`
+	Passed       int                 `json:"passed"`
+	Skipped      int                 `json:"skipped"`
+	Failed       int                 `json:"failed"`
+}
+
+func writeSummaryJSON(path string, summary conformanceSummary) error {
+	b, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	return os.WriteFile(path, b, 0o644)
 }
 
 func printCapabilityMatrix() {

--- a/internal/harness/provider-conformance/main_test.go
+++ b/internal/harness/provider-conformance/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -50,5 +53,38 @@ func TestCapabilityMatrixHasRegisteredProviders(t *testing.T) {
 	}
 	if !foundOpenAI {
 		t.Fatalf("CapabilityRows = %#v, want openai row", rows)
+	}
+}
+
+func TestWriteSummaryJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "summary.json")
+	summary := conformanceSummary{
+		Providers: []string{"mock"},
+		Harnesses: []string{"provider-conformance"},
+		Results: []conformanceResult{{
+			Provider: "mock",
+			Harness:  "provider-conformance",
+			Status:   statusPassed,
+		}},
+		Passed: 1,
+	}
+	if err := writeSummaryJSON(path, summary); err != nil {
+		t.Fatalf("writeSummaryJSON returned error: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	if !strings.HasSuffix(string(b), "\n") {
+		t.Fatalf("summary JSON should end with newline: %q", b)
+	}
+
+	var got conformanceSummary
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("summary JSON did not decode: %v", err)
+	}
+	if got.Passed != 1 || len(got.Results) != 1 || got.Results[0].Status != statusPassed {
+		t.Fatalf("summary JSON decoded as %#v, want one passed result", got)
 	}
 }

--- a/internal/website/docs/guides/provider-conformance.md
+++ b/internal/website/docs/guides/provider-conformance.md
@@ -88,6 +88,16 @@ The command also prints the registered model, image, and video provider
 capabilities before running conformance. Disable that with `-capabilities=false`
 when you only want pass/fail output.
 
+For automation, add `-summary-json` to capture the selected providers,
+harnesses, registered capability rows, and pass/skip/fail results in a stable
+machine-readable file:
+
+```sh
+go run ./internal/harness/provider-conformance \
+  -providers mock \
+  -summary-json provider-conformance-summary.json
+```
+
 ## Related docs
 
 - [The Agent Harness](agent-harness.html)


### PR DESCRIPTION
Summary:
- Add -summary-json to the provider conformance harness so automated runs can emit selected providers, harnesses, capability rows, and pass/skip/fail results.
- Add JSON tags to AI capability rows for stable machine-readable summaries.
- Document the summary output flag in the provider conformance guide.

Testing:
- go build ./...
- NO_PROXY="*" no_proxy="*" HTTPS_PROXY= HTTP_PROXY= go test ./...
- golangci-lint run ./...

Closes #3123