### PR TITLE
Improve flow run history validation

### DIFF
--- a/cmd/micro/flow/flow.go
+++ b/cmd/micro/flow/flow.go
@@ -134,7 +134,11 @@ func flowRuns(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	runs = filterFlowRuns(runs, flowRunOptions{Pending: c.Bool("pending"), Status: c.String("status"), Stage: c.String("stage"), Limit: c.Int("limit")})
+	opts, err := validateFlowRunOptions(flowRunOptions{Pending: c.Bool("pending"), Status: c.String("status"), Stage: c.String("stage"), Limit: c.Int("limit")})
+	if err != nil {
+		return err
+	}
+	runs = filterFlowRuns(runs, opts)
 	if len(runs) == 0 {
 		if c.Bool("pending") {
 			fmt.Printf("  No pending runs recorded for flow %q.\n", name)
@@ -151,6 +155,18 @@ type flowRunOptions struct {
 	Status  string
 	Stage   string
 	Limit   int
+}
+
+func validateFlowRunOptions(opts flowRunOptions) (flowRunOptions, error) {
+	switch opts.Status {
+	case "", "running", "done", "failed":
+	default:
+		return opts, fmt.Errorf("invalid run status %q: expected running, done, or failed", opts.Status)
+	}
+	if opts.Limit < 0 {
+		return opts, fmt.Errorf("invalid limit %d: expected a non-negative value", opts.Limit)
+	}
+	return opts, nil
 }
 
 func filterFlowRuns(runs []aiflow.Run, opts flowRunOptions) []aiflow.Run {
@@ -194,6 +210,7 @@ func writeFlowRuns(w io.Writer, runs []aiflow.Run, asJSON bool) error {
 		enc.SetIndent("", "  ")
 		return enc.Encode(runs)
 	}
+	fmt.Fprintf(w, "  %d run%s\n", len(runs), plural(len(runs)))
 	for _, r := range runs {
 		id := r.ID
 		if len(id) > 8 {
@@ -214,6 +231,13 @@ func writeFlowRuns(w io.Writer, runs []aiflow.Run, asJSON bool) error {
 		}
 	}
 	return nil
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func flowFlags() []cli.Flag {

--- a/cmd/micro/flow/flow_test.go
+++ b/cmd/micro/flow/flow_test.go
@@ -29,6 +29,7 @@ func TestWriteFlowRunsIncludesStepDetails(t *testing.T) {
 	}
 	got := out.String()
 	for _, want := range []string{
+		"1 run",
 		"12345678  failed   stage=charge",
 		"updated=2026-06-24T12:30:00Z",
 		"- reserve      done        attempts=1",
@@ -37,6 +38,20 @@ func TestWriteFlowRunsIncludesStepDetails(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestValidateFlowRunOptionsRejectsInvalidStatus(t *testing.T) {
+	_, err := validateFlowRunOptions(flowRunOptions{Status: "stuck"})
+	if err == nil || !strings.Contains(err.Error(), "invalid run status") {
+		t.Fatalf("expected invalid status error, got %v", err)
+	}
+}
+
+func TestValidateFlowRunOptionsRejectsNegativeLimit(t *testing.T) {
+	_, err := validateFlowRunOptions(flowRunOptions{Limit: -1})
+	if err == nil || !strings.Contains(err.Error(), "invalid limit") {
+		t.Fatalf("expected invalid limit error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Validate micro flow runs filters before reading history so bad statuses or negative limits fail clearly.
- Add a plain-text run count summary for durable flow history output.
- Cover the new validation and summary output in flow CLI tests.

Testing:
- go test ./cmd/micro/flow
- go build ./...
- golangci-lint run ./...
- go test ./... (fails in this sandbox because loopback targets are forbidden and an existing cache timing test expired)

Closes #3147