### PR TITLE
Add flow run stage filtering

### DIFF
--- a/cmd/micro/flow/flow.go
+++ b/cmd/micro/flow/flow.go
@@ -79,6 +79,7 @@ Examples:
 					&cli.BoolFlag{Name: "pending", Usage: "Only show runs that have not completed"},
 					&cli.StringFlag{Name: "status", Usage: "Only show runs with this status (running, done, failed)"},
 					&cli.IntFlag{Name: "limit", Usage: "Show the most recently updated N runs"},
+					&cli.StringFlag{Name: "stage", Usage: "Only show runs currently checkpointed at this stage"},
 				},
 				Action: flowRuns,
 			},
@@ -133,7 +134,7 @@ func flowRuns(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	runs = filterFlowRuns(runs, flowRunOptions{Pending: c.Bool("pending"), Status: c.String("status"), Limit: c.Int("limit")})
+	runs = filterFlowRuns(runs, flowRunOptions{Pending: c.Bool("pending"), Status: c.String("status"), Stage: c.String("stage"), Limit: c.Int("limit")})
 	if len(runs) == 0 {
 		if c.Bool("pending") {
 			fmt.Printf("  No pending runs recorded for flow %q.\n", name)
@@ -148,6 +149,7 @@ func flowRuns(c *cli.Context) error {
 type flowRunOptions struct {
 	Pending bool
 	Status  string
+	Stage   string
 	Limit   int
 }
 
@@ -161,6 +163,9 @@ func filterFlowRuns(runs []aiflow.Run, opts flowRunOptions) []aiflow.Run {
 			continue
 		}
 		if opts.Status != "" && run.Status != opts.Status {
+			continue
+		}
+		if opts.Stage != "" && run.State.Stage != opts.Stage {
 			continue
 		}
 		filtered = append(filtered, run)

--- a/cmd/micro/flow/flow_test.go
+++ b/cmd/micro/flow/flow_test.go
@@ -89,6 +89,23 @@ func TestFilterFlowRunsStatus(t *testing.T) {
 	}
 }
 
+func TestFilterFlowRunsStage(t *testing.T) {
+	runs := []aiflow.Run{
+		{ID: "run-1", Status: "failed", State: aiflow.State{Stage: "reserve"}},
+		{ID: "run-2", Status: "failed", State: aiflow.State{Stage: "charge"}},
+		{ID: "run-3", Status: "running", State: aiflow.State{Stage: "charge"}},
+		{ID: "run-4", Status: "done", State: aiflow.State{}},
+	}
+
+	got := filterFlowRuns(runs, flowRunOptions{Stage: "charge"})
+	if len(got) != 2 {
+		t.Fatalf("filterFlowRuns returned %d runs, want 2: %+v", len(got), got)
+	}
+	if got[0].ID != "run-2" || got[1].ID != "run-3" {
+		t.Fatalf("charge-stage runs = %+v", got)
+	}
+}
+
 func TestFilterFlowRunsLimitKeepsNewestRuns(t *testing.T) {
 	runs := []aiflow.Run{
 		{ID: "run-1", Status: "done"},


### PR DESCRIPTION
Summary:
- Add a --stage filter to micro flow runs so operators can narrow durable workflow history to runs checkpointed at a specific stage.
- Cover stage filtering in the flow CLI tests.

Testing:
- go test ./cmd/micro/flow ./flow
- go build ./...
- go test ./... (fails in this environment because loopback targets are forbidden for existing grpc/a2a/transport tests)
- golangci-lint run ./...

Closes #3143