### PR TITLE
Expose streaming in provider capabilities

### DIFF
--- a/ai/capabilities.go
+++ b/ai/capabilities.go
@@ -19,6 +19,10 @@ type Capabilities struct {
 	Image bool `json:"image"`
 	// Video reports whether ai.NewVideo can construct a video model provider.
 	Video bool `json:"video"`
+	// Stream reports whether the provider has registered end-to-end token streaming.
+	// Providers that only satisfy the Model interface with ErrStreamingUnsupported
+	// leave this false until their Stream implementation is usable.
+	Stream bool `json:"stream"`
 }
 
 // ProviderCapabilities reports the capabilities registered for provider.
@@ -26,11 +30,13 @@ func ProviderCapabilities(provider string) Capabilities {
 	_, hasModel := providers[provider]
 	_, hasImage := imageProviders[provider]
 	_, hasVideo := videoProviders[provider]
+	_, hasStream := streamProviders[provider]
 
 	return Capabilities{
-		Model: hasModel,
-		Image: hasImage,
-		Video: hasVideo,
+		Model:  hasModel,
+		Image:  hasImage,
+		Video:  hasVideo,
+		Stream: hasStream,
 	}
 }
 
@@ -47,6 +53,9 @@ func CapabilityMatrix() map[string]Capabilities {
 		names[name] = struct{}{}
 	}
 	for name := range videoProviders {
+		names[name] = struct{}{}
+	}
+	for name := range streamProviders {
 		names[name] = struct{}{}
 	}
 
@@ -72,8 +81,17 @@ func CapabilityRows() []CapabilityRow {
 	return rows
 }
 
+// RegisterStream records that provider has a usable Stream implementation.
+// Providers should call this from init alongside Register once Stream returns
+// chunks instead of ErrStreamingUnsupported.
+func RegisterStream(provider string) {
+	streamProviders[provider] = struct{}{}
+}
+
+var streamProviders = make(map[string]struct{})
+
 // RegisteredProviders returns the registered provider names in sorted order.
-// kind may be "model", "image", "video", or empty for the union of all
+// kind may be "model", "image", "video", "stream", or empty for the union of all
 // provider registries.
 func RegisteredProviders(kind string) []string {
 	names := map[string]struct{}{}
@@ -91,12 +109,18 @@ func RegisteredProviders(kind string) []string {
 			for name := range r {
 				names[name] = struct{}{}
 			}
+		case map[string]struct{}:
+			for name := range r {
+				names[name] = struct{}{}
+			}
 		}
 	}
 
 	switch kind {
 	case "model":
 		add(providers)
+	case "stream":
+		add(streamProviders)
 	case "image":
 		add(imageProviders)
 	case "video":

--- a/ai/capabilities_test.go
+++ b/ai/capabilities_test.go
@@ -32,6 +32,12 @@ func TestRegisteredProviders(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RegisteredProviders(video) = %#v, want %#v", got, want)
 	}
+
+	got = ai.RegisteredProviders("stream")
+	want = []string{}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RegisteredProviders(stream) = %#v, want %#v", got, want)
+	}
 }
 
 func TestCapabilityRows(t *testing.T) {
@@ -71,5 +77,19 @@ func TestCapabilityMatrix(t *testing.T) {
 	}
 	if caps := ai.ProviderCapabilities("missing"); caps != (ai.Capabilities{}) {
 		t.Fatalf("ProviderCapabilities(missing) = %#v", caps)
+	}
+}
+
+func TestRegisterStream(t *testing.T) {
+	ai.RegisterStream("test-stream")
+
+	if caps := ai.ProviderCapabilities("test-stream"); caps != (ai.Capabilities{Stream: true}) {
+		t.Fatalf("ProviderCapabilities(test-stream) = %#v", caps)
+	}
+
+	got := ai.RegisteredProviders("stream")
+	want := []string{"test-stream"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RegisteredProviders(stream) = %#v, want %#v", got, want)
 	}
 }

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -156,10 +156,10 @@ func writeSummaryJSON(path string, summary conformanceSummary) error {
 
 func writeCapabilityMarkdown(path string, rows []ai.CapabilityRow) error {
 	var b strings.Builder
-	b.WriteString("| Provider | Model | Image | Video |\n")
-	b.WriteString("| --- | --- | --- | --- |\n")
+	b.WriteString("| Provider | Model | Image | Video | Streaming |\n")
+	b.WriteString("| --- | --- | --- | --- | --- |\n")
 	for _, row := range rows {
-		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", row.Provider, mark(row.Model), mark(row.Image), mark(row.Video))
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n", row.Provider, mark(row.Model), mark(row.Image), mark(row.Video), mark(row.Stream))
 	}
 	return os.WriteFile(path, []byte(b.String()), 0o644)
 }
@@ -173,9 +173,9 @@ func mark(ok bool) string {
 
 func printCapabilityMatrix() {
 	fmt.Println("Provider capability matrix:")
-	fmt.Println("provider     model  image  video")
+	fmt.Println("provider     model  image  video  stream")
 	for _, row := range ai.CapabilityRows() {
-		fmt.Printf("%-12s %-5s  %-5s  %-5s\n", row.Provider, yesNo(row.Model), yesNo(row.Image), yesNo(row.Video))
+		fmt.Printf("%-12s %-5s  %-5s  %-5s  %-6s\n", row.Provider, yesNo(row.Model), yesNo(row.Image), yesNo(row.Video), yesNo(row.Stream))
 	}
 	fmt.Println()
 }

--- a/internal/harness/provider-conformance/main_test.go
+++ b/internal/harness/provider-conformance/main_test.go
@@ -72,9 +72,9 @@ func TestWriteCapabilityMarkdown(t *testing.T) {
 	}
 	got := string(b)
 	for _, want := range []string{
-		"| Provider | Model | Image | Video |",
-		"| mock | ✅ | — | — |",
-		"| vision | — | ✅ | ✅ |",
+		"| Provider | Model | Image | Video | Streaming |",
+		"| mock | ✅ | — | — | — |",
+		"| vision | — | ✅ | ✅ | — |",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("capabilities markdown = %q, want row %q", got, want)


### PR DESCRIPTION
Summary:
- Add an explicit streaming capability bit and registration hook to the AI provider capability matrix.
- Include streaming in provider-conformance console and Markdown capability output.
- Add tests for stream capability registration and matrix rendering.

Testing:
- go build ./...
- go test ./ai ./internal/harness/provider-conformance
- go test ./... (fails in this environment: loopback targets forbidden for grpc/a2a tests)
- golangci-lint run ./...

Closes #3133