### PR TITLE
Add filters for flow run history

### DIFF
--- a/cmd/micro/flow/flow.go
+++ b/cmd/micro/flow/flow.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"sort"
 	"syscall"
 
 	"github.com/urfave/cli/v2"
@@ -76,6 +77,8 @@ Examples:
 				Flags: []cli.Flag{
 					&cli.BoolFlag{Name: "json", Usage: "Print durable run history as JSON for automation"},
 					&cli.BoolFlag{Name: "pending", Usage: "Only show runs that have not completed"},
+					&cli.StringFlag{Name: "status", Usage: "Only show runs with this status (running, done, failed)"},
+					&cli.IntFlag{Name: "limit", Usage: "Show the most recently updated N runs"},
 				},
 				Action: flowRuns,
 			},
@@ -130,9 +133,7 @@ func flowRuns(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if c.Bool("pending") {
-		runs = pendingFlowRuns(runs)
-	}
+	runs = filterFlowRuns(runs, flowRunOptions{Pending: c.Bool("pending"), Status: c.String("status"), Limit: c.Int("limit")})
 	if len(runs) == 0 {
 		if c.Bool("pending") {
 			fmt.Printf("  No pending runs recorded for flow %q.\n", name)
@@ -144,17 +145,42 @@ func flowRuns(c *cli.Context) error {
 	return writeFlowRuns(os.Stdout, runs, c.Bool("json"))
 }
 
-func pendingFlowRuns(runs []aiflow.Run) []aiflow.Run {
+type flowRunOptions struct {
+	Pending bool
+	Status  string
+	Limit   int
+}
+
+func filterFlowRuns(runs []aiflow.Run, opts flowRunOptions) []aiflow.Run {
 	if len(runs) == 0 {
 		return nil
 	}
-	pending := make([]aiflow.Run, 0, len(runs))
+	filtered := make([]aiflow.Run, 0, len(runs))
 	for _, run := range runs {
-		if run.Status != "done" {
-			pending = append(pending, run)
+		if opts.Pending && run.Status == "done" {
+			continue
 		}
+		if opts.Status != "" && run.Status != opts.Status {
+			continue
+		}
+		filtered = append(filtered, run)
 	}
-	return pending
+	if opts.Limit > 0 && len(filtered) > opts.Limit {
+		sort.SliceStable(filtered, func(i, j int) bool {
+			if filtered[i].Updated.Equal(filtered[j].Updated) {
+				return filtered[i].Started.Before(filtered[j].Started)
+			}
+			return filtered[i].Updated.Before(filtered[j].Updated)
+		})
+		start := len(filtered) - opts.Limit
+		limited := append([]aiflow.Run(nil), filtered[start:]...)
+		return limited
+	}
+	return filtered
+}
+
+func pendingFlowRuns(runs []aiflow.Run) []aiflow.Run {
+	return filterFlowRuns(runs, flowRunOptions{Pending: true})
 }
 
 func writeFlowRuns(w io.Writer, runs []aiflow.Run, asJSON bool) error {

--- a/cmd/micro/flow/flow_test.go
+++ b/cmd/micro/flow/flow_test.go
@@ -71,3 +71,54 @@ func TestPendingFlowRunsFiltersCompletedRuns(t *testing.T) {
 		t.Fatalf("pending runs = %+v", got)
 	}
 }
+
+func TestFilterFlowRunsStatus(t *testing.T) {
+	runs := []aiflow.Run{
+		{ID: "run-1", Status: "done"},
+		{ID: "run-2", Status: "failed"},
+		{ID: "run-3", Status: "running"},
+		{ID: "run-4", Status: "failed"},
+	}
+
+	got := filterFlowRuns(runs, flowRunOptions{Status: "failed"})
+	if len(got) != 2 {
+		t.Fatalf("filterFlowRuns returned %d runs, want 2: %+v", len(got), got)
+	}
+	if got[0].ID != "run-2" || got[1].ID != "run-4" {
+		t.Fatalf("failed runs = %+v", got)
+	}
+}
+
+func TestFilterFlowRunsLimitKeepsNewestRuns(t *testing.T) {
+	runs := []aiflow.Run{
+		{ID: "run-1", Status: "done"},
+		{ID: "run-2", Status: "failed"},
+		{ID: "run-3", Status: "running"},
+	}
+
+	got := filterFlowRuns(runs, flowRunOptions{Limit: 2})
+	if len(got) != 2 {
+		t.Fatalf("filterFlowRuns returned %d runs, want 2: %+v", len(got), got)
+	}
+	if got[0].ID != "run-2" || got[1].ID != "run-3" {
+		t.Fatalf("limited runs = %+v", got)
+	}
+}
+
+func TestFilterFlowRunsCombinesPendingStatusAndLimit(t *testing.T) {
+	runs := []aiflow.Run{
+		{ID: "run-1", Status: "failed"},
+		{ID: "run-2", Status: "done"},
+		{ID: "run-3", Status: "failed"},
+		{ID: "run-4", Status: "running"},
+		{ID: "run-5", Status: "failed"},
+	}
+
+	got := filterFlowRuns(runs, flowRunOptions{Pending: true, Status: "failed", Limit: 2})
+	if len(got) != 2 {
+		t.Fatalf("filterFlowRuns returned %d runs, want 2: %+v", len(got), got)
+	}
+	if got[0].ID != "run-3" || got[1].ID != "run-5" {
+		t.Fatalf("filtered runs = %+v", got)
+	}
+}


### PR DESCRIPTION
Adds status and limit filters to `micro flow runs` so durable workflow history can be inspected more directly from the CLI.

Summary:
- Add `--status` and `--limit` flags for durable flow run history.
- Share filtering logic with the existing `--pending` path.
- Cover status, limit, and combined filtering behavior with tests.

Testing:
- `go build ./...`
- `go test ./cmd/micro/flow ./flow`
- `go test ./cmd/micro/flow`
- `go test ./...` (fails in this sandbox where loopback gRPC targets are blocked by Envoy)
- `golangci-lint run ./...`

Closes #3139