### PR TITLE
Document agent OpenTelemetry spans

### DIFF
--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,7 +30,11 @@ func (m *otelTestModel) Stream(context.Context, *ai.Request, ...ai.GenerateOptio
 }
 func (m *otelTestModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (*ai.Response, error) {
 	if m.opts.ToolHandler != nil {
-		_ = m.opts.ToolHandler(ctx, ai.ToolCall{ID: "call-1", Name: "probe", Input: map[string]any{"ok": true}})
+		if strings.Contains(req.Prompt, "delegate") {
+			_ = m.opts.ToolHandler(ctx, ai.ToolCall{ID: "call-delegate", Name: toolDelegate, Input: map[string]any{"task": "subtask"}})
+		} else if !strings.Contains(req.Prompt, "subtask") {
+			_ = m.opts.ToolHandler(ctx, ai.ToolCall{ID: "call-1", Name: "probe", Input: map[string]any{"ok": true}})
+		}
 	}
 	return &ai.Response{Reply: "done", Usage: ai.Usage{InputTokens: 2, OutputTokens: 3, TotalTokens: 5}}, nil
 }
@@ -112,9 +118,60 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 func spanAttributes(attrs []attribute.KeyValue) map[string]string {
 	out := make(map[string]string, len(attrs))
 	for _, attr := range attrs {
-		out[string(attr.Key)] = attr.Value.AsString()
+		out[string(attr.Key)] = fmt.Sprint(attr.Value.AsInterface())
 	}
 	return out
+}
+
+func TestAgentOpenTelemetrySpansDelegateLineage(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exp))
+	st := store.NewMemoryStore()
+	a := New(Name("conductor"), Provider("oteltest"), WithStore(st), TraceProvider(tp))
+	if _, err := a.Ask(context.Background(), "delegate please"); err != nil {
+		t.Fatal(err)
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	var parentRunID string
+	var delegateSpanID string
+	var subRunSeen bool
+	for _, s := range spans {
+		attrs := spanAttributes(s.Attributes())
+		if s.Name() == spanNameRun && attrs[AttrAgentName] == "conductor" {
+			parentRunID = attrs[AttrRunID]
+		}
+	}
+	if parentRunID == "" {
+		t.Fatal("parent run span missing run id")
+	}
+	for _, s := range spans {
+		attrs := spanAttributes(s.Attributes())
+		if s.Name() == spanNameToolCall && attrs[AttrToolName] == toolDelegate {
+			if attrs[AttrDelegate] != "true" || attrs[AttrRunID] != parentRunID {
+				t.Fatalf("delegate span missing correlation attributes: %#v", attrs)
+			}
+			delegateSpanID = s.SpanContext().SpanID().String()
+		}
+	}
+	if delegateSpanID == "" {
+		t.Fatal("delegate tool span not emitted")
+	}
+	for _, s := range spans {
+		attrs := spanAttributes(s.Attributes())
+		if s.Name() == spanNameRun && attrs[AttrAgentName] == "conductor.sub" {
+			if attrs[AttrParentRunID] != parentRunID {
+				t.Fatalf("sub-agent run parent attr = %q, want %q", attrs[AttrParentRunID], parentRunID)
+			}
+			if s.Parent().SpanID().String() != delegateSpanID {
+				t.Fatalf("sub-agent run parent span = %s, want delegate span %s", s.Parent().SpanID(), delegateSpanID)
+			}
+			subRunSeen = true
+		}
+	}
+	if !subRunSeen {
+		t.Fatalf("sub-agent run span not emitted; got %d spans", len(spans))
+	}
 }
 
 func TestAgentRunTimelineRecordsModelAndToolWithoutTraceProvider(t *testing.T) {

--- a/internal/website/docs/guides/agent-harness.md
+++ b/internal/website/docs/guides/agent-harness.md
@@ -37,11 +37,43 @@ your stack — the harness *is* the stack.
 | Interop | MCP (tools), A2A (agents), x402 (paid tools) | Shipped |
 | Resilience | Per-call timeout with context propagation; opt-in retry/backoff (`ModelRetry`) across the loop | Shipped |
 | Durable runs | Checkpoint and resume an agent run (flows already do) | In progress |
-| Observability | `RunInfo` → OpenTelemetry spans; run history on the CLI | In progress |
+| Observability | `RunInfo` → OpenTelemetry spans for runs, model calls, tools, delegation, and failures; persisted run history | Shipped |
 | Streaming | `ai.Stream` through chat, agent, and A2A | In progress |
 
 The "in progress" rows are exactly the roadmap's [Now and Next](/docs/roadmap.html),
 and the work is happening in the open.
+
+## Observing agent runs
+
+Pass an OpenTelemetry tracer provider when you construct an agent to turn the
+agent's `RunInfo` into spans:
+
+```go
+agent := micro.NewAgent("conductor",
+    micro.AgentProvider("anthropic"),
+    micro.AgentTraceProvider(otel.GetTracerProvider()),
+)
+```
+
+A traced `Ask` emits a parent `agent.run` span plus child spans for
+`agent.model.call` and `agent.tool.call`. Delegate tool calls are marked with
+`agent.delegate=true`; ephemeral sub-agents start their own `agent.run` span with
+`agent.run.parent_id` set to the delegating run, so a trace shows the hand-off
+from service-like agent to sub-agent. Failure and refusal outcomes set error
+status on the relevant span and are also recorded in the persisted run timeline.
+
+Important span attributes include:
+
+| Attribute | Meaning |
+|---|---|
+| `agent.run.id` | Stable run correlation ID surfaced as `ai.RunInfo.RunID` |
+| `agent.run.parent_id` | Parent run for delegated sub-agent work |
+| `agent.name` | Agent that owns the run or call |
+| `agent.model.provider` / `agent.model.name` | Provider and configured model for model calls |
+| `agent.tool.name` | Tool invoked by the model |
+| `agent.delegate` | Whether the tool call is a delegation boundary |
+| `agent.latency_ms` | Elapsed time for the run/call |
+| `agent.tokens.*` | Token usage when the provider reports it |
 
 ## Why services are the right substrate
 

--- a/micro.go
+++ b/micro.go
@@ -142,6 +142,10 @@ func AgentWrapTool(w ...ai.ToolWrapper) AgentOption {
 	return agent.WrapTool(w...)
 }
 
+// AgentTraceProvider enables OpenTelemetry spans for agent runs, model calls,
+// tool calls, delegation, and failures.
+func AgentTraceProvider(tp trace.TracerProvider) AgentOption { return agent.TraceProvider(tp) }
+
 // NewFlow creates an event-driven LLM orchestration unit.
 //
 //	f := micro.NewFlow("onboard-user",


### PR DESCRIPTION
## Summary
- Add a top-level micro.AgentTraceProvider helper for enabling agent OpenTelemetry spans alongside the existing flow helper.
- Extend agent OpenTelemetry tests to verify delegate spans correlate to the parent run and that delegated sub-agent run spans are parented under the delegate call.
- Document how to enable agent tracing and inspect key run/model/tool/delegate attributes.

Closes #3182
Closes #3197

## Testing
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by the sandbox envoy: client/grpc and transport/grpc)
- golangci-lint run ./...