### PR TITLE
Add A2A completed-task streaming

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -18,10 +18,11 @@
 //		BaseURL:  "https://agents.example.com",
 //	})
 //
-// Scope of this version: the synchronous JSON-RPC binding — `message/send`
-// (returns a completed Task), `tasks/get`, and Agent Card discovery.
-// Streaming (`message/stream`), multi-turn `input-required`, and push
-// notifications are advertised as unsupported and are follow-ups.
+// Scope of this version: the JSON-RPC binding — `message/send`
+// (returns a completed Task), `message/stream` (SSE with the completed
+// Task event), `tasks/get`, and Agent Card discovery. Multi-turn
+// `input-required`, `tasks/resubscribe`, and push notifications are
+// advertised as unsupported and are follow-ups.
 package a2a
 
 import (
@@ -314,7 +315,7 @@ func Card(name, url, description string, services []string) AgentCard {
 		URL:             url,
 		Version:         "1.0.0",
 		ProtocolVersion: protocolVersion,
-		Capabilities:    Capabilities{Streaming: false, PushNotifications: false},
+		Capabilities:    Capabilities{Streaming: true, PushNotifications: false},
 		// The agent converses over a single Chat endpoint; advertise that
 		// as one skill, tagged with the services it manages.
 		DefaultInputModes:  []string{"text/plain"},
@@ -416,13 +417,15 @@ func (d *dispatcher) serve(w http.ResponseWriter, r *http.Request, invoke Invoke
 	switch req.Method {
 	case "message/send":
 		d.send(requestContext(r.Context()), w, req, invoke)
+	case "message/stream":
+		d.stream(requestContext(r.Context()), w, req, invoke)
 	case "tasks/get":
 		d.get(w, req)
 	case "tasks/cancel":
 		// v1 tasks complete synchronously, so they're already terminal.
 		writeRPC(w, req.ID, nil, &rpcError{Code: errNotCancelable, Message: "task is not cancelable"})
-	case "message/stream", "tasks/resubscribe":
-		writeRPC(w, req.ID, nil, &rpcError{Code: errMethodNotFound, Message: "streaming is not supported"})
+	case "tasks/resubscribe":
+		writeRPC(w, req.ID, nil, &rpcError{Code: errMethodNotFound, Message: "resubscribe is not supported"})
 	default:
 		writeRPC(w, req.ID, nil, &rpcError{Code: errMethodNotFound, Message: "method not found: " + req.Method})
 	}
@@ -433,15 +436,38 @@ type sendParams struct {
 }
 
 func (d *dispatcher) send(ctx context.Context, w http.ResponseWriter, req rpcRequest, invoke Invoke) {
-	var p sendParams
-	if err := json.Unmarshal(req.Params, &p); err != nil {
-		writeRPC(w, req.ID, nil, &rpcError{Code: errInvalidParams, Message: "invalid params"})
+	task, e := d.run(ctx, req.Params, invoke)
+	if e != nil {
+		writeRPC(w, req.ID, nil, e)
 		return
+	}
+	writeRPC(w, req.ID, task, nil)
+}
+
+func (d *dispatcher) stream(ctx context.Context, w http.ResponseWriter, req rpcRequest, invoke Invoke) {
+	task, e := d.run(ctx, req.Params, invoke)
+	if e != nil {
+		writeRPC(w, req.ID, nil, e)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(sseWriter{w: w}).Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: task})
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (d *dispatcher) run(ctx context.Context, params json.RawMessage, invoke Invoke) (*Task, *rpcError) {
+	var p sendParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &rpcError{Code: errInvalidParams, Message: "invalid params"}
 	}
 	text := textOf(p.Message.Parts)
 	if text == "" {
-		writeRPC(w, req.ID, nil, &rpcError{Code: errInvalidParams, Message: "message has no text part"})
-		return
+		return nil, &rpcError{Code: errInvalidParams, Message: "message has no text part"}
 	}
 
 	reply, err := invoke(ctx, text)
@@ -464,7 +490,7 @@ func (d *dispatcher) send(ctx context.Context, w http.ResponseWriter, req rpcReq
 		task.Artifacts = []Artifact{textArtifact(reply)}
 	}
 	d.store(task)
-	writeRPC(w, req.ID, task, nil)
+	return task, nil
 }
 
 type getParams struct {
@@ -563,6 +589,24 @@ func requestContext(parent context.Context) context.Context {
 		cancel()
 	}()
 	return ctx
+}
+
+type sseWriter struct {
+	w http.ResponseWriter
+}
+
+func (s sseWriter) Write(p []byte) (int, error) {
+	if _, err := s.w.Write([]byte("data: ")); err != nil {
+		return 0, err
+	}
+	n, err := s.w.Write(p)
+	if err != nil {
+		return n, err
+	}
+	if _, err := s.w.Write([]byte("\n")); err != nil {
+		return n, err
+	}
+	return n, nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,6 +46,7 @@ func newGatewayWithAgent(t *testing.T) (*httptest.Server, func()) {
 
 	srv := server.NewServer(
 		server.Name("echo"),
+		server.Address("127.0.0.1:0"),
 		server.Registry(reg),
 		server.Metadata(map[string]string{"type": "agent", "services": ""}),
 	)
@@ -145,6 +148,42 @@ func TestMessageSendUsesRequestContext(t *testing.T) {
 	}
 }
 
+func TestMessageStream(t *testing.T) {
+	ts, cleanup := newGatewayWithAgent(t)
+	defer cleanup()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"message/stream","params":{"message":{"role":"user","parts":[{"kind":"text","text":"ping"}],"kind":"message"}}}`
+	resp, err := http.Post(ts.URL+"/agents/echo", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("content-type = %q, want text/event-stream", ct)
+	}
+
+	var line string
+	if _, err := fmt.Fscan(resp.Body, &line); err != nil {
+		t.Fatalf("read event prefix: %v", err)
+	}
+	if line != "data:" {
+		t.Fatalf("event prefix = %q, want data:", line)
+	}
+	var out struct {
+		Result Task      `json:"result"`
+		Error  *rpcError `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode event: %v", err)
+	}
+	if out.Error != nil {
+		t.Fatalf("rpc error: %+v", out.Error)
+	}
+	if out.Result.Status.State != stateCompleted || len(out.Result.Artifacts) != 1 || textOf(out.Result.Artifacts[0].Parts) != "pong" {
+		t.Fatalf("streamed task = %+v", out.Result)
+	}
+}
+
 func TestUnknownMethod(t *testing.T) {
 	ts, cleanup := newGatewayWithAgent(t)
 	defer cleanup()
@@ -152,9 +191,9 @@ func TestUnknownMethod(t *testing.T) {
 	var resp struct {
 		Error *rpcError `json:"error"`
 	}
-	rpc(t, ts.URL+"/agents/echo", `{"jsonrpc":"2.0","id":1,"method":"message/stream","params":{}}`, &resp)
+	rpc(t, ts.URL+"/agents/echo", `{"jsonrpc":"2.0","id":1,"method":"tasks/resubscribe","params":{}}`, &resp)
 	if resp.Error == nil || resp.Error.Code != errMethodNotFound {
-		t.Errorf("expected method-not-found for streaming, got %+v", resp.Error)
+		t.Errorf("expected method-not-found for resubscribe, got %+v", resp.Error)
 	}
 }
 

--- a/internal/website/docs/guides/a2a-protocol.md
+++ b/internal/website/docs/guides/a2a-protocol.md
@@ -132,9 +132,10 @@ yet terminal, it polls `tasks/get` until it completes.
 
 ## Scope
 
-This is the synchronous JSON-RPC binding:
+This is the JSON-RPC binding for completed-task execution:
 
 - **`message/send`** runs the agent and returns a completed `Task`.
+- **`message/stream`** streams the completed `Task` as an SSE `data:` event, giving A2A clients a streaming-compatible path while the underlying agent call remains synchronous.
 - **`tasks/get`** returns a recent task by id.
 - **Agent Card** discovery, generated from the registry.
 
@@ -142,11 +143,11 @@ Both directions work: the gateway exposes your agents, and `a2a.Client` (via `fl
 
 Not yet supported (advertised as such on the card, so clients negotiate correctly):
 
-- **`message/stream`** (SSE streaming) and `tasks/resubscribe`.
+- **`tasks/resubscribe`** for reconnecting to a live stream.
 - Multi-turn `input-required` tasks.
 - Push notifications.
 
-These are the natural follow-ups; the synchronous binding is what makes a Go Micro agent both reachable from, and able to reach, the A2A ecosystem today.
+These are the natural follow-ups; the completed-task binding is what makes a Go Micro agent both reachable from, and able to reach, the A2A ecosystem today.
 
 ## See also
 


### PR DESCRIPTION
Summary:
- Add message/stream support to the A2A gateway using SSE data events that carry the completed task.
- Advertise streaming capability on generated agent cards.
- Document the completed-task streaming scope and keep tasks/resubscribe listed as unsupported.

Testing:
- go build ./...
- go test ./gateway/a2a
- go test ./... (fails in this environment: grpc loopback targets forbidden in client/grpc and transport/grpc tests)
- golangci-lint run ./...

Closes #3155