### PR TITLE
fix: add temporary go.mod for phantom module retraction

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,0 +1,6 @@
+module go-micro.dev/v6/cmd
+
+go 1.24
+
+// wipe out phantom module cache
+retract [v0.0.0, v1.18.1]

--- a/cmd/micro/go.mod
+++ b/cmd/micro/go.mod
@@ -1,0 +1,6 @@
+module go-micro.dev/v6/cmd/micro
+
+go 1.24
+
+// wipe out phantom module cache
+retract [v0.0.0, v1.18.1]


### PR DESCRIPTION
## Summary
Adds temporary `go.mod` files to `cmd` and `cmd/micro` to allow retraction of phantom versions cached by the Go proxy.

## Instructions for Maintainer
To clear the proxy cache, these tags must be pushed **before** this PR is merged or immediately after:
1. `git tag cmd/v1.18.1`
2. `git tag cmd/micro/v1.18.1`
3. `git push origin --tags`

These files will be removed in a follow-up PR to restore the build.

Fixes #2987

🤖 Generated with [Claude Code](https://claude.com/claude-code)