### PR TITLE
Align public docs with current x402 flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ Every endpoint is an AI-callable tool — and it can be a *paid* tool. Go Micro 
 
 ```bash
 # Charge for tool calls at the MCP gateway (off unless you set a pay-to address)
-micro mcp serve --x402-pay-to 0xYourAddress --x402-network solana --x402-amount 10000
+micro mcp serve --x402_pay_to 0xYourAddress --x402_network solana --x402_amount 10000
 # Per-tool amounts via a config file
-micro mcp serve --x402-config x402.json
+micro mcp serve --x402_config x402.json
 ```
 
 See the [Payments (x402) guide](internal/website/docs/guides/x402-payments.md).

--- a/internal/website/docs/guides/x402-payments.md
+++ b/internal/website/docs/guides/x402-payments.md
@@ -42,10 +42,10 @@ Because every endpoint is already an MCP tool, the gateway is where you charge. 
 
 ```bash
 micro mcp serve --address :3000 \
-    --x402-pay-to 0xYourAddress \
-    --x402-network solana \
-    --x402-amount 10000 \
-    --x402-facilitator https://facilitator.example
+    --x402_pay_to 0xYourAddress \
+    --x402_network solana \
+    --x402_amount 10000 \
+    --x402_facilitator https://facilitator.example
 ```
 
 ## A shoppable catalog
@@ -69,7 +69,7 @@ Free tools carry no `payment` block. This is the foundation for a tool marketpla
 Different tools can cost different amounts. Pricing is an **operator** concern — the payTo address is the operator's, and amounts change without redeploying anyone's service — so it's configured at the gateway with a file, the same way per-tool scopes and rate limits are. Point the gateway at an x402 config:
 
 ```bash
-micro mcp serve --address :3000 --x402-config x402.json
+micro mcp serve --address :3000 --x402_config x402.json
 ```
 
 ```json
@@ -85,7 +85,7 @@ micro mcp serve --address :3000 --x402-config x402.json
 }
 ```
 
-`amount` is the default (here `"0"` — free unless priced), and `amounts` sets per-tool overrides keyed by tool name. There is no "pricing" abstraction; it's the x402 `amount`, resolved per tool, in the protocol's own vocabulary. The standalone gateway accepts the same file via `--x402-config` or the `X402_CONFIG` environment variable.
+`amount` is the default (here `"0"` — free unless priced), and `amounts` sets per-tool overrides keyed by tool name. There is no "pricing" abstraction; it's the x402 `amount`, resolved per tool, in the protocol's own vocabulary. `micro mcp serve` accepts the file via `--x402_config`; the standalone gateway accepts the same file via `--x402-config` or the `X402_CONFIG` environment variable.
 
 ## Paying for tools (the consumer side)
 

--- a/internal/website/docs/index.md
+++ b/internal/website/docs/index.md
@@ -34,7 +34,7 @@ about the framework.
 - [Transport](transport.html)
 - [Store](store.html)
 - [Plugins](plugins.html)
-- [Examples](examples/index.md)
+- [Examples](examples/)
 
 ## Development & Deployment
 
@@ -52,9 +52,9 @@ about the framework.
 ## Advanced
 
 - [Framework Comparison](guides/comparison.html)
-- [Architecture Decisions](architecture/index.md)
-- [Real-World Examples](examples/realworld/index.md)
-- [Migration Guides](guides/migration/index.md)
+- [Architecture Decisions](architecture/)
+- [Real-World Examples](examples/realworld/)
+- [Migration Guides](guides/migration/)
 - [Observability](observability.html)
 - [Contributing](contributing.html)
 - [Roadmap](roadmap.html)


### PR DESCRIPTION
Summary:
- Align README and x402 guide examples with the current `micro mcp serve` underscore x402 flags.
- Clarify the standalone MCP gateway still accepts the hyphenated x402 config flag.
- Clean docs index links to generated section directories.

Testing:
- go build ./...
- golangci-lint run ./...
- go test ./... (fails in this environment due loopback/Envoy restrictions in grpc transport/client and dependent A2A tests)

Closes #3152