### PR TITLE
Verify AI provider capability docs

### DIFF
--- a/internal/website/docs/guides/ai-provider-guide.md
+++ b/internal/website/docs/guides/ai-provider-guide.md
@@ -30,21 +30,21 @@ imports are linked in:
 
 ```go
 for _, row := range ai.CapabilityRows() {
-    fmt.Printf("%s: chat=%t image=%t video=%t\n", row.Provider, row.Model, row.Image, row.Video)
+    fmt.Printf("%s: chat=%t image=%t video=%t stream=%t\n", row.Provider, row.Model, row.Image, row.Video, row.Stream)
 }
 ```
 
 The built-in providers currently register these capability interfaces:
 
-| Provider | Chat/text (`ai.Model`) | Image (`ai.ImageModel`) | Video (`ai.VideoModel`) |
-| --- | --- | --- | --- |
-| `anthropic` | Yes | No | No |
-| `atlascloud` | Yes | Yes | Yes |
-| `gemini` | Yes | No | No |
-| `groq` | Yes | No | No |
-| `mistral` | Yes | No | No |
-| `openai` | Yes | Yes | No |
-| `together` | Yes | No | No |
+| Provider | Chat/text (`ai.Model`) | Image (`ai.ImageModel`) | Video (`ai.VideoModel`) | Streaming (`ai.Stream`) |
+| --- | --- | --- | --- | --- |
+| `anthropic` | Yes | No | No | No |
+| `atlascloud` | Yes | Yes | Yes | No |
+| `gemini` | Yes | No | No | No |
+| `groq` | Yes | No | No | No |
+| `mistral` | Yes | No | No | No |
+| `openai` | Yes | Yes | No | No |
+| `together` | Yes | No | No | No |
 
 ## Step 1: Implement the `ai.Model` Interface
 

--- a/internal/website/docs/guides/provider_capabilities_test.go
+++ b/internal/website/docs/guides/provider_capabilities_test.go
@@ -1,0 +1,47 @@
+package guides_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"go-micro.dev/v6/ai"
+	_ "go-micro.dev/v6/ai/anthropic"
+	_ "go-micro.dev/v6/ai/atlascloud"
+	_ "go-micro.dev/v6/ai/gemini"
+	_ "go-micro.dev/v6/ai/groq"
+	_ "go-micro.dev/v6/ai/mistral"
+	_ "go-micro.dev/v6/ai/openai"
+	_ "go-micro.dev/v6/ai/together"
+)
+
+func TestAIProviderGuideCapabilityMatrixMatchesRegistry(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+
+	guidePath := filepath.Join(filepath.Dir(filename), "ai-provider-guide.md")
+	b, err := os.ReadFile(guidePath)
+	if err != nil {
+		t.Fatalf("read AI provider guide: %v", err)
+	}
+	guide := string(b)
+
+	for _, row := range ai.CapabilityRows() {
+		want := fmt.Sprintf("| `%s` | %s | %s | %s | %s |", row.Provider, yesNo(row.Model), yesNo(row.Image), yesNo(row.Video), yesNo(row.Stream))
+		if !strings.Contains(guide, want) {
+			t.Fatalf("AI provider guide capability matrix is stale; missing row %q", want)
+		}
+	}
+}
+
+func yesNo(ok bool) string {
+	if ok {
+		return "Yes"
+	}
+	return "No"
+}


### PR DESCRIPTION
Summary:
- Add streaming support to the AI provider capability guide table and example output.
- Add a docs test that compares the guide matrix against the registered provider capability rows so the published support matrix cannot drift.

Testing:
- go build ./...
- go test ./internal/website/docs/guides -run TestAIProviderGuideCapabilityMatrixMatchesRegistry -count=1
- go test ./... (fails in this sandbox because loopback gRPC/A2A tests are blocked by the environment: "Loopback targets forbidden")
- golangci-lint run ./...

Closes #3141