### PR TITLE
Improve A2A streaming task lifecycle

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -229,6 +229,7 @@ type Task struct {
 const (
 	stateCompleted = "completed"
 	stateFailed    = "failed"
+	stateWorking   = "working"
 )
 
 // JSON-RPC envelopes.
@@ -508,25 +509,40 @@ func (d *dispatcher) streamChunks(ctx context.Context, w http.ResponseWriter, re
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
 	enc := json.NewEncoder(sseWriter{w: w})
+	flush := func() {
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+	taskID := uuid.New().String()
+	contextID := p.Message.ContextID
+	if contextID == "" {
+		contextID = uuid.New().String()
+	}
 	var reply strings.Builder
 	for {
 		chunk, err := stream.Recv()
 		if err == io.EOF {
-			break
+			task := taskFromReplyWithIDs(p.Message, reply.String(), stateCompleted, taskID, contextID)
+			d.store(task)
+			_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: task})
+			flush()
+			return
 		}
 		if err != nil {
-			_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: errInternal, Message: err.Error()}})
+			task := taskFromReplyWithIDs(p.Message, "error: "+err.Error(), stateFailed, taskID, contextID)
+			d.store(task)
+			_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: task, Error: &rpcError{Code: errInternal, Message: err.Error()}})
+			flush()
 			return
 		}
 		if chunk == nil || chunk.Reply == "" {
 			continue
 		}
 		reply.WriteString(chunk.Reply)
-		task := taskFromReply(p.Message, reply.String(), stateCompleted)
+		task := taskFromReplyWithIDs(p.Message, reply.String(), stateWorking, taskID, contextID)
 		_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: task})
-		if f, ok := w.(http.Flusher); ok {
-			f.Flush()
-		}
+		flush()
 	}
 }
 
@@ -614,8 +630,12 @@ func taskFromReply(input Message, reply, state string) *Task {
 	if contextID == "" {
 		contextID = uuid.New().String()
 	}
+	return taskFromReplyWithIDs(input, reply, state, uuid.New().String(), contextID)
+}
+
+func taskFromReplyWithIDs(input Message, reply, state, taskID, contextID string) *Task {
 	task := &Task{
-		ID:        uuid.New().String(),
+		ID:        taskID,
 		ContextID: contextID,
 		Kind:      "task",
 		History:   []Message{input},

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	pb "go-micro.dev/v6/agent/proto"
+	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/client"
 	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/selector"
@@ -191,6 +193,106 @@ func TestMessageStream(t *testing.T) {
 	if out.Result.Status.State != stateCompleted || len(out.Result.Artifacts) != 1 || textOf(out.Result.Artifacts[0].Parts) != "pong" {
 		t.Fatalf("streamed task = %+v", out.Result)
 	}
+}
+
+type sliceStream struct {
+	chunks []string
+	err    error
+}
+
+func (s *sliceStream) Recv() (*ai.Response, error) {
+	if len(s.chunks) == 0 {
+		if s.err != nil {
+			err := s.err
+			s.err = nil
+			return nil, err
+		}
+		return nil, io.EOF
+	}
+	next := s.chunks[0]
+	s.chunks = s.chunks[1:]
+	return &ai.Response{Reply: next}, nil
+}
+
+func (s *sliceStream) Close() error { return nil }
+
+func TestMessageStreamChunksStoreFinalTask(t *testing.T) {
+	d := newDispatcher()
+	body := `{"jsonrpc":"2.0","id":1,"method":"message/stream","params":{"message":{"role":"user","parts":[{"kind":"text","text":"ping"}],"kind":"message"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+
+	d.serveWithStream(rr, req, nil, func(ctx context.Context, text string) (ai.Stream, error) {
+		if text != "ping" {
+			t.Fatalf("stream text = %q, want ping", text)
+		}
+		return &sliceStream{chunks: []string{"po", "ng"}}, nil
+	})
+
+	if ct := rr.Result().Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("content-type = %q, want text/event-stream", ct)
+	}
+	var events []struct {
+		Result Task      `json:"result"`
+		Error  *rpcError `json:"error"`
+	}
+	for _, line := range strings.Split(strings.TrimSpace(rr.Body.String()), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		line = strings.TrimPrefix(line, "data: ")
+		var event struct {
+			Result Task      `json:"result"`
+			Error  *rpcError `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("decode event %q: %v", line, err)
+		}
+		events = append(events, event)
+	}
+	if len(events) != 3 {
+		t.Fatalf("events = %d, want 3; body %s", len(events), rr.Body.String())
+	}
+	for i, event := range events {
+		if event.Error != nil {
+			t.Fatalf("event %d error: %+v", i, event.Error)
+		}
+		if event.Result.ID != events[0].Result.ID || event.Result.ContextID != events[0].Result.ContextID {
+			t.Fatalf("event %d changed task identity: %+v vs %+v", i, event.Result, events[0].Result)
+		}
+	}
+	if events[0].Result.Status.State != stateWorking || textOf(events[0].Result.Artifacts[0].Parts) != "po" {
+		t.Fatalf("first event = %+v, want working po", events[0].Result)
+	}
+	final := events[len(events)-1].Result
+	if final.Status.State != stateCompleted || textOf(final.Artifacts[0].Parts) != "pong" {
+		t.Fatalf("final event = %+v, want completed pong", final)
+	}
+
+	got := rpcTaskFromDispatcher(t, d, final.ID)
+	if got.ID != final.ID || got.Status.State != stateCompleted || textOf(got.Artifacts[0].Parts) != "pong" {
+		t.Fatalf("stored task = %+v, want final", got)
+	}
+}
+
+func rpcTaskFromDispatcher(t *testing.T, d *dispatcher, id string) Task {
+	t.Helper()
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"id":"%s"}}`, id)
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	d.serve(rr, req, nil)
+	var resp struct {
+		Result Task      `json:"result"`
+		Error  *rpcError `json:"error"`
+	}
+	if err := json.NewDecoder(rr.Result().Body).Decode(&resp); err != nil {
+		t.Fatalf("decode tasks/get: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("tasks/get error: %+v", resp.Error)
+	}
+	return resp.Result
 }
 
 func TestUnknownMethod(t *testing.T) {


### PR DESCRIPTION
Summary:
- Keep A2A message/stream chunks tied to one task/context identity.
- Emit working updates while streaming and store the final completed or failed task for tasks/get.
- Add coverage for chunked SSE streaming and final task retrieval.

Testing:
- go build ./...
- go test ./gateway/a2a
- go test ./... (fails in this environment: grpc loopback targets forbidden in client/grpc and transport/grpc)
- golangci-lint run ./...

Closes #3200
Closes #3202