### PR TITLE
Add flow step context to run info

### DIFF
--- a/ai/model.go
+++ b/ai/model.go
@@ -113,12 +113,17 @@ const (
 // RunInfo describes the agent run a tool call belongs to. The agent
 // attaches it to the context passed to a ToolHandler, so a wrapper can
 // correlate calls within a run and across delegation without coupling to
-// the agent package. Per-call detail (tool name, id) is on the ToolCall;
-// step and attempt counts are naturally counted by the wrapper itself.
+// the agent package. Flows also attach their name and current step so
+// tools and agents called from a workflow can be tied back to the
+// services → agents → workflows lifecycle that invoked them. Per-call
+// detail (tool name, id) is on the ToolCall; attempt counts are naturally
+// counted by the wrapper itself.
 type RunInfo struct {
-	RunID    string // correlation id for this agent run (one per Ask)
+	RunID    string // correlation id for this agent or flow run
 	ParentID string // the run that delegated to this one, if any
 	Agent    string // the agent's name
+	Flow     string // the flow's name, when the call is part of a workflow
+	Step     string // the flow step currently executing, when known
 }
 
 type runInfoKey struct{}

--- a/flow/steps.go
+++ b/flow/steps.go
@@ -390,7 +390,7 @@ func (f *Flow) Pending(ctx context.Context) ([]Run, error) {
 func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 	steps := f.opts.Steps
 	ctx = withDeps(ctx, &runDeps{client: f.client, model: f.model, tools: f.toolSet})
-	ctx = ai.WithRunInfo(ctx, ai.RunInfo{RunID: run.ID, Agent: f.name})
+	ctx = ai.WithRunInfo(ctx, ai.RunInfo{RunID: run.ID, Agent: f.name, Flow: f.name})
 	ctx, finishSpan := f.startRunSpan(ctx, run)
 	var spanErr error
 	defer func() { finishSpan(run, spanErr) }()
@@ -477,6 +477,10 @@ func (f *Flow) runStep(ctx context.Context, step Step, in State) (State, int, er
 		// error is surfaced so callers can detect cancellation upstream.
 		if err := ctx.Err(); err != nil {
 			return in, attempt - 1, err
+		}
+		if info, ok := ai.RunInfoFrom(ctx); ok {
+			info.Step = step.Name
+			ctx = ai.WithRunInfo(ctx, info)
 		}
 		out, err := step.Run(ctx, in)
 		if err == nil {

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -112,6 +112,12 @@ func TestFlowStepContextIncludesRunInfo(t *testing.T) {
 	if got.RunID == "" {
 		t.Fatal("RunInfo.RunID is empty")
 	}
+	if got.Flow != "correlated" {
+		t.Fatalf("RunInfo.Flow = %q, want correlated", got.Flow)
+	}
+	if got.Step != "inspect" {
+		t.Fatalf("RunInfo.Step = %q, want inspect", got.Step)
+	}
 }
 
 func TestFlowResumePendingResumesOldestRunsUntilFailure(t *testing.T) {


### PR DESCRIPTION
Summary:
- Add Flow and Step fields to ai.RunInfo so calls made inside workflows can be correlated to the flow and step that invoked them.
- Attach flow name at run start and current step before step execution.
- Extend flow RunInfo coverage tests.

Testing:
- go build ./...
- go test ./flow ./ai
- go test ./... (fails in this environment because loopback targets are forbidden for grpc tests)
- golangci-lint run ./...

Closes #3157