### PR TITLE
Tag single-step flow run info as flows

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -222,7 +222,7 @@ func (f *Flow) Execute(ctx context.Context, data string) error {
 	}
 
 	runID := uuid.New().String()
-	ctx = ai.WithRunInfo(ctx, ai.RunInfo{RunID: runID, Agent: f.name})
+	ctx = ai.WithRunInfo(ctx, ai.RunInfo{RunID: runID, Flow: f.name})
 
 	start := time.Now()
 

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -1,7 +1,11 @@
 package flow
 
 import (
+	"context"
 	"testing"
+
+	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/registry"
 )
 
 func TestNew(t *testing.T) {
@@ -83,3 +87,45 @@ func TestDefaultOptions(t *testing.T) {
 		t.Error("default system prompt is empty")
 	}
 }
+
+func TestSingleStepFlowRunInfoIdentifiesFlow(t *testing.T) {
+	model := &runInfoModel{}
+	f := New("single-observed")
+	f.model = model
+	f.toolSet = ai.NewTools(registry.NewMemoryRegistry())
+
+	if err := f.Execute(context.Background(), "observe me"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if model.got.RunID == "" {
+		t.Fatal("RunInfo.RunID is empty")
+	}
+	if model.got.Flow != "single-observed" {
+		t.Fatalf("RunInfo.Flow = %q, want single-observed", model.got.Flow)
+	}
+	if model.got.Agent != "" {
+		t.Fatalf("RunInfo.Agent = %q, want empty for flow-owned LLM run", model.got.Agent)
+	}
+	if model.got.Step != "" {
+		t.Fatalf("RunInfo.Step = %q, want empty for single-step flow", model.got.Step)
+	}
+}
+
+type runInfoModel struct {
+	got ai.RunInfo
+}
+
+func (m *runInfoModel) Init(...ai.Option) error { return nil }
+
+func (m *runInfoModel) Options() ai.Options { return ai.Options{} }
+
+func (m *runInfoModel) Generate(ctx context.Context, _ *ai.Request, _ ...ai.GenerateOption) (*ai.Response, error) {
+	m.got, _ = ai.RunInfoFrom(ctx)
+	return &ai.Response{Reply: "ok"}, nil
+}
+
+func (m *runInfoModel) Stream(context.Context, *ai.Request, ...ai.GenerateOption) (ai.Stream, error) {
+	return nil, ai.ErrStreamingUnsupported
+}
+
+func (m *runInfoModel) String() string { return "run-info-model" }


### PR DESCRIPTION
Summary:
- Set single-step flow LLM RunInfo to populate the Flow field instead of Agent, aligning observability correlation with stepped flows.
- Add a regression test covering single-step flow RunInfo fields.

Testing:
- go build ./...
- go test ./flow
- go test ./... (fails in this sandbox due pre-existing cache timing and loopback-target restrictions in grpc tests)
- golangci-lint run ./...

Closes #3167