### PR TITLE
Propagate flow checkpoint failures

### DIFF
--- a/flow/steps.go
+++ b/flow/steps.go
@@ -408,7 +408,10 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 		step := steps[i]
 		run.State.Stage = step.Name
 		run.Steps[i].Status = "in_progress"
-		f.save(ctx, run)
+		if err := f.save(ctx, run); err != nil {
+			spanErr = err
+			return run, err
+		}
 
 		out, attempts, err := f.runStepSpan(ctx, step, run.State)
 		run.Steps[i].Attempts = attempts
@@ -417,7 +420,10 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 			run.Steps[i].Status = "failed"
 			run.Steps[i].Error = err.Error()
 			run.Status = "failed"
-			f.save(ctx, run)
+			if saveErr := f.save(ctx, run); saveErr != nil {
+				spanErr = saveErr
+				return run, fmt.Errorf("%w; additionally failed to checkpoint failed run: %v", err, saveErr)
+			}
 			f.record(resultFromRun(f.opts.TriggerTopic, run))
 			f.log.Logf(logger.ErrorLevel, "Flow %s run %s failed at step %q: %v", f.name, run.ID, step.Name, err)
 			return run, err
@@ -431,13 +437,22 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 		} else {
 			run.State.Stage = ""
 		}
-		f.save(ctx, run)
+		if err := f.save(ctx, run); err != nil {
+			spanErr = err
+			return run, err
+		}
 	}
 
 	run.Status = "done"
-	f.save(ctx, run)
+	if err := f.save(ctx, run); err != nil {
+		spanErr = err
+		return run, err
+	}
 	if f.opts.DeleteOnSuccess && f.checkpoint != nil {
-		_ = f.checkpoint.Delete(ctx, run.ID)
+		if err := f.checkpoint.Delete(ctx, run.ID); err != nil {
+			spanErr = err
+			return run, err
+		}
 	}
 	f.record(resultFromRun(f.opts.TriggerTopic, run))
 	f.log.Logf(logger.InfoLevel, "Flow %s run %s completed (%d steps)", f.name, run.ID, len(steps))
@@ -479,13 +494,15 @@ func (f *Flow) runStep(ctx context.Context, step Step, in State) (State, int, er
 	return in, retries + 1, lastErr
 }
 
-func (f *Flow) save(ctx context.Context, run Run) {
+func (f *Flow) save(ctx context.Context, run Run) error {
 	if f.checkpoint == nil {
-		return
+		return nil
 	}
 	if err := f.checkpoint.Save(ctx, run); err != nil {
 		f.log.Logf(logger.ErrorLevel, "Flow %s checkpoint save: %v", f.name, err)
+		return fmt.Errorf("flow %s checkpoint save: %w", f.name, err)
 	}
+	return nil
 }
 
 func validateSteps(steps []Step) error {

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -417,6 +417,59 @@ func TestStoreCheckpointHonorsCanceledContext(t *testing.T) {
 	}
 }
 
+type failingCheckpoint struct {
+	err error
+}
+
+func (c failingCheckpoint) Save(context.Context, Run) error { return c.err }
+func (c failingCheckpoint) Load(context.Context, string) (Run, bool, error) {
+	return Run{}, false, c.err
+}
+func (c failingCheckpoint) Delete(context.Context, string) error { return c.err }
+func (c failingCheckpoint) List(context.Context) ([]Run, error)  { return nil, c.err }
+
+func TestFlowCheckpointSaveFailureStopsRun(t *testing.T) {
+	checkpointErr := errors.New("checkpoint unavailable")
+	var ran bool
+	f := New("checkpoint-fails",
+		WithCheckpoint(failingCheckpoint{err: checkpointErr}),
+		Steps(Step{Name: "work", Run: func(_ context.Context, in State) (State, error) {
+			ran = true
+			return in, nil
+		}}),
+	)
+
+	err := f.Execute(context.Background(), "start")
+	if !errors.Is(err, checkpointErr) {
+		t.Fatalf("Execute error = %v, want checkpoint error", err)
+	}
+	if ran {
+		t.Fatal("step ran even though the in-progress checkpoint failed")
+	}
+}
+
+func TestFlowDeleteOnSuccessFailureIsReturned(t *testing.T) {
+	checkpointErr := errors.New("delete unavailable")
+	cp := &deleteFailCheckpoint{Checkpoint: StoreCheckpoint(store.NewMemoryStore(), "delete-fails"), err: checkpointErr}
+	f := New("delete-fails",
+		WithCheckpoint(cp),
+		DeleteOnSuccess(),
+		Steps(appendStep("work")),
+	)
+
+	err := f.Execute(context.Background(), "")
+	if !errors.Is(err, checkpointErr) {
+		t.Fatalf("Execute error = %v, want delete error", err)
+	}
+}
+
+type deleteFailCheckpoint struct {
+	Checkpoint
+	err error
+}
+
+func (c *deleteFailCheckpoint) Delete(context.Context, string) error { return c.err }
+
 func TestStateSetScan(t *testing.T) {
 	var s State
 	type payload struct {


### PR DESCRIPTION
Summary:
- Stop stepped flow execution when checkpoint saves fail instead of continuing without durable state.
- Return DeleteOnSuccess cleanup errors so stale successful checkpoints are visible.
- Add tests for checkpoint save and delete failure propagation.

Testing:
- go build ./...
- go test ./flow
- go test ./... (fails in this environment because loopback targets are forbidden for grpc/a2a integration tests)
- golangci-lint run ./...

Closes #3149