### PR TITLE
Update architect priority queue after durable resume

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,18 +21,17 @@ changes, architectural rewrites. Those go to the human.
 
 ## Now (ranked)
 
-1. **Durable agent loop** (#3010) — checkpoint and resume an agent run via
-   `flow.Checkpoint` so long-running agents survive restarts without replaying
-   completed tool calls. Roadmap → *Next*; promoted because the Now hardening
-   items (0→hero and provider matrix) have shipped, and durability is the biggest
-   remaining harness-operability gap.
-2. **Streaming end to end** (#3012) — `ai.Stream` through `micro chat`, the agent
+1. **Streaming end to end** (#3012) — `ai.Stream` through `micro chat`, the agent
    RPC, and A2A `message/stream`; scope to chat + one provider first. Roadmap →
-   *Next*.
-3. **Registry disconnection detection** (#2956) — readiness/health when a service
+   *Next* and now the highest-value lifecycle seam after durable agent resume
+   shipped.
+2. **Registry disconnection detection** (#2956) — readiness/health when a service
    silently loses its registry connection. Community-requested production
    reliability; keeps the service substrate operable because agents depend on
    discovery.
+3. **Agent observability spans** (#3182) — export `RunInfo` as OpenTelemetry spans
+   for agent runs, model calls, tool calls, delegation, and failures. Roadmap →
+   *Next*; makes the now-durable harness inspectable in production.
 4. **Execution lifecycle hooks & metadata** (#2980) — before/after-tool, retry,
    and failure hooks; first check overlap with the shipped run-timeline /
    OpenTelemetry work and scope to what's not already covered.


### PR DESCRIPTION
Summary
- Drop the completed durable agent loop item after #3010 closed via #3180.
- Promote streaming, registry health, and newly filed agent observability issue #3182 in priority order.

Testing
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in grpc tests)
- golangci-lint run ./...

Closes #3181