### PR TITLE
Add flow execution timeout option

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -182,6 +182,19 @@ func (f *Flow) Register(reg registry.Registry, br broker.Broker, cl client.Clien
 // registry. In-flight and past runs remain in the store; Stop only ends
 // the flow's liveness, mirroring how a service leaves the registry when
 // it shuts down.
+func (f *Flow) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if f.opts.Timeout <= 0 {
+		return ctx, func() {}
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, f.opts.Timeout)
+}
+
 func (f *Flow) Stop() error {
 	if f.sub != nil {
 		_ = f.sub.Unsubscribe()
@@ -199,6 +212,9 @@ func (f *Flow) Stop() error {
 // called automatically on each broker event, but can also be
 // invoked directly for testing or one-shot use.
 func (f *Flow) Execute(ctx context.Context, data string) error {
+	ctx, cancel := f.withTimeout(ctx)
+	defer cancel()
+
 	// Stepped flows run the ordered, checkpointed step loop.
 	if len(f.opts.Steps) > 0 {
 		_, err := f.startRun(ctx, data)

--- a/flow/options.go
+++ b/flow/options.go
@@ -24,6 +24,9 @@ type Options struct {
 	BaseURL string
 	// HistoryLimit is the max messages per flow execution.
 	HistoryLimit int
+	// Timeout bounds one flow execution when the caller did not already
+	// provide a context deadline. Zero means no flow-level timeout.
+	Timeout time.Duration
 	// OnResult is called after each execution with the result.
 	OnResult func(Result)
 	// Agent, if set, names a registered agent the flow hands each event
@@ -92,6 +95,13 @@ func BaseURL(url string) Option {
 // HistoryLimit sets the max messages per execution.
 func HistoryLimit(n int) Option {
 	return func(o *Options) { o.HistoryLimit = n }
+}
+
+// Timeout bounds one flow execution when the caller did not already
+// provide a context deadline. It applies to broker-triggered runs,
+// Execute calls, resumed stepped runs, and retry backoff waits.
+func Timeout(d time.Duration) Option {
+	return func(o *Options) { o.Timeout = d }
 }
 
 // OnResult sets a callback for each execution result.

--- a/flow/steps.go
+++ b/flow/steps.go
@@ -331,6 +331,9 @@ func (f *Flow) startRun(ctx context.Context, data string) (Run, error) {
 // Resume continues a persisted run by id, picking up at the step it
 // stopped on. Completed runs are a no-op.
 func (f *Flow) Resume(ctx context.Context, runID string) error {
+	ctx, cancel := f.withTimeout(ctx)
+	defer cancel()
+
 	if err := validateSteps(f.opts.Steps); err != nil {
 		return err
 	}
@@ -360,6 +363,9 @@ func (f *Flow) Resume(ctx context.Context, runID string) error {
 // stops and returns that run id with the error so callers can log, alert, or
 // retry later without hiding the failing run.
 func (f *Flow) ResumePending(ctx context.Context) (string, error) {
+	ctx, cancel := f.withTimeout(ctx)
+	defer cancel()
+
 	runs, err := f.Pending(ctx)
 	if err != nil {
 		return "", err

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -279,6 +279,50 @@ func TestFlowStepRetryBackoffWaitsBetweenAttempts(t *testing.T) {
 	}
 }
 
+func TestFlowTimeoutStopsRetryBackoff(t *testing.T) {
+	var attempts int
+	step := Step{Name: "slow", Run: func(_ context.Context, in State) (State, error) {
+		attempts++
+		return in, errors.New("transient")
+	}}
+
+	f := New("timeout-backoff",
+		WithCheckpoint(StoreCheckpoint(store.NewMemoryStore(), "timeout-backoff")),
+		Timeout(20*time.Millisecond),
+		Retry(1),
+		RetryBackoff(time.Hour),
+		Steps(step),
+	)
+	err := f.Execute(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected the timed-out run to fail")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("want a context deadline error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("timeout should stop during backoff before retrying, got %d attempts", attempts)
+	}
+}
+
+func TestFlowTimeoutRespectsExistingDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+
+	f := New("existing-deadline", Timeout(time.Millisecond))
+	got, stop := f.withTimeout(ctx)
+	defer stop()
+
+	wantDeadline, _ := ctx.Deadline()
+	gotDeadline, ok := got.Deadline()
+	if !ok {
+		t.Fatal("expected the existing deadline to remain set")
+	}
+	if !gotDeadline.Equal(wantDeadline) {
+		t.Fatalf("deadline = %v, want existing deadline %v", gotDeadline, wantDeadline)
+	}
+}
+
 func TestFlowStepRetryBackoffStopsOnCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var attempts int


### PR DESCRIPTION
Summary:
- Add a flow-level Timeout option that bounds executions when callers have not already supplied a context deadline.
- Apply the timeout to direct Execute calls and stepped-flow resume paths, including retry backoff waits.
- Add coverage for timeout-triggered retry cancellation and preserving caller deadlines.

Testing:
- go test ./flow
- go build ./...
- go test ./... (fails in this environment: cache timing flake and loopback targets forbidden for grpc tests)
- golangci-lint run ./...

Closes #3163