### PR TITLE
Update architect priority queue after lifecycle hooks

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -19,15 +19,28 @@ redirect the loop; direction always wins.
 items the loop can auto-merge): brand/positioning copy, breaking public-API
 changes, architectural rewrites. Those go to the human.
 
-## Now (ranked)
+## Later (ranked)
 
-1. **Execution lifecycle hooks & metadata** (#2980) — before/after-tool, retry,
-   and failure hooks; first reconcile the issue with the shipped `AgentWrapTool`,
-   structured refusal reasons, `RunInfo`, OpenTelemetry spans, durable resume, and
-   A2A streaming task lifecycle, then close it or scope only a CI-verifiable gap
-   that those primitives cannot express. Roadmap → resilience/operability; now
-   ranked first because streaming shipped and this is the remaining open Now-phase
-   reliability seam for long-running agents and workflows.
+1. **Agent memory compaction and retrieval controls** (#3209) — add explicit,
+   store-backed summarization/retrieval behavior for long-running agents so
+   durable, streaming, observable runs do not become context-growth demos.
+   Roadmap → memory management; ranked first because the Now/Next reliability
+   work has shipped and long-lived agents need bounded, recoverable context before
+   deeper autonomous workflows can be trustworthy.
+2. **Human-in-the-loop pause/resume for agent runs** (#3210) — persist a paused
+   approval/intervention point and resume safely through the existing
+   guardrail/run-inspection path. Roadmap → human-in-the-loop pause/resume; ranked
+   second because it turns guardrails from one-shot refusals into an operable
+   workflow primitive without changing the public architecture.
+3. **x402 spend caps and live facilitator conformance** (#3211) — enforce paid-tool
+   budgets and add credential-gated live facilitator checks. Roadmap → x402 paid
+   remote tools; ranked after memory and pause/resume because it hardens a narrower
+   paid-tool seam but is important for trust once agents can act for longer.
+4. **A2A push notifications and multi-turn task support** (#3212) — extend the A2A
+   gateway/client path beyond streaming lifecycle updates into push and multi-turn
+   task state. Roadmap → A2A push notifications and multi-turn tasks; ranked after
+   local run operability because interop depth compounds best once the local run
+   lifecycle is bounded and inspectable.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:
- Removed the closed lifecycle hooks priority (#2980) from the architect queue.
- Added newly filed Later-roadmap priorities for memory compaction/retrieval (#3209), human-in-the-loop pause/resume (#3210), x402 spend caps/conformance (#3211), and A2A push/multi-turn support (#3212).

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3208