### PR TITLE
Expose model retry attempt metadata

### DIFF
--- a/ai/model.go
+++ b/ai/model.go
@@ -116,14 +116,18 @@ const (
 // the agent package. Flows also attach their name and current step so
 // tools and agents called from a workflow can be tied back to the
 // services → agents → workflows lifecycle that invoked them. Per-call
-// detail (tool name, id) is on the ToolCall; attempt counts are naturally
-// counted by the wrapper itself.
+// detail (tool name, id) is on the ToolCall. Attempt and MaxAttempts are
+// set while a model Generate call is in progress, so tools and wrappers can
+// tell which provider attempt produced the call and whether it is part of a
+// retry budget. They are zero when no model-attempt context is known.
 type RunInfo struct {
-	RunID    string // correlation id for this agent or flow run
-	ParentID string // the run that delegated to this one, if any
-	Agent    string // the agent's name
-	Flow     string // the flow's name, when the call is part of a workflow
-	Step     string // the flow step currently executing, when known
+	RunID       string // correlation id for this agent or flow run
+	ParentID    string // the run that delegated to this one, if any
+	Agent       string // the agent's name
+	Flow        string // the flow's name, when the call is part of a workflow
+	Step        string // the flow step currently executing, when known
+	Attempt     int    // current model Generate attempt, starting at 1 when known
+	MaxAttempts int    // configured model Generate attempt budget when known
 }
 
 type runInfoKey struct{}

--- a/ai/retry.go
+++ b/ai/retry.go
@@ -60,6 +60,11 @@ func GenerateWithRetry(ctx context.Context, m Model, req *Request, policy Genera
 		if policy.Timeout > 0 {
 			callCtx, cancel = context.WithTimeout(ctx, policy.Timeout)
 		}
+		if info, ok := RunInfoFrom(callCtx); ok {
+			info.Attempt = attempt
+			info.MaxAttempts = policy.MaxAttempts
+			callCtx = WithRunInfo(callCtx, info)
+		}
 		resp, err := m.Generate(callCtx, req, opts...)
 		cancel()
 		if err == nil {

--- a/ai/retry_test.go
+++ b/ai/retry_test.go
@@ -94,3 +94,42 @@ func TestGenerateWithRetryHonorsPerAttemptTimeout(t *testing.T) {
 		t.Fatalf("attempts = %d, want 2", attempts)
 	}
 }
+
+func TestGenerateWithRetryAddsAttemptMetadataToRunInfo(t *testing.T) {
+	var got []RunInfo
+	model := retryModel{generate: func(ctx context.Context, _ *Request, _ ...GenerateOption) (*Response, error) {
+		info, ok := RunInfoFrom(ctx)
+		if !ok {
+			t.Fatal("RunInfo missing from attempt context")
+		}
+		got = append(got, info)
+		if info.Attempt == 1 {
+			return nil, errors.New("temporary provider outage")
+		}
+		return &Response{Reply: "ok"}, nil
+	}}
+
+	ctx := WithRunInfo(context.Background(), RunInfo{RunID: "run-1", Agent: "worker"})
+	_, err := GenerateWithRetry(ctx, model, &Request{Prompt: "hi"}, GeneratePolicy{
+		MaxAttempts: 2,
+		Backoff:     time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("GenerateWithRetry returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("attempt contexts = %d, want 2", len(got))
+	}
+	for i, info := range got {
+		wantAttempt := i + 1
+		if info.Attempt != wantAttempt {
+			t.Fatalf("attempt %d RunInfo.Attempt = %d, want %d", i, info.Attempt, wantAttempt)
+		}
+		if info.MaxAttempts != 2 {
+			t.Fatalf("attempt %d RunInfo.MaxAttempts = %d, want 2", i, info.MaxAttempts)
+		}
+		if info.RunID != "run-1" || info.Agent != "worker" {
+			t.Fatalf("attempt %d RunInfo identity = (%q, %q), want (run-1, worker)", i, info.RunID, info.Agent)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add model retry attempt metadata to ai.RunInfo so lifecycle wrappers and tools can correlate provider attempts within a run.
- Populate RunInfo.Attempt and RunInfo.MaxAttempts for each GenerateWithRetry attempt while preserving existing run identity fields.
- Add retry coverage proving attempt metadata is present across a transient retry.

Closes #2980
Closes #3206

## Testing
- go build ./...
- go test ./ai ./agent
- go test ./... (fails in this sandbox because loopback gRPC targets are forbidden by the environment proxy)
- golangci-lint run ./...