### PR TITLE
Add checkpointed agent run resume

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	pb "go-micro.dev/v6/agent/proto"
 	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/flow"
 	"go-micro.dev/v6/gateway/a2a"
 	"go-micro.dev/v6/server"
 	"go-micro.dev/v6/store"
@@ -171,6 +172,27 @@ func (a *agentImpl) Ask(ctx context.Context, message string) (*Response, error) 
 	return a.ask(ctx, message, a.parentRunID)
 }
 
+// Resume returns the response for a checkpointed agent run. Completed runs are
+// returned from the checkpoint without calling the model or replaying tool
+// calls; failed or in-progress runs continue from the saved input message.
+func Resume(ctx context.Context, ag Agent, runID string) (*Response, error) {
+	a, ok := ag.(*agentImpl)
+	if !ok {
+		return nil, fmt.Errorf("agent resume: unsupported agent implementation %T", ag)
+	}
+	return a.resume(ctx, runID)
+}
+
+// Pending returns checkpointed agent runs that have not completed. It mirrors
+// flow.Pending for startup recovery loops that drain durable agent work.
+func Pending(ctx context.Context, ag Agent) ([]flow.Run, error) {
+	a, ok := ag.(*agentImpl)
+	if !ok {
+		return nil, fmt.Errorf("agent pending: unsupported agent implementation %T", ag)
+	}
+	return a.pending(ctx)
+}
+
 func (a *agentImpl) ask(ctx context.Context, message, parentRunID string) (*Response, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -179,6 +201,10 @@ func (a *agentImpl) ask(ctx context.Context, message, parentRunID string) (*Resp
 		a.setup()
 	}
 
+	return a.askLocked(ctx, uuid.New().String(), message, parentRunID, nil)
+}
+
+func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID string, existing *flow.Run) (*Response, error) {
 	toolList, err := a.discoverTools()
 	if err != nil {
 		return nil, fmt.Errorf("discover tools: %w", err)
@@ -189,12 +215,16 @@ func (a *agentImpl) ask(ctx context.Context, message, parentRunID string) (*Resp
 	a.calls = map[string]int{}
 
 	// Correlate this run's tool calls and surface lineage to wrappers.
-	a.runID = uuid.New().String()
+	a.runID = runID
 	ctx = ai.WithRunInfo(ctx, ai.RunInfo{
 		RunID:    a.runID,
 		ParentID: parentRunID,
 		Agent:    a.opts.Name,
 	})
+	run := a.newCheckpointRun(runID, message, parentRunID, existing)
+	if err := a.saveRun(ctx, run); err != nil {
+		return nil, err
+	}
 	ctx, endRun := a.startRun(ctx, message)
 	defer func() { endRun(err) }()
 
@@ -209,6 +239,10 @@ func (a *agentImpl) ask(ctx context.Context, message, parentRunID string) (*Resp
 		Backoff:     a.opts.ModelRetryBackoff,
 	})
 	if err != nil {
+		run.Status = "failed"
+		run.Steps[0].Status = "failed"
+		run.Steps[0].Error = err.Error()
+		_ = a.saveRun(ctx, run)
 		return nil, err
 	}
 
@@ -227,13 +261,25 @@ func (a *agentImpl) ask(ctx context.Context, message, parentRunID string) (*Resp
 		reply += resp.Answer
 	}
 
-	return &Response{
+	res := &Response{
 		Reply:     reply,
 		ToolCalls: resp.ToolCalls,
 		Agent:     a.opts.Name,
 		RunID:     a.runID,
 		ParentID:  parentRunID,
-	}, nil
+	}
+	run.Status = "done"
+	run.State.Stage = ""
+	if b, marshalErr := json.Marshal(res); marshalErr == nil {
+		run.State.Data = b
+	}
+	run.Steps[0].Status = "done"
+	run.Steps[0].Attempts++
+	run.Steps[0].Result = reply
+	if err := a.saveRun(ctx, run); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // Chat implements the proto AgentHandler interface for RPC.

--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go-micro.dev/v6/flow"
+)
+
+const agentAskStep = "ask"
+
+func (a *agentImpl) newCheckpointRun(runID, message, parentRunID string, existing *flow.Run) flow.Run {
+	now := time.Now()
+	run := flow.Run{
+		ID:       runID,
+		ParentID: parentRunID,
+		Flow:     a.opts.Name,
+		State:    flow.State{Stage: agentAskStep, Data: []byte(message)},
+		Steps:    []flow.StepRecord{{Name: agentAskStep, Status: "in_progress"}},
+		Status:   "running",
+		Started:  now,
+		Updated:  now,
+	}
+	if existing != nil {
+		run = *existing
+		run.Status = "running"
+		run.State.Stage = agentAskStep
+		if len(run.Steps) == 0 {
+			run.Steps = []flow.StepRecord{{Name: agentAskStep}}
+		}
+		run.Steps[0].Status = "in_progress"
+		run.Steps[0].Error = ""
+	}
+	return run
+}
+
+func (a *agentImpl) saveRun(ctx context.Context, run flow.Run) error {
+	if a.opts.Checkpoint == nil {
+		return nil
+	}
+	if err := a.opts.Checkpoint.Save(ctx, run); err != nil {
+		return fmt.Errorf("agent %s checkpoint save: %w", a.opts.Name, err)
+	}
+	return nil
+}
+
+func (a *agentImpl) resume(ctx context.Context, runID string) (*Response, error) {
+	if a.opts.Checkpoint == nil {
+		return nil, fmt.Errorf("agent %s has no checkpoint configured", a.opts.Name)
+	}
+	run, ok, err := a.opts.Checkpoint.Load(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("agent run %s not found", runID)
+	}
+	if run.Status == "done" {
+		var resp Response
+		if err := json.Unmarshal(run.State.Data, &resp); err != nil {
+			return nil, fmt.Errorf("agent run %s response decode: %w", runID, err)
+		}
+		return &resp, nil
+	}
+	message := string(run.State.Data)
+	parentID := run.ParentID
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.model == nil {
+		a.setup()
+	}
+	return a.askLocked(ctx, run.ID, message, parentID, &run)
+}
+
+func (a *agentImpl) pending(ctx context.Context) ([]flow.Run, error) {
+	if a.opts.Checkpoint == nil {
+		return nil, nil
+	}
+	runs, err := a.opts.Checkpoint.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := runs[:0]
+	for _, run := range runs {
+		if run.Flow == a.opts.Name && run.Status != "done" {
+			out = append(out, run)
+		}
+	}
+	return out, nil
+}

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/flow"
+	"go-micro.dev/v6/store"
+)
+
+func TestResumeCompletedCheckpointDoesNotReplayModel(t *testing.T) {
+	ctx := context.Background()
+	cp := flow.StoreCheckpoint(store.NewStore(), "durable-agent")
+	calls := 0
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		calls++
+		return &ai.Response{Reply: "done"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("durable-agent"), WithCheckpoint(cp))
+	resp, err := a.Ask(ctx, "finish the work")
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("model calls after Ask = %d, want 1", calls)
+	}
+
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		calls++
+		t.Fatal("Resume of a completed run replayed the model")
+		return nil, nil
+	}
+	resumed, err := Resume(ctx, a, resp.RunID)
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resumed.Reply != "done" {
+		t.Fatalf("resumed reply = %q, want done", resumed.Reply)
+	}
+	if resumed.RunID != resp.RunID {
+		t.Fatalf("resumed run id = %q, want %q", resumed.RunID, resp.RunID)
+	}
+	if calls != 1 {
+		t.Fatalf("model calls after Resume = %d, want 1", calls)
+	}
+}
+
+func TestPendingReturnsUnfinishedAgentRuns(t *testing.T) {
+	ctx := context.Background()
+	cp := flow.StoreCheckpoint(store.NewStore(), "pending-agent")
+	run := flow.Run{ID: "run-1", Flow: "pending-agent", Status: "failed", State: flow.State{Stage: agentAskStep, Data: []byte("retry me")}}
+	if err := cp.Save(ctx, run); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	a := newTestAgent(Name("pending-agent"), WithCheckpoint(cp))
+	runs, err := Pending(ctx, a)
+	if err != nil {
+		t.Fatalf("Pending: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != "run-1" {
+		t.Fatalf("Pending = %#v, want run-1", runs)
+	}
+}

--- a/agent/options.go
+++ b/agent/options.go
@@ -6,6 +6,7 @@ import (
 
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/client"
+	"go-micro.dev/v6/flow"
 	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/store"
 	"go.opentelemetry.io/otel/trace"
@@ -59,6 +60,9 @@ type Options struct {
 	// Memory is the agent's conversation memory. Nil = the default
 	// store-backed memory (durable across restarts).
 	Memory Memory
+	// Checkpoint persists agent Ask runs so callers can resume by run id
+	// after a restart without replaying a run that already completed.
+	Checkpoint flow.Checkpoint
 
 	// MaxSteps bounds the number of tool executions per Ask (0 =
 	// unbounded). Once exceeded, further tool calls are refused and the
@@ -209,6 +213,15 @@ func WithA2A(addr string) Option {
 // in-process, database, or semantic store.
 func WithMemory(m Memory) Option {
 	return func(o *Options) { o.Memory = m }
+}
+
+// WithCheckpoint sets the durability backend for agent Ask runs. The
+// Checkpoint interface is shared with flow so services, agents, and workflows
+// can use one execution history backend. When set, each Ask is saved as a
+// single-step run keyed by run id; Resume returns a completed run's persisted
+// response instead of calling the model again.
+func WithCheckpoint(c flow.Checkpoint) Option {
+	return func(o *Options) { o.Checkpoint = c }
 }
 
 // WrapTool registers a tool-execution wrapper, the tool-side analog of


### PR DESCRIPTION
## Summary
- Add optional flow.Checkpoint-backed durability for agent Ask runs.
- Add Resume and Pending helpers for checkpointed agent runs so completed runs return their stored response without replaying model/tool work.
- Add regression coverage for completed-run resume and pending-run listing.

Closes #3010
Closes #3179

## Testing
- go build ./...
- go test ./... (environment warning: loopback targets are forbidden for grpc client/transport tests)
- golangci-lint run ./...