### PR TITLE
Validate durable flow step names

### DIFF
--- a/flow/steps.go
+++ b/flow/steps.go
@@ -305,6 +305,9 @@ func LLM(prompt string) StepFunc {
 
 // startRun begins a fresh run of the flow's steps with the given input.
 func (f *Flow) startRun(ctx context.Context, data string) (Run, error) {
+	if err := validateSteps(f.opts.Steps); err != nil {
+		return Run{}, err
+	}
 	run := Run{
 		ID:      uuid.New().String(),
 		Flow:    f.name,
@@ -321,6 +324,9 @@ func (f *Flow) startRun(ctx context.Context, data string) (Run, error) {
 // Resume continues a persisted run by id, picking up at the step it
 // stopped on. Completed runs are a no-op.
 func (f *Flow) Resume(ctx context.Context, runID string) error {
+	if err := validateSteps(f.opts.Steps); err != nil {
+		return err
+	}
 	if f.checkpoint == nil {
 		return fmt.Errorf("flow %s has no checkpoint configured", f.name)
 	}
@@ -479,6 +485,20 @@ func (f *Flow) save(ctx context.Context, run Run) {
 	if err := f.checkpoint.Save(ctx, run); err != nil {
 		f.log.Logf(logger.ErrorLevel, "Flow %s checkpoint save: %v", f.name, err)
 	}
+}
+
+func validateSteps(steps []Step) error {
+	seen := make(map[string]struct{}, len(steps))
+	for i, step := range steps {
+		if step.Name == "" {
+			return fmt.Errorf("flow: step %d has an empty name", i)
+		}
+		if _, ok := seen[step.Name]; ok {
+			return fmt.Errorf("flow: duplicate step name %q", step.Name)
+		}
+		seen[step.Name] = struct{}{}
+	}
+	return nil
 }
 
 func stepIndex(steps []Step, name string) int {

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -318,6 +318,41 @@ func TestFlowStepRetryStopsOnCancel(t *testing.T) {
 	}
 }
 
+func TestFlowStepNamesMustBeUnique(t *testing.T) {
+	step := Step{Name: "work", Run: func(_ context.Context, in State) (State, error) {
+		return in, nil
+	}}
+	f := New("duplicate-steps",
+		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "duplicate-steps")),
+		Steps(step, step),
+	)
+
+	err := f.Execute(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected duplicate step names to fail validation")
+	}
+	if got, want := err.Error(), `flow: duplicate step name "work"`; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestFlowStepNamesMustBeNonEmpty(t *testing.T) {
+	f := New("empty-step-name",
+		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "empty-step-name")),
+		Steps(Step{Name: "", Run: func(_ context.Context, in State) (State, error) {
+			return in, nil
+		}}),
+	)
+
+	err := f.Execute(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected an empty step name to fail validation")
+	}
+	if got, want := err.Error(), "flow: step 0 has an empty name"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
 // A step with no Run function is reported as a configuration error rather
 // than panicking the run.
 func TestFlowStepNilRun(t *testing.T) {


### PR DESCRIPTION
Summary:
- Validate durable flow step names before starting or resuming a run.
- Reject empty or duplicate step names so checkpoint resume points remain unambiguous.
- Add tests for duplicate and empty step names.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback targets are forbidden for grpc/a2a transport tests)
- golangci-lint run ./...

Closes #3127