### PR TITLE
Track parent run IDs for durable flows

### DIFF
--- a/flow/otel.go
+++ b/flow/otel.go
@@ -17,6 +17,7 @@ const (
 	spanNameFlowStep = "flow.step"
 
 	AttrFlowRunID     = "flow.run.id"
+	AttrFlowParentID  = "flow.run.parent_id"
 	AttrFlowName      = "flow.name"
 	AttrFlowStepName  = "flow.step.name"
 	AttrFlowStatus    = "flow.status"
@@ -34,6 +35,7 @@ func (f *Flow) startRunSpan(ctx context.Context, run Run) (context.Context, func
 	}
 	ctx, span := f.tracer().Start(ctx, spanNameFlowRun, trace.WithSpanKind(trace.SpanKindInternal), trace.WithAttributes(
 		attribute.String(AttrFlowRunID, run.ID),
+		attribute.String(AttrFlowParentID, run.ParentID),
 		attribute.String(AttrFlowName, f.name),
 		attribute.String(AttrFlowStatus, run.Status),
 	))
@@ -60,6 +62,7 @@ func (f *Flow) runStepSpan(ctx context.Context, step Step, in State) (State, int
 	info, _ := ai.RunInfoFrom(ctx)
 	ctx, span := f.tracer().Start(ctx, spanNameFlowStep, trace.WithAttributes(
 		attribute.String(AttrFlowRunID, info.RunID),
+		attribute.String(AttrFlowParentID, info.ParentID),
 		attribute.String(AttrFlowName, f.name),
 		attribute.String(AttrFlowStepName, step.Name),
 	))

--- a/flow/otel_test.go
+++ b/flow/otel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/store"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -19,7 +20,8 @@ func TestFlowOpenTelemetrySpans(t *testing.T) {
 		return in, nil
 	}}
 	f := New("observed", WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "observed")), TraceProvider(tp), Steps(step))
-	if err := f.Execute(context.Background(), "start"); err != nil {
+	ctx := withTestRunInfo(context.Background(), "agent-run-otel")
+	if err := f.Execute(ctx, "start"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -32,12 +34,12 @@ func TestFlowOpenTelemetrySpans(t *testing.T) {
 		case spanNameFlowRun:
 			seen[spanNameFlowRun] = true
 			runID = attrs[AttrFlowRunID]
-			if attrs[AttrFlowName] != "observed" || attrs[AttrFlowStatus] != "done" {
+			if attrs[AttrFlowName] != "observed" || attrs[AttrFlowStatus] != "done" || attrs[AttrFlowParentID] != "agent-run-otel" {
 				t.Fatalf("run span attributes = %#v", attrs)
 			}
 		case spanNameFlowStep:
 			seen[spanNameFlowStep] = true
-			if attrs[AttrFlowName] != "observed" || attrs[AttrFlowStepName] != "inspect" {
+			if attrs[AttrFlowName] != "observed" || attrs[AttrFlowStepName] != "inspect" || attrs[AttrFlowParentID] != "agent-run-otel" {
 				t.Fatalf("step span attributes = %#v", attrs)
 			}
 		}
@@ -67,4 +69,8 @@ func flowSpanAttributes(attrs []attribute.KeyValue) map[string]string {
 		out[string(attr.Key)] = attr.Value.AsString()
 	}
 	return out
+}
+
+func withTestRunInfo(ctx context.Context, runID string) context.Context {
+	return ai.WithRunInfo(ctx, ai.RunInfo{RunID: runID, Agent: "planner"})
 }

--- a/flow/steps.go
+++ b/flow/steps.go
@@ -74,13 +74,14 @@ type StepRecord struct {
 // saves and loads. It is retained for success and failure unless the flow
 // opts into cleanup with DeleteOnSuccess.
 type Run struct {
-	ID      string       `json:"id"`
-	Flow    string       `json:"flow"`
-	State   State        `json:"state"`
-	Steps   []StepRecord `json:"steps"`
-	Status  string       `json:"status"` // running | done | failed
-	Started time.Time    `json:"started"`
-	Updated time.Time    `json:"updated"`
+	ID       string       `json:"id"`
+	ParentID string       `json:"parent_id,omitempty"`
+	Flow     string       `json:"flow"`
+	State    State        `json:"state"`
+	Steps    []StepRecord `json:"steps"`
+	Status   string       `json:"status"` // running | done | failed
+	Started  time.Time    `json:"started"`
+	Updated  time.Time    `json:"updated"`
 }
 
 // Checkpoint persists and restores flow runs so a run survives a crash
@@ -309,12 +310,17 @@ func (f *Flow) startRun(ctx context.Context, data string) (Run, error) {
 	if err := validateSteps(f.opts.Steps); err != nil {
 		return Run{}, err
 	}
+	parentID := ""
+	if info, ok := ai.RunInfoFrom(ctx); ok {
+		parentID = info.RunID
+	}
 	run := Run{
-		ID:      uuid.New().String(),
-		Flow:    f.name,
-		State:   State{Stage: f.opts.Steps[0].Name, Data: []byte(data)},
-		Status:  "running",
-		Started: time.Now(),
+		ID:       uuid.New().String(),
+		ParentID: parentID,
+		Flow:     f.name,
+		State:    State{Stage: f.opts.Steps[0].Name, Data: []byte(data)},
+		Status:   "running",
+		Started:  time.Now(),
 	}
 	for _, s := range f.opts.Steps {
 		run.Steps = append(run.Steps, StepRecord{Name: s.Name, Status: "pending"})
@@ -390,7 +396,7 @@ func (f *Flow) Pending(ctx context.Context) ([]Run, error) {
 func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 	steps := f.opts.Steps
 	ctx = withDeps(ctx, &runDeps{client: f.client, model: f.model, tools: f.toolSet})
-	ctx = ai.WithRunInfo(ctx, ai.RunInfo{RunID: run.ID, Agent: f.name, Flow: f.name})
+	ctx = ai.WithRunInfo(ctx, ai.RunInfo{RunID: run.ID, ParentID: run.ParentID, Agent: f.name, Flow: f.name})
 	ctx, finishSpan := f.startRunSpan(ctx, run)
 	var spanErr error
 	defer func() { finishSpan(run, spanErr) }()

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -99,11 +99,13 @@ func TestFlowStepContextIncludesRunInfo(t *testing.T) {
 		return in, nil
 	}}
 
+	mem := store.NewMemoryStore()
 	f := New("correlated",
-		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "correlated")),
+		WithCheckpoint(StoreCheckpoint(mem, "correlated")),
 		Steps(step),
 	)
-	if err := f.Execute(context.Background(), "start"); err != nil {
+	ctx := ai.WithRunInfo(context.Background(), ai.RunInfo{RunID: "agent-run-1", Agent: "planner"})
+	if err := f.Execute(ctx, "start"); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if got.Agent != "correlated" {
@@ -115,8 +117,18 @@ func TestFlowStepContextIncludesRunInfo(t *testing.T) {
 	if got.Flow != "correlated" {
 		t.Fatalf("RunInfo.Flow = %q, want correlated", got.Flow)
 	}
+	if got.ParentID != "agent-run-1" {
+		t.Fatalf("RunInfo.ParentID = %q, want agent-run-1", got.ParentID)
+	}
 	if got.Step != "inspect" {
 		t.Fatalf("RunInfo.Step = %q, want inspect", got.Step)
+	}
+	runs, err := StoreCheckpoint(mem, "correlated").List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ParentID != "agent-run-1" {
+		t.Fatalf("persisted parent id = %+v, want agent-run-1", runs)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Persist parent run IDs on durable flow runs so workflows launched from agents retain lifecycle lineage.
- Attach parent run IDs to flow run and step OpenTelemetry spans for cross-layer correlation.
- Extend flow tests to verify parent lineage is propagated, persisted, and traced.

Testing:
- go build ./...
- go test ./... (fails in this environment: loopback gRPC targets are forbidden by envoy in client/grpc and transport/grpc tests)
- golangci-lint run ./...

Closes #3161