### PR TITLE
Publish provider conformance summaries

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -59,4 +59,19 @@ jobs:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           ATLASCLOUD_API_KEY: ${{ secrets.ATLASCLOUD_API_KEY }}
-        run: go run ./internal/harness/provider-conformance -require-configured
+        run: |
+          go run ./internal/harness/provider-conformance \
+            -require-configured \
+            -summary-json provider-conformance-summary.json \
+            -summary-markdown provider-conformance-summary.md \
+            -capabilities-markdown provider-capabilities.md
+      - name: Upload provider conformance summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: provider-conformance
+          path: |
+            provider-conformance-summary.json
+            provider-conformance-summary.md
+            provider-capabilities.md
+          if-no-files-found: ignore

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -51,6 +51,7 @@ func main() {
 	requireConfiguredFlag := flag.Bool("require-configured", false, "fail when a selected live provider is missing an API key")
 	capabilitiesFlag := flag.Bool("capabilities", true, "print the registered provider capability matrix before running conformance")
 	summaryJSONFlag := flag.String("summary-json", "", "write a machine-readable conformance summary to this path")
+	summaryMarkdownFlag := flag.String("summary-markdown", "", "write a human-readable conformance summary to this path")
 	capabilityMarkdownFlag := flag.String("capabilities-markdown", "", "write the registered provider capability matrix as a Markdown table")
 	flag.Parse()
 
@@ -102,18 +103,24 @@ func main() {
 	}
 
 	fmt.Printf("\nprovider conformance: %d passed, %d skipped providers, %d failed\n", ran, skipped, failed)
+	summary := conformanceSummary{
+		Providers:    providers,
+		Harnesses:    harnesses,
+		Capabilities: ai.CapabilityRows(),
+		Results:      results,
+		Passed:       ran,
+		Skipped:      skipped,
+		Failed:       failed,
+	}
 	if *summaryJSONFlag != "" {
-		summary := conformanceSummary{
-			Providers:    providers,
-			Harnesses:    harnesses,
-			Capabilities: ai.CapabilityRows(),
-			Results:      results,
-			Passed:       ran,
-			Skipped:      skipped,
-			Failed:       failed,
-		}
 		if err := writeSummaryJSON(*summaryJSONFlag, summary); err != nil {
 			fmt.Fprintf(os.Stderr, "write summary: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	if *summaryMarkdownFlag != "" {
+		if err := writeSummaryMarkdown(*summaryMarkdownFlag, summary); err != nil {
+			fmt.Fprintf(os.Stderr, "write summary markdown: %v\n", err)
 			os.Exit(1)
 		}
 	}
@@ -155,13 +162,45 @@ func writeSummaryJSON(path string, summary conformanceSummary) error {
 }
 
 func writeCapabilityMarkdown(path string, rows []ai.CapabilityRow) error {
+	return os.WriteFile(path, []byte(capabilityMarkdown(rows)), 0o644)
+}
+
+func writeSummaryMarkdown(path string, summary conformanceSummary) error {
+	var b strings.Builder
+	b.WriteString("# Provider conformance summary\n\n")
+	fmt.Fprintf(&b, "Passed: %d. Skipped providers: %d. Failed: %d.\n\n", summary.Passed, summary.Skipped, summary.Failed)
+	b.WriteString("## Capability matrix\n\n")
+	b.WriteString(capabilityMarkdown(summary.Capabilities))
+	b.WriteString("\n## Harness results\n\n")
+	b.WriteString("| Provider | Harness | Status | Detail |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, result := range summary.Results {
+		harness := result.Harness
+		if harness == "" {
+			harness = "—"
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", result.Provider, harness, result.Status, markdownCell(result.Error))
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o644)
+}
+
+func capabilityMarkdown(rows []ai.CapabilityRow) string {
 	var b strings.Builder
 	b.WriteString("| Provider | Model | Image | Video | Streaming |\n")
 	b.WriteString("| --- | --- | --- | --- | --- |\n")
 	for _, row := range rows {
 		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n", row.Provider, mark(row.Model), mark(row.Image), mark(row.Video), mark(row.Stream))
 	}
-	return os.WriteFile(path, []byte(b.String()), 0o644)
+	return b.String()
+}
+
+func markdownCell(s string) string {
+	if s == "" {
+		return "—"
+	}
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "\n", "<br>")
+	return s
 }
 
 func mark(ok bool) string {

--- a/internal/harness/provider-conformance/main_test.go
+++ b/internal/harness/provider-conformance/main_test.go
@@ -82,6 +82,39 @@ func TestWriteCapabilityMarkdown(t *testing.T) {
 	}
 }
 
+func TestWriteSummaryMarkdown(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "summary.md")
+	summary := conformanceSummary{
+		Capabilities: []ai.CapabilityRow{{Provider: "mock", Capabilities: ai.Capabilities{Model: true}}},
+		Results: []conformanceResult{
+			{Provider: "mock", Harness: "agent-flow", Status: statusPassed},
+			{Provider: "live", Status: statusSkipped, Error: "missing | key"},
+		},
+		Passed:  1,
+		Skipped: 1,
+	}
+	if err := writeSummaryMarkdown(path, summary); err != nil {
+		t.Fatalf("writeSummaryMarkdown returned error: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read summary markdown: %v", err)
+	}
+	got := string(b)
+	for _, want := range []string{
+		"# Provider conformance summary",
+		"Passed: 1. Skipped providers: 1. Failed: 0.",
+		"| mock | ✅ | — | — | — |",
+		"| mock | agent-flow | passed | — |",
+		"| live | — | skipped | missing \\| key |",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary markdown = %q, want %q", got, want)
+		}
+	}
+}
+
 func TestWriteSummaryJSON(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "summary.json")
 	summary := conformanceSummary{


### PR DESCRIPTION
Adds human-readable provider conformance artifacts on top of the live harness so scheduled runs publish both the capability matrix and per-harness results.

Summary:
- Add a -summary-markdown output to the provider conformance harness.
- Upload JSON, Markdown summary, and capability matrix artifacts from scheduled/manual live conformance runs.

Testing:
- go test ./internal/harness/provider-conformance
- go build ./...
- go test ./... (fails in this sandbox because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3145