### PR TITLE
Add agent memory compaction controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Just as a service composes pluggable abstractions (registry, broker, store), an 
 ```go
 agent := micro.NewAgent("assistant",
     micro.AgentProvider("anthropic"),                 // model — swap the provider
-    micro.AgentMemory(micro.NewInMemory(50)),         // memory — default is store-backed & durable
+    micro.AgentCompactMemory(40, 12),                 // memory — durable, summarized, recallable
     micro.AgentTool("weather", "Get the weather for a city",
         map[string]any{"city": map[string]any{"type": "string"}},
         func(ctx context.Context, in map[string]any) (string, error) {
@@ -247,7 +247,7 @@ agent := micro.NewAgent("assistant",
 )
 ```
 
-**Memory** is durable and store-backed by default (Postgres, NATS KV, or file), so an agent picks up where it left off after a restart — or supply your own with `AgentMemory`. **Tools** are your services automatically, plus any function you register with `AgentTool`.
+**Memory** is durable and store-backed by default (Postgres, NATS KV, or file), so an agent picks up where it left off after a restart — or supply your own with `AgentMemory`. Long-running agents can opt into `AgentCompactMemory(maxMessages, keepRecent)`: older turns are collapsed into a deterministic summary, recent turns stay verbatim, and relevant archived turns are recalled on future asks without replaying the whole conversation. **Tools** are your services automatically, plus any function you register with `AgentTool`.
 
 ### Paid tools (x402)
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -150,6 +150,8 @@ func (a *agentImpl) setup() {
 		a.mem = a.opts.Memory
 	case a.ephemeral:
 		a.mem = NewInMemory(a.opts.HistoryLimit)
+	case a.opts.MemoryCompaction.MaxMessages > 0:
+		a.mem = NewCompactingMemory(a.stateStore(), "history", a.opts.MemoryCompaction.MaxMessages, a.opts.MemoryCompaction.KeepRecent)
 	default:
 		a.mem = NewMemory(a.stateStore(), "history", a.opts.HistoryLimit)
 	}
@@ -251,11 +253,21 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 	ctx, endRun := a.startRun(ctx, message)
 	defer func() { endRun(err) }()
 
+	messages := a.mem.Messages()
+	if recall, ok := a.mem.(MemoryRecall); ok && a.opts.MemoryRecallLimit > 0 {
+		if recalled := recall.Recall(message, a.opts.MemoryRecallLimit); len(recalled) > 0 {
+			messages = append([]ai.Message{{
+				Role:    "system",
+				Content: "Relevant recalled memory follows; use it as durable prior context without assuming the whole conversation was replayed.",
+			}}, append(recalled, messages...)...)
+		}
+	}
+
 	resp, err := ai.GenerateWithRetry(ctx, a.model, &ai.Request{
 		Prompt:       message,
 		SystemPrompt: a.buildPrompt(),
 		Tools:        toolList,
-		Messages:     a.mem.Messages(),
+		Messages:     messages,
 	}, ai.GeneratePolicy{
 		Timeout:     a.opts.ModelTimeout,
 		MaxAttempts: a.opts.ModelMaxAttempts,

--- a/agent/integration_test.go
+++ b/agent/integration_test.go
@@ -179,3 +179,46 @@ func TestDelegateRequiresTask(t *testing.T) {
 		t.Errorf("delegate with no task should error; got %q", content)
 	}
 }
+
+func TestCompactingMemorySummarizesAndRecallsArchivedContext(t *testing.T) {
+	var sawSummary, sawRecall bool
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		for _, msg := range req.Messages {
+			text := msg.Content.(string)
+			if strings.Contains(text, "Conversation memory summary") && strings.Contains(text, "alpha project") {
+				sawSummary = true
+			}
+			if strings.Contains(text, "alpha project budget is 42") {
+				sawRecall = true
+			}
+		}
+		return &ai.Response{Reply: "ok"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("memory"), CompactMemory(4, 2), MemoryRecallLimit(3))
+	turns := []string{
+		"alpha project budget is 42",
+		"beta project owner is sam",
+		"gamma project deadline is monday",
+		"delta project status is green",
+		"epsilon project risk is low",
+	}
+	for _, turn := range turns {
+		if _, err := a.Ask(context.Background(), turn); err != nil {
+			t.Fatalf("Ask(%q): %v", turn, err)
+		}
+	}
+	if got := len(a.mem.Messages()); got > 4 {
+		t.Fatalf("compacted memory retained %d messages, want <= 4", got)
+	}
+	if _, err := a.Ask(context.Background(), "what was the alpha budget?"); err != nil {
+		t.Fatalf("Ask recall: %v", err)
+	}
+	if !sawSummary {
+		t.Error("model request did not include a deterministic compacted summary")
+	}
+	if !sawRecall {
+		t.Error("model request did not recall archived matching context")
+	}
+}

--- a/agent/memory.go
+++ b/agent/memory.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"sync"
 
 	"go-micro.dev/v6/ai"
@@ -21,6 +23,21 @@ type Memory interface {
 	Clear()
 }
 
+// MemoryCompaction configures deterministic, store-backed context compaction
+// for the default memory implementation. When the retained conversation grows
+// past MaxMessages, older turns are collapsed into a summary message while the
+// newest KeepRecent turns stay verbatim for provider-neutral continuity.
+type MemoryCompaction struct {
+	MaxMessages int
+	KeepRecent  int
+}
+
+// MemoryRecall is implemented by memory backends that can retrieve durable
+// prior context relevant to a new turn without replaying every stored message.
+type MemoryRecall interface {
+	Recall(query string, limit int) []ai.Message
+}
+
 // NewMemory returns the default store-backed memory: an in-process
 // conversation buffer (truncated to limit) that persists to the store
 // under key, so an agent picks up where it left off after a restart.
@@ -28,6 +45,33 @@ type Memory interface {
 func NewMemory(s store.Store, key string, limit int) Memory {
 	m := &storeMemory{store: s, key: key, hist: ai.NewHistory(limit)}
 	m.load()
+	return m
+}
+
+// NewCompactingMemory returns store-backed memory with explicit compaction and
+// retrieval controls. It keeps all messages in the backing store, compacts older
+// turns into a deterministic summary when the conversation exceeds maxMessages,
+// and lets callers recall relevant prior turns with Recall.
+func NewCompactingMemory(s store.Store, key string, maxMessages, keepRecent int) Memory {
+	if keepRecent <= 0 {
+		keepRecent = maxMessages / 2
+	}
+	if keepRecent < 1 {
+		keepRecent = 1
+	}
+	m := &storeMemory{
+		store: s,
+		key:   key,
+		// Use an unlimited buffer here; compaction, not truncation, decides
+		// what remains in active context so a summary can preserve older turns.
+		hist: ai.NewHistory(0),
+		compaction: MemoryCompaction{
+			MaxMessages: maxMessages,
+			KeepRecent:  keepRecent,
+		},
+	}
+	m.load()
+	m.compact()
 	return m
 }
 
@@ -39,16 +83,19 @@ func NewInMemory(limit int) Memory {
 // storeMemory is the default Memory: an ai.History buffer optionally
 // persisted to a store.
 type storeMemory struct {
-	mu    sync.Mutex
-	store store.Store
-	key   string
-	hist  *ai.History
+	mu         sync.Mutex
+	store      store.Store
+	key        string
+	hist       *ai.History
+	compaction MemoryCompaction
+	archive    []ai.Message
 }
 
 func (m *storeMemory) Add(role, content string) {
 	m.mu.Lock()
 	m.hist.Add(role, content)
 	m.mu.Unlock()
+	m.compact()
 	m.save()
 }
 
@@ -61,8 +108,33 @@ func (m *storeMemory) Messages() []ai.Message {
 func (m *storeMemory) Clear() {
 	m.mu.Lock()
 	m.hist.Reset()
+	m.archive = nil
 	m.mu.Unlock()
 	m.save()
+}
+
+// Recall returns archived messages whose content contains words from query.
+// It is deterministic and provider-neutral: no embeddings or model calls are
+// required, but semantic/vector stores can replace Memory for richer retrieval.
+func (m *storeMemory) Recall(query string, limit int) []ai.Message {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if limit <= 0 {
+		limit = 5
+	}
+	terms := recallTerms(query)
+	var out []ai.Message
+	for i := len(m.archive) - 1; i >= 0 && len(out) < limit; i-- {
+		msg := m.archive[i]
+		text := strings.ToLower(fmt.Sprint(msg.Content))
+		for _, term := range terms {
+			if strings.Contains(text, term) {
+				out = append(out, msg)
+				break
+			}
+		}
+	}
+	return out
 }
 
 func (m *storeMemory) load() {
@@ -73,12 +145,17 @@ func (m *storeMemory) load() {
 	if err != nil || len(recs) == 0 {
 		return
 	}
-	var msgs []ai.Message
-	if err := json.Unmarshal(recs[0].Value, &msgs); err != nil {
-		return
+	var state memoryState
+	if err := json.Unmarshal(recs[0].Value, &state); err != nil {
+		var msgs []ai.Message
+		if err := json.Unmarshal(recs[0].Value, &msgs); err != nil {
+			return
+		}
+		state.Messages = msgs
 	}
 	m.mu.Lock()
-	for _, msg := range msgs {
+	m.archive = state.Archive
+	for _, msg := range state.Messages {
 		m.hist.Add(msg.Role, msg.Content)
 	}
 	m.mu.Unlock()
@@ -89,10 +166,83 @@ func (m *storeMemory) save() {
 		return
 	}
 	m.mu.Lock()
-	data, err := json.Marshal(m.hist.Messages())
+	data, err := json.Marshal(memoryState{
+		Messages: m.hist.Messages(),
+		Archive:  m.archive,
+	})
 	m.mu.Unlock()
 	if err != nil {
 		return
 	}
 	_ = m.store.Write(&store.Record{Key: m.key, Value: data})
+}
+
+func (m *storeMemory) compact() {
+	if m.compaction.MaxMessages <= 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	msgs := m.hist.Messages()
+	if len(msgs) <= m.compaction.MaxMessages {
+		return
+	}
+	keep := m.compaction.KeepRecent
+	if keep <= 0 || keep >= m.compaction.MaxMessages {
+		keep = m.compaction.MaxMessages - 1
+	}
+	if keep < 1 {
+		keep = 1
+	}
+	cut := len(msgs) - keep
+	older := msgs[:cut]
+	recent := msgs[cut:]
+	m.archive = append(m.archive, older...)
+	summary := ai.Message{
+		Role:    "system",
+		Content: fmt.Sprintf("Conversation memory summary: %s", summarizeMessages(older)),
+	}
+	m.hist.Reset()
+	m.hist.Add(summary.Role, summary.Content)
+	for _, msg := range recent {
+		m.hist.Add(msg.Role, msg.Content)
+	}
+}
+
+func summarizeMessages(msgs []ai.Message) string {
+	var b strings.Builder
+	for i, msg := range msgs {
+		if i > 0 {
+			b.WriteString(" | ")
+		}
+		fmt.Fprintf(&b, "%s: %s", msg.Role, compactText(fmt.Sprint(msg.Content), 120))
+	}
+	return b.String()
+}
+
+func compactText(s string, max int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if max > 0 && len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}
+
+func recallTerms(query string) []string {
+	seen := map[string]bool{}
+	var terms []string
+	for _, term := range strings.Fields(strings.ToLower(query)) {
+		term = strings.Trim(term, ".,!?;:\"'()[]{}")
+		if len(term) < 3 || seen[term] {
+			continue
+		}
+		seen[term] = true
+		terms = append(terms, term)
+	}
+	return terms
+}
+
+type memoryState struct {
+	Messages []ai.Message `json:"messages"`
+	Archive  []ai.Message `json:"archive,omitempty"`
 }

--- a/agent/options.go
+++ b/agent/options.go
@@ -60,6 +60,13 @@ type Options struct {
 	// Memory is the agent's conversation memory. Nil = the default
 	// store-backed memory (durable across restarts).
 	Memory Memory
+	// MemoryCompaction enables deterministic compaction/retrieval on the
+	// default store-backed memory. Custom Memory implementations can expose
+	// retrieval by implementing MemoryRecall.
+	MemoryCompaction MemoryCompaction
+	// MemoryRecallLimit bounds recalled archived turns injected into a model
+	// request (0 disables recall injection).
+	MemoryRecallLimit int
 	// Checkpoint persists agent Ask runs so callers can resume by run id
 	// after a restart without replaying a run that already completed.
 	Checkpoint flow.Checkpoint
@@ -213,6 +220,25 @@ func WithA2A(addr string) Option {
 // in-process, database, or semantic store.
 func WithMemory(m Memory) Option {
 	return func(o *Options) { o.Memory = m }
+}
+
+// CompactMemory enables deterministic, store-backed memory compaction for the
+// default agent memory. Older turns are summarized once active context exceeds
+// maxMessages, keepRecent newest turns remain verbatim, and recalled archived
+// turns are injected into matching future asks.
+func CompactMemory(maxMessages, keepRecent int) Option {
+	return func(o *Options) {
+		o.MemoryCompaction = MemoryCompaction{MaxMessages: maxMessages, KeepRecent: keepRecent}
+		if o.MemoryRecallLimit == 0 {
+			o.MemoryRecallLimit = 5
+		}
+	}
+}
+
+// MemoryRecallLimit sets how many archived turns a memory backend may inject
+// into a model request for the current Ask. Use 0 to disable retrieval.
+func MemoryRecallLimit(n int) Option {
+	return func(o *Options) { o.MemoryRecallLimit = n }
 }
 
 // WithCheckpoint sets the durability backend for agent Ask runs. The

--- a/micro.go
+++ b/micro.go
@@ -110,17 +110,35 @@ func AgentApproveTool(fn ApproveFunc) AgentOption { return agent.ApproveTool(fn)
 // Memory is an agent's pluggable conversation memory.
 type Memory = agent.Memory
 
+// MemoryRecall is implemented by memory backends that retrieve prior context.
+type MemoryRecall = agent.MemoryRecall
+
 // ToolFunc handles a custom agent tool call.
 type ToolFunc = agent.ToolFunc
 
 // NewMemory returns the default store-backed agent memory.
 func NewMemory(s store.Store, key string, limit int) Memory { return agent.NewMemory(s, key, limit) }
 
+// NewCompactingMemory returns store-backed memory with deterministic
+// summarization and retrieval controls.
+func NewCompactingMemory(s store.Store, key string, maxMessages, keepRecent int) Memory {
+	return agent.NewCompactingMemory(s, key, maxMessages, keepRecent)
+}
+
 // NewInMemory returns non-persistent agent memory.
 func NewInMemory(limit int) Memory { return agent.NewInMemory(limit) }
 
 // AgentMemory sets the agent's conversation memory (default: store-backed).
 func AgentMemory(m Memory) AgentOption { return agent.WithMemory(m) }
+
+// AgentCompactMemory enables deterministic default-memory compaction and
+// retrieval for long-running agents.
+func AgentCompactMemory(maxMessages, keepRecent int) AgentOption {
+	return agent.CompactMemory(maxMessages, keepRecent)
+}
+
+// AgentMemoryRecallLimit bounds recalled archived turns injected per Ask.
+func AgentMemoryRecallLimit(n int) AgentOption { return agent.MemoryRecallLimit(n) }
 
 // AgentTool registers a custom tool the agent can call, beyond its services.
 func AgentTool(name, description string, properties map[string]any, handler ToolFunc) AgentOption {


### PR DESCRIPTION
Summary:
- Add deterministic store-backed memory compaction for long-running agents.
- Add recall hooks so archived context can be injected without replaying every turn.
- Document AgentCompactMemory in the agent memory guide.

Testing:
- go build ./...
- go test ./... (environment blocks loopback gRPC tests: client/grpc and transport/grpc report Loopback targets forbidden)
- golangci-lint run ./...

Closes #3209
Closes #3214