### PR TITLE
Update architect priorities after streaming

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,20 +21,13 @@ changes, architectural rewrites. Those go to the human.
 
 ## Now (ranked)
 
-1. **End-to-end agent streaming** (#3200) — complete the roadmap streaming slice:
-   usable `ai.Stream` beyond the current OpenAI path, A2A `message/stream` chunk
-   delivery, cancellation/error semantics, and docs so chat and long-task UX are
-   real across the harness boundary. Roadmap → *Next* streaming, but it now ranks
-   first because durable resume, provider conformance, registry readiness, 0→hero,
-   and agent OpenTelemetry have shipped; streaming is the largest remaining seam
-   in the services → agents → workflows interaction loop.
-2. **Execution lifecycle hooks & metadata** (#2980) — before/after-tool, retry,
+1. **Execution lifecycle hooks & metadata** (#2980) — before/after-tool, retry,
    and failure hooks; first reconcile the issue with the shipped `AgentWrapTool`,
-   structured refusal reasons, `RunInfo`, and OpenTelemetry spans, then close it or
-   scope only a CI-verifiable gap that wrappers plus tracing cannot express.
-   Roadmap → resilience/operability, but ranked after streaming because most of
-   the originally requested lifecycle metadata now exists and the remaining value
-   is validation/scoping rather than a missing harness primitive.
+   structured refusal reasons, `RunInfo`, OpenTelemetry spans, durable resume, and
+   A2A streaming task lifecycle, then close it or scope only a CI-verifiable gap
+   that those primitives cannot express. Roadmap → resilience/operability; now
+   ranked first because streaming shipped and this is the remaining open Now-phase
+   reliability seam for long-running agents and workflows.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:
- Removed completed streaming item #3200 from the architect priority queue.
- Promoted #2980 as the remaining Now-phase reliability seam after recent durable resume, observability, and A2A streaming lifecycle work.

Assessment:
- Shipped: #3203 closed #3200, adding the A2A streaming task lifecycle work that removes the highest-ranked queue item.
- In flight: no open codex PRs were found; #2980 is the only open codex-labeled issue in the queue scan.
- Top gap: reliability/lifecycle policy remains the next validation point, but it should be reconciled against existing wrappers, RunInfo, OpenTelemetry, durable resume, and A2A streaming before adding new API surface.

Testing:
- go build ./...
- go test ./... (failed/timeboxed in this environment due loopback target restriction in go-micro.dev/v6/client/grpc and 120s timeout)
- golangci-lint run ./...

Closes #3204