### PR TITLE
Harden micro new no-MCP contract

### DIFF
--- a/cmd/micro/cli/new/contract_test.go
+++ b/cmd/micro/cli/new/contract_test.go
@@ -19,6 +19,45 @@ import (
 // It shells out to `micro new` (which runs `go mod tidy`) and `go build`, so
 // it needs the Go toolchain and module access; it is skipped under `-short`.
 func TestZeroToOneContract(t *testing.T) {
+	generated := generateService(t, "helloworld")
+
+	for _, rel := range []string{"go.mod", "main.go", "handler/helloworld.go", "README.md", "Makefile"} {
+		if _, err := os.Stat(filepath.Join(generated.dir, rel)); err != nil {
+			t.Fatalf("generated file %s: %v", rel, err)
+		}
+	}
+
+	generated.replaceModule(t)
+	generated.build(t)
+}
+
+// TestZeroToOneNoMCPContract keeps the MCP opt-out path honest. Some services
+// intentionally run without the local MCP listener, but that variant must still
+// satisfy the same 0→1 contract: scaffold, tidy, and build without additional
+// toolchain dependencies.
+func TestZeroToOneNoMCPContract(t *testing.T) {
+	generated := generateService(t, "worker", "--no-mcp")
+
+	main, err := os.ReadFile(filepath.Join(generated.dir, "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(main), "gateway/mcp") || strings.Contains(string(main), "WithMCP") {
+		t.Fatalf("--no-mcp generated main.go with MCP wiring:\n%s", main)
+	}
+
+	generated.replaceModule(t)
+	generated.build(t)
+}
+
+type generatedService struct {
+	dir      string
+	repoRoot string
+}
+
+func generateService(t *testing.T, name string, args ...string) generatedService {
+	t.Helper()
+
 	if testing.Short() {
 		t.Skip("contract test shells out to the Go toolchain; skipped with -short")
 	}
@@ -39,35 +78,44 @@ func TestZeroToOneContract(t *testing.T) {
 	defer os.Chdir(oldwd)
 
 	set := flag.NewFlagSet("micro-new", flag.ContinueOnError)
-	if err := set.Parse([]string{"helloworld"}); err != nil {
+	set.Bool("no-mcp", false, "")
+	set.Bool("proto", false, "")
+	set.String("template", "", "")
+	set.String("prompt", "", "")
+	set.String("provider", "", "")
+	set.String("api_key", "", "")
+	if err := set.Parse(append(args, name)); err != nil {
 		t.Fatal(err)
 	}
 	ctx := cli.NewContext(cli.NewApp(), set, nil)
 
 	if err := Run(ctx); err != nil {
-		t.Fatalf("micro new helloworld: %v", err)
+		t.Fatalf("micro new %s %s: %v", strings.Join(args, " "), name, err)
 	}
 
-	serviceDir := filepath.Join(tmp, "helloworld")
-	for _, rel := range []string{"go.mod", "main.go", "handler/helloworld.go", "README.md", "Makefile"} {
-		if _, err := os.Stat(filepath.Join(serviceDir, rel)); err != nil {
-			t.Fatalf("generated file %s: %v", rel, err)
-		}
-	}
+	return generatedService{dir: filepath.Join(tmp, name), repoRoot: repoRoot}
+}
 
-	modPath := filepath.Join(serviceDir, "go.mod")
+func (g generatedService) replaceModule(t *testing.T) {
+	t.Helper()
+
+	modPath := filepath.Join(g.dir, "go.mod")
 	mod, err := os.ReadFile(modPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	modText := strings.Replace(string(mod), "go-micro.dev/v6 latest", "go-micro.dev/v6 v6.0.0", 1)
-	modText += "\nreplace go-micro.dev/v6 => " + filepath.ToSlash(repoRoot) + "\n"
+	modText += "\nreplace go-micro.dev/v6 => " + filepath.ToSlash(g.repoRoot) + "\n"
 	if err := os.WriteFile(modPath, []byte(modText), 0644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func (g generatedService) build(t *testing.T) {
+	t.Helper()
 
 	cmd := exec.Command("go", "build", "./...")
-	cmd.Dir = serviceDir
+	cmd.Dir = g.dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("generated service go build ./... failed: %v\n%s", err, out)


### PR DESCRIPTION
Summary:
- Refactor the micro new contract test around a shared generated-service helper.
- Add coverage for micro new --no-mcp so the MCP opt-out scaffold has no MCP wiring and still builds.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3159