### PR TITLE
Record A2A agent replies in task history

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -483,12 +483,20 @@ func (d *dispatcher) run(ctx context.Context, params json.RawMessage, invoke Inv
 		Status:    TaskStatus{Timestamp: time.Now().UTC().Format(time.RFC3339)},
 	}
 	if err != nil {
+		reply = "error: " + err.Error()
 		task.Status.State = stateFailed
-		task.Artifacts = []Artifact{textArtifact("error: " + err.Error())}
 	} else {
 		task.Status.State = stateCompleted
-		task.Artifacts = []Artifact{textArtifact(reply)}
 	}
+	task.Artifacts = []Artifact{textArtifact(reply)}
+	task.History = append(task.History, Message{
+		Role:      "agent",
+		Parts:     []Part{{Kind: "text", Text: reply}},
+		MessageID: uuid.New().String(),
+		TaskID:    task.ID,
+		ContextID: task.ContextID,
+		Kind:      "message",
+	})
 	d.store(task)
 	return task, nil
 }

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -104,6 +104,12 @@ func TestMessageSendAndGet(t *testing.T) {
 	if len(task.Artifacts) != 1 || textOf(task.Artifacts[0].Parts) != "pong" {
 		t.Fatalf("artifact = %+v, want text 'pong'", task.Artifacts)
 	}
+	if len(task.History) != 2 || task.History[1].Role != "agent" || textOf(task.History[1].Parts) != "pong" {
+		t.Fatalf("history = %+v, want user turn followed by agent reply", task.History)
+	}
+	if task.History[1].TaskID != task.ID || task.History[1].ContextID != task.ContextID {
+		t.Fatalf("agent history linkage = task %q/%q context %q/%q", task.History[1].TaskID, task.ID, task.History[1].ContextID, task.ContextID)
+	}
 
 	got := rpcTask(t, ts.URL+"/agents/echo", `{
 		"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"id":"`+task.ID+`"}}`)
@@ -145,6 +151,9 @@ func TestMessageSendUsesRequestContext(t *testing.T) {
 	}
 	if len(resp.Result.Artifacts) != 1 || textOf(resp.Result.Artifacts[0].Parts) != "error: context canceled" {
 		t.Fatalf("artifact = %+v, want context cancellation", resp.Result.Artifacts)
+	}
+	if len(resp.Result.History) != 2 || resp.Result.History[1].Role != "agent" || textOf(resp.Result.History[1].Parts) != "error: context canceled" {
+		t.Fatalf("history = %+v, want failed agent reply recorded", resp.Result.History)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Record the agent reply as a message in A2A task history for successful and failed runs.
- Verify persisted task history links the agent reply to the task and context.

Testing:
- go test ./gateway/a2a ./ai
- go build ./...
- go test ./... (fails in this sandbox because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3169