### PR TITLE
Add provider capability markdown export

### DIFF
--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -51,6 +51,7 @@ func main() {
 	requireConfiguredFlag := flag.Bool("require-configured", false, "fail when a selected live provider is missing an API key")
 	capabilitiesFlag := flag.Bool("capabilities", true, "print the registered provider capability matrix before running conformance")
 	summaryJSONFlag := flag.String("summary-json", "", "write a machine-readable conformance summary to this path")
+	capabilityMarkdownFlag := flag.String("capabilities-markdown", "", "write the registered provider capability matrix as a Markdown table")
 	flag.Parse()
 
 	providers := splitCSV(*providersFlag)
@@ -62,6 +63,12 @@ func main() {
 
 	if *capabilitiesFlag {
 		printCapabilityMatrix()
+	}
+	if *capabilityMarkdownFlag != "" {
+		if err := writeCapabilityMarkdown(*capabilityMarkdownFlag, ai.CapabilityRows()); err != nil {
+			fmt.Fprintf(os.Stderr, "write capabilities markdown: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	var ran, skipped, failed int
@@ -145,6 +152,23 @@ func writeSummaryJSON(path string, summary conformanceSummary) error {
 	}
 	b = append(b, '\n')
 	return os.WriteFile(path, b, 0o644)
+}
+
+func writeCapabilityMarkdown(path string, rows []ai.CapabilityRow) error {
+	var b strings.Builder
+	b.WriteString("| Provider | Model | Image | Video |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, row := range rows {
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", row.Provider, mark(row.Model), mark(row.Image), mark(row.Video))
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o644)
+}
+
+func mark(ok bool) string {
+	if ok {
+		return "✅"
+	}
+	return "—"
 }
 
 func printCapabilityMatrix() {

--- a/internal/harness/provider-conformance/main_test.go
+++ b/internal/harness/provider-conformance/main_test.go
@@ -56,6 +56,32 @@ func TestCapabilityMatrixHasRegisteredProviders(t *testing.T) {
 	}
 }
 
+func TestWriteCapabilityMarkdown(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "capabilities.md")
+	rows := []ai.CapabilityRow{
+		{Provider: "mock", Capabilities: ai.Capabilities{Model: true}},
+		{Provider: "vision", Capabilities: ai.Capabilities{Image: true, Video: true}},
+	}
+	if err := writeCapabilityMarkdown(path, rows); err != nil {
+		t.Fatalf("writeCapabilityMarkdown returned error: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read capabilities markdown: %v", err)
+	}
+	got := string(b)
+	for _, want := range []string{
+		"| Provider | Model | Image | Video |",
+		"| mock | ✅ | — | — |",
+		"| vision | — | ✅ | ✅ |",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("capabilities markdown = %q, want row %q", got, want)
+		}
+	}
+}
+
 func TestWriteSummaryJSON(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "summary.json")
 	summary := conformanceSummary{

--- a/internal/website/docs/guides/provider-conformance.md
+++ b/internal/website/docs/guides/provider-conformance.md
@@ -90,12 +90,15 @@ when you only want pass/fail output.
 
 For automation, add `-summary-json` to capture the selected providers,
 harnesses, registered capability rows, and pass/skip/fail results in a stable
-machine-readable file:
+machine-readable file. Add `-capabilities-markdown` when you also want a
+ready-to-publish Markdown support table for release notes, docs, or issue
+updates:
 
 ```sh
 go run ./internal/harness/provider-conformance \
   -providers mock \
-  -summary-json provider-conformance-summary.json
+  -summary-json provider-conformance-summary.json \
+  -capabilities-markdown provider-capabilities.md
 ```
 
 ## Related docs


### PR DESCRIPTION
Adds a provider-conformance flag for exporting the registered provider capability matrix as a Markdown table, so conformance runs can publish a stable support table alongside JSON automation output.

Testing:
- go build ./...
- go test ./internal/harness/provider-conformance -run TestWriteCapabilityMarkdown -count=1 -v
- go test ./... (fails in this sandbox due loopback targets forbidden for grpc/a2a/transport grpc tests)
- golangci-lint run ./...

Closes #3131