### PR TITLE
Add OpenAI streaming path

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -43,6 +43,7 @@ type Agent interface {
 	Init(...Option)
 	Options() Options
 	Ask(ctx context.Context, message string) (*Response, error)
+	Stream(ctx context.Context, message string) (ai.Stream, error)
 	Run() error
 	Stop() error
 	String() string
@@ -170,6 +171,28 @@ func (a *agentImpl) stateStore() store.Store {
 // This is the programmatic API for direct use.
 func (a *agentImpl) Ask(ctx context.Context, message string) (*Response, error) {
 	return a.ask(ctx, message, a.parentRunID)
+}
+
+// Stream sends a message and returns a streaming model response. Tool-calling
+// agent runs still use Ask; Stream is for chat turns where immediate token
+// delivery is more important than tool orchestration.
+func (a *agentImpl) Stream(ctx context.Context, message string) (ai.Stream, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.model == nil {
+		a.setup()
+	}
+	toolList, err := a.discoverTools()
+	if err != nil {
+		return nil, fmt.Errorf("discover tools: %w", err)
+	}
+	a.mem.Add("user", message)
+	return a.model.Stream(ctx, &ai.Request{
+		Prompt:       message,
+		SystemPrompt: a.buildPrompt(),
+		Tools:        toolList,
+		Messages:     a.mem.Messages(),
+	})
 }
 
 // Resume returns the response for a checkpointed agent run. Completed runs are
@@ -333,13 +356,13 @@ func (a *agentImpl) Run() error {
 	// Ask in-process — no separate gateway needed to be queried by URL.
 	if a.opts.A2AAddress != "" {
 		card := a2a.Card(a.opts.Name, "http://localhost"+a.opts.A2AAddress, "", a.opts.Services)
-		handler := a2a.NewAgentHandler(card, func(ctx context.Context, text string) (string, error) {
+		handler := a2a.NewAgentStreamHandler(card, func(ctx context.Context, text string) (string, error) {
 			resp, err := a.Ask(ctx, text)
 			if err != nil {
 				return "", err
 			}
 			return resp.Reply, nil
-		})
+		}, a.Stream)
 		go func() {
 			if err := http.ListenAndServe(a.opts.A2AAddress, handler); err != nil {
 				fmt.Printf("agent %s A2A server: %v\n", a.opts.Name, err)

--- a/ai/capabilities_test.go
+++ b/ai/capabilities_test.go
@@ -34,7 +34,7 @@ func TestRegisteredProviders(t *testing.T) {
 	}
 
 	got = ai.RegisteredProviders("stream")
-	want = []string{}
+	want = []string{"openai"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RegisteredProviders(stream) = %#v, want %#v", got, want)
 	}
@@ -48,7 +48,7 @@ func TestCapabilityRows(t *testing.T) {
 		{Provider: "gemini", Capabilities: ai.Capabilities{Model: true}},
 		{Provider: "groq", Capabilities: ai.Capabilities{Model: true}},
 		{Provider: "mistral", Capabilities: ai.Capabilities{Model: true}},
-		{Provider: "openai", Capabilities: ai.Capabilities{Model: true, Image: true}},
+		{Provider: "openai", Capabilities: ai.Capabilities{Model: true, Image: true, Stream: true}},
 		{Provider: "together", Capabilities: ai.Capabilities{Model: true}},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -69,7 +69,7 @@ func TestCapabilityMatrix(t *testing.T) {
 		}
 	}
 
-	if caps := ai.ProviderCapabilities("openai"); caps != (ai.Capabilities{Model: true, Image: true}) {
+	if caps := ai.ProviderCapabilities("openai"); caps != (ai.Capabilities{Model: true, Image: true, Stream: true}) {
 		t.Fatalf("ProviderCapabilities(openai) = %#v", caps)
 	}
 	if caps := ai.ProviderCapabilities("atlascloud"); caps != (ai.Capabilities{Model: true, Image: true, Video: true}) {
@@ -88,7 +88,7 @@ func TestRegisterStream(t *testing.T) {
 	}
 
 	got := ai.RegisteredProviders("stream")
-	want := []string{"test-stream"}
+	want := []string{"openai", "test-stream"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RegisteredProviders(stream) = %#v, want %#v", got, want)
 	}

--- a/ai/openai/openai.go
+++ b/ai/openai/openai.go
@@ -2,6 +2,7 @@
 package openai
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -20,6 +21,7 @@ func init() {
 	ai.RegisterImage("openai", func(opts ...ai.Option) ai.ImageModel {
 		return NewProvider(opts...)
 	})
+	ai.RegisterStream("openai")
 }
 
 // Provider implements the ai.Model interface for OpenAI
@@ -140,9 +142,88 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 	return resp, nil
 }
 
-// Stream generates a streaming response (not yet implemented)
+// Stream generates a streaming response from the OpenAI chat completions API.
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
-	return nil, fmt.Errorf("%w: openai provider", ai.ErrStreamingUnsupported)
+	messages := []map[string]any{
+		{"role": "system", "content": req.SystemPrompt},
+		{"role": "user", "content": req.Prompt},
+	}
+	apiReq := map[string]any{
+		"model":    p.opts.Model,
+		"messages": messages,
+		"stream":   true,
+	}
+	reqBody, err := json.Marshal(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal stream request: %w", err)
+	}
+	apiURL := strings.TrimRight(p.opts.BaseURL, "/") + "/v1/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stream request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	httpReq.Header.Set("Authorization", "Bearer "+p.opts.APIKey)
+
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("stream API request failed: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		defer httpResp.Body.Close()
+		respBody, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("stream API error (%s): %s", httpResp.Status, string(respBody))
+	}
+	return &openAIStream{body: httpResp.Body, scanner: bufio.NewScanner(httpResp.Body)}, nil
+}
+
+type openAIStream struct {
+	body    io.ReadCloser
+	scanner *bufio.Scanner
+	closed  bool
+}
+
+func (s *openAIStream) Recv() (*ai.Response, error) {
+	for s.scanner.Scan() {
+		line := strings.TrimSpace(s.scanner.Text())
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue
+		}
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "[DONE]" {
+			return nil, io.EOF
+		}
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content string `json:"content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			return nil, fmt.Errorf("failed to parse stream chunk: %w", err)
+		}
+		if len(chunk.Choices) == 0 || chunk.Choices[0].Delta.Content == "" {
+			continue
+		}
+		return &ai.Response{Reply: chunk.Choices[0].Delta.Content}, nil
+	}
+	if err := s.scanner.Err(); err != nil {
+		return nil, err
+	}
+	return nil, io.EOF
+}
+
+func (s *openAIStream) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.body.Close()
 }
 
 // callAPI makes an HTTP request to the OpenAI API

--- a/ai/openai/openai_test.go
+++ b/ai/openai/openai_test.go
@@ -2,7 +2,11 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"go-micro.dev/v6/ai"
@@ -81,16 +85,44 @@ func TestProvider_Generate_NoAPIKey(t *testing.T) {
 	}
 }
 
-func TestProvider_Stream_NotImplemented(t *testing.T) {
-	p := NewProvider()
+func TestProvider_Stream(t *testing.T) {
+	var sawStream bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path = %s, want /v1/chat/completions", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		sawStream, _ = body["stream"].(bool)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hel\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
 
-	req := &ai.Request{
-		Prompt: "Hello",
+	p := NewProvider(ai.WithAPIKey("test-key"), ai.WithBaseURL(ts.URL))
+	stream, err := p.Stream(context.Background(), &ai.Request{Prompt: "Hello"})
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+	defer stream.Close()
+	if !sawStream {
+		t.Fatal("stream request did not set stream=true")
 	}
 
-	_, err := p.Stream(context.Background(), req)
-	if !errors.Is(err, ai.ErrStreamingUnsupported) {
-		t.Fatalf("Stream error = %v, want ErrStreamingUnsupported", err)
+	first, err := stream.Recv()
+	if err != nil || first.Reply != "hel" {
+		t.Fatalf("first chunk = %#v, %v; want hel", first, err)
+	}
+	second, err := stream.Recv()
+	if err != nil || second.Reply != "lo" {
+		t.Fatalf("second chunk = %#v, %v; want lo", second, err)
+	}
+	if _, err := stream.Recv(); !errors.Is(err, io.EOF) {
+		t.Fatalf("final error = %v, want EOF", err)
 	}
 }
 

--- a/cmd/micro/chat/chat.go
+++ b/cmd/micro/chat/chat.go
@@ -10,7 +10,9 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -79,6 +81,7 @@ Examples:
 			&cli.StringFlag{Name: "model", Usage: "Model name (uses provider default if unset)", EnvVars: []string{"MICRO_AI_MODEL"}},
 			&cli.StringFlag{Name: "base_url", Usage: "Override the provider's base URL", EnvVars: []string{"MICRO_AI_BASE_URL"}},
 			&cli.StringFlag{Name: "prompt", Usage: "Send a single prompt and exit (non-interactive)"},
+			&cli.BoolFlag{Name: "stream", Usage: "Stream model output as it is generated when the provider supports it"},
 		},
 		Action: run,
 	})
@@ -102,6 +105,7 @@ type session struct {
 	sysPrompt string
 	procs     []*exec.Cmd
 	agents    map[string]agentInfo
+	stream    bool
 
 	// Built-in agent capabilities (plan, delegate), shared with the
 	// agent package so the direct-service fallback has the same tools a
@@ -311,6 +315,7 @@ func run(c *cli.Context) error {
 	modelName := c.String("model")
 	baseURL := c.String("base_url")
 	singlePrompt := c.String("prompt")
+	streamOutput := c.Bool("stream")
 
 	if provider == "" {
 		provider = ai.AutoDetectProvider(baseURL)
@@ -347,6 +352,7 @@ func run(c *cli.Context) error {
 		hist:          ai.NewHistory(50),
 		builtinTools:  builtinTools,
 		builtinHandle: builtinHandle,
+		stream:        streamOutput,
 	}
 	s.refreshTools()
 
@@ -449,12 +455,21 @@ func (s *session) ask(ctx context.Context, prompt string) error {
 	// Fallback: direct service access (no agents)
 	s.hist.Add("user", prompt)
 
-	resp, err := s.model.Generate(ctx, &ai.Request{
+	req := &ai.Request{
 		Prompt:       prompt,
 		SystemPrompt: s.sysPrompt,
 		Tools:        s.toolList,
 		Messages:     s.hist.Messages(),
-	})
+	}
+	if s.stream {
+		if err := s.askStream(ctx, req); err == nil {
+			return nil
+		} else if !errors.Is(err, ai.ErrStreamingUnsupported) {
+			return err
+		}
+	}
+
+	resp, err := s.model.Generate(ctx, req)
 	if err != nil {
 		return err
 	}
@@ -485,6 +500,34 @@ func (s *session) ask(ctx context.Context, prompt string) error {
 	if resp.Answer != "" {
 		fmt.Println()
 		fmt.Println(resp.Answer)
+	}
+	return nil
+}
+
+func (s *session) askStream(ctx context.Context, req *ai.Request) error {
+	stream, err := s.model.Stream(ctx, req)
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+	var reply strings.Builder
+	for {
+		chunk, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if chunk == nil || chunk.Reply == "" {
+			continue
+		}
+		fmt.Print(chunk.Reply)
+		reply.WriteString(chunk.Reply)
+	}
+	if reply.Len() > 0 {
+		fmt.Println()
+		s.hist.Add("assistant", reply.String())
 	}
 	return nil
 }

--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -36,6 +37,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/client"
 	codecbytes "go-micro.dev/v6/codec/bytes"
 	"go-micro.dev/v6/registry"
@@ -92,6 +94,9 @@ func New(opts Options) *Gateway {
 // to Agent.Chat (the gateway) or an in-process Ask (an embedded agent).
 type Invoke func(ctx context.Context, text string) (string, error)
 
+// StreamInvoke runs an agent for one message and returns streaming output chunks.
+type StreamInvoke func(ctx context.Context, text string) (ai.Stream, error)
+
 // NewAgentHandler returns an http.Handler that serves the A2A protocol
 // for a single agent: its Agent Card at / and /.well-known/agent.json,
 // and the JSON-RPC endpoint at /. invoke runs the agent. This is what an
@@ -104,6 +109,19 @@ func NewAgentHandler(card AgentCard, invoke Invoke) http.Handler {
 	mux.HandleFunc("GET /{$}", serveCard)
 	mux.HandleFunc("GET /.well-known/agent.json", serveCard)
 	mux.HandleFunc("POST /{$}", func(w http.ResponseWriter, r *http.Request) { d.serve(w, r, invoke) })
+	return mux
+}
+
+// NewAgentStreamHandler is like NewAgentHandler, but serves A2A message/stream
+// by forwarding model chunks as server-sent task updates when stream is non-nil.
+func NewAgentStreamHandler(card AgentCard, invoke Invoke, stream StreamInvoke) http.Handler {
+	d := newDispatcher()
+	mux := http.NewServeMux()
+	card.URL = strings.TrimRight(card.URL, "/")
+	serveCard := func(w http.ResponseWriter, _ *http.Request) { writeJSON(w, http.StatusOK, card) }
+	mux.HandleFunc("GET /{$}", serveCard)
+	mux.HandleFunc("GET /.well-known/agent.json", serveCard)
+	mux.HandleFunc("POST /{$}", func(w http.ResponseWriter, r *http.Request) { d.serveWithStream(w, r, invoke, stream) })
 	return mux
 }
 
@@ -404,6 +422,10 @@ type dispatcher struct {
 func newDispatcher() *dispatcher { return &dispatcher{tasks: map[string]*Task{}} }
 
 func (d *dispatcher) serve(w http.ResponseWriter, r *http.Request, invoke Invoke) {
+	d.serveWithStream(w, r, invoke, nil)
+}
+
+func (d *dispatcher) serveWithStream(w http.ResponseWriter, r *http.Request, invoke Invoke, streamInvoke StreamInvoke) {
 	var req rpcRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeRPC(w, nil, nil, &rpcError{Code: errParse, Message: "parse error"})
@@ -418,6 +440,10 @@ func (d *dispatcher) serve(w http.ResponseWriter, r *http.Request, invoke Invoke
 	case "message/send":
 		d.send(requestContext(r.Context()), w, req, invoke)
 	case "message/stream":
+		if streamInvoke != nil {
+			d.streamChunks(requestContext(r.Context()), w, req, streamInvoke)
+			return
+		}
 		d.stream(requestContext(r.Context()), w, req, invoke)
 	case "tasks/get":
 		d.get(w, req)
@@ -460,6 +486,50 @@ func (d *dispatcher) stream(ctx context.Context, w http.ResponseWriter, req rpcR
 	}
 }
 
+func (d *dispatcher) streamChunks(ctx context.Context, w http.ResponseWriter, req rpcRequest, invoke StreamInvoke) {
+	var p sendParams
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		writeRPC(w, req.ID, nil, &rpcError{Code: errInvalidParams, Message: "invalid params"})
+		return
+	}
+	text := textOf(p.Message.Parts)
+	if text == "" {
+		writeRPC(w, req.ID, nil, &rpcError{Code: errInvalidParams, Message: "message has no text part"})
+		return
+	}
+	stream, err := invoke(ctx, text)
+	if err != nil {
+		writeRPC(w, req.ID, nil, &rpcError{Code: errInternal, Message: err.Error()})
+		return
+	}
+	defer stream.Close()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	enc := json.NewEncoder(sseWriter{w: w})
+	var reply strings.Builder
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: errInternal, Message: err.Error()}})
+			return
+		}
+		if chunk == nil || chunk.Reply == "" {
+			continue
+		}
+		reply.WriteString(chunk.Reply)
+		task := taskFromReply(p.Message, reply.String(), stateCompleted)
+		_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: task})
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+}
+
 func (d *dispatcher) run(ctx context.Context, params json.RawMessage, invoke Invoke) (*Task, *rpcError) {
 	var p sendParams
 	if err := json.Unmarshal(params, &p); err != nil {
@@ -471,32 +541,12 @@ func (d *dispatcher) run(ctx context.Context, params json.RawMessage, invoke Inv
 	}
 
 	reply, err := invoke(ctx, text)
-	contextID := p.Message.ContextID
-	if contextID == "" {
-		contextID = uuid.New().String()
-	}
-	task := &Task{
-		ID:        uuid.New().String(),
-		ContextID: contextID,
-		Kind:      "task",
-		History:   []Message{p.Message},
-		Status:    TaskStatus{Timestamp: time.Now().UTC().Format(time.RFC3339)},
-	}
+	state := stateCompleted
 	if err != nil {
 		reply = "error: " + err.Error()
-		task.Status.State = stateFailed
-	} else {
-		task.Status.State = stateCompleted
+		state = stateFailed
 	}
-	task.Artifacts = []Artifact{textArtifact(reply)}
-	task.History = append(task.History, Message{
-		Role:      "agent",
-		Parts:     []Part{{Kind: "text", Text: reply}},
-		MessageID: uuid.New().String(),
-		TaskID:    task.ID,
-		ContextID: task.ContextID,
-		Kind:      "message",
-	})
+	task := taskFromReply(p.Message, reply, state)
 	d.store(task)
 	return task, nil
 }
@@ -557,6 +607,30 @@ func (d *dispatcher) store(t *Task) {
 		d.order = d.order[1:]
 		delete(d.tasks, oldest)
 	}
+}
+
+func taskFromReply(input Message, reply, state string) *Task {
+	contextID := input.ContextID
+	if contextID == "" {
+		contextID = uuid.New().String()
+	}
+	task := &Task{
+		ID:        uuid.New().String(),
+		ContextID: contextID,
+		Kind:      "task",
+		History:   []Message{input},
+		Status:    TaskStatus{State: state, Timestamp: time.Now().UTC().Format(time.RFC3339)},
+		Artifacts: []Artifact{textArtifact(reply)},
+	}
+	task.History = append(task.History, Message{
+		Role:      "agent",
+		Parts:     []Part{{Kind: "text", Text: reply}},
+		MessageID: uuid.New().String(),
+		TaskID:    task.ID,
+		ContextID: task.ContextID,
+		Kind:      "message",
+	})
+	return task
 }
 
 func textOf(parts []Part) string {

--- a/internal/website/docs/guides/ai-provider-guide.md
+++ b/internal/website/docs/guides/ai-provider-guide.md
@@ -43,7 +43,7 @@ The built-in providers currently register these capability interfaces:
 | `gemini` | Yes | No | No | No |
 | `groq` | Yes | No | No | No |
 | `mistral` | Yes | No | No | No |
-| `openai` | Yes | Yes | No | No |
+| `openai` | Yes | Yes | No | Yes |
 | `together` | Yes | No | No | No |
 
 ## Step 1: Implement the `ai.Model` Interface


### PR DESCRIPTION
## Summary
- Implement OpenAI chat-completions streaming and register the provider streaming capability.
- Add a micro chat --stream option for direct token output when the provider supports streaming.
- Expose agent/A2A streaming hooks for embedded agents so message/stream can emit chunk updates.
- Update capability tests and provider guide.

Closes #3012
Closes #3184

## Testing
- go build ./...
- go test ./... (fails in this sandbox because loopback gRPC/mdns/store timing tests are environment-sensitive; targeted tests pass)
- go test ./gateway/a2a ./agent ./cmd/micro/chat ./ai ./ai/openai ./internal/website/docs/guides
- golangci-lint run ./...