### PR TITLE
Add JSON output for AI provider capabilities

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -196,6 +196,12 @@ The CLI can print the provider capabilities registered in the current build:
 micro ai providers
 ```
 
+For automation and docs generation, emit the same matrix as stable JSON:
+
+```bash
+micro ai providers --json
+```
+
 It reports support from Go Micro's provider registry, so the matrix reflects the model, image, and video interfaces available to this binary rather than external provider marketing claims.
 
 ## Supported Providers

--- a/cmd/micro/ai/ai.go
+++ b/cmd/micro/ai/ai.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -21,16 +22,32 @@ func init() {
 		Name:  "ai",
 		Usage: "Inspect AI provider support",
 		Subcommands: []*cli.Command{{
-			Name:   "providers",
-			Usage:  "Print the registered AI provider capability matrix",
+			Name:  "providers",
+			Usage: "Print the registered AI provider capability matrix",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "json",
+					Usage: "Print the capability matrix as JSON",
+				},
+			},
 			Action: providersAction,
 		}},
 	})
 }
 
 func providersAction(c *cli.Context) error {
-	writeProviderMatrix(c.App.Writer, goai.CapabilityRows())
+	rows := goai.CapabilityRows()
+	if c.Bool("json") {
+		return writeProviderJSON(c.App.Writer, rows)
+	}
+	writeProviderMatrix(c.App.Writer, rows)
 	return nil
+}
+
+func writeProviderJSON(w io.Writer, rows []goai.CapabilityRow) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(rows)
 }
 
 func writeProviderMatrix(w io.Writer, rows []goai.CapabilityRow) {

--- a/cmd/micro/ai/ai_test.go
+++ b/cmd/micro/ai/ai_test.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -26,5 +27,27 @@ func TestWriteProviderMatrix(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("matrix output missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestWriteProviderJSON(t *testing.T) {
+	rows := []goai.CapabilityRow{
+		{Provider: "openai", Capabilities: goai.Capabilities{Model: true, Image: true}},
+	}
+
+	var out bytes.Buffer
+	if err := writeProviderJSON(&out, rows); err != nil {
+		t.Fatalf("writeProviderJSON returned error: %v", err)
+	}
+
+	var got []goai.CapabilityRow
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("JSON output did not decode: %v\n%s", err, out.String())
+	}
+	if len(got) != 1 || got[0].Provider != "openai" || !got[0].Model || !got[0].Image || got[0].Video {
+		t.Fatalf("decoded JSON = %#v, want openai model+image", got)
+	}
+	if !strings.HasSuffix(out.String(), "\n") {
+		t.Fatalf("JSON output should end with newline: %q", out.String())
 	}
 }


### PR DESCRIPTION
Summary:
- Add a --json flag to micro ai providers so automation and docs generation can consume the registered provider capability matrix.
- Cover JSON output with a unit test and document the new flag in the AI README.

Testing:
- go build ./...
- go test ./cmd/micro/ai ./ai
- go run ./cmd/micro ai providers --json | head -20
- golangci-lint run ./...

Note: go test ./... was attempted but failed in this environment due loopback proxy restrictions in grpc/a2a tests plus an unrelated store test failure.

Closes #3125