### PR TITLE
Add durable approval pause for agents

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -87,6 +87,11 @@ type agentImpl struct {
 	// Both are surfaced to tool wrappers via ai.RunInfo on the context.
 	runID       string
 	parentRunID string
+
+	// pause records a guardrail approval pause raised during the current
+	// Ask. The model provider only sees a refused tool result; the agent
+	// converts it into a durable paused run instead of completing the run.
+	pause *approvalPause
 }
 
 // New creates a new Agent.
@@ -238,6 +243,7 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 	a.mem.Add("user", message)
 	a.steps = 0
 	a.calls = map[string]int{}
+	a.pause = nil
 
 	// Correlate this run's tool calls and surface lineage to wrappers.
 	a.runID = runID
@@ -279,6 +285,18 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		run.Steps[0].Error = err.Error()
 		_ = a.saveRun(ctx, run)
 		return nil, err
+	}
+	if a.pause != nil && a.opts.Checkpoint != nil {
+		run.Status = "paused"
+		run.State.Stage = agentApprovalStep
+		run.State.Data = []byte(message)
+		run.Steps[0].Status = "paused"
+		run.Steps[0].Error = a.pause.Message
+		run.Steps[0].Result = a.pause.Tool
+		if err := a.saveRun(ctx, run); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("agent run %s paused for approval: %s", run.ID, a.pause.Message)
 	}
 
 	if resp.Reply != "" {

--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -200,6 +200,11 @@ func (a *agentImpl) loopWrap(next ai.ToolHandler) ai.ToolHandler {
 }
 
 // approveWrap gates each action before it runs (ApproveTool).
+type approvalPause struct {
+	Tool    string
+	Message string
+}
+
 func (a *agentImpl) approveWrap(next ai.ToolHandler) ai.ToolHandler {
 	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
 		if a.opts.Approve != nil {
@@ -208,6 +213,7 @@ func (a *agentImpl) approveWrap(next ai.ToolHandler) ai.ToolHandler {
 				if reason != "" {
 					msg += ": " + reason
 				}
+				a.pause = &approvalPause{Tool: call.Name, Message: msg}
 				return refused(call.ID, ai.RefusedApproval, msg)
 			}
 		}

--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -9,7 +9,10 @@ import (
 	"go-micro.dev/v6/flow"
 )
 
-const agentAskStep = "ask"
+const (
+	agentAskStep      = "ask"
+	agentApprovalStep = "approval"
+)
 
 func (a *agentImpl) newCheckpointRun(runID, message, parentRunID string, existing *flow.Run) flow.Run {
 	now := time.Now()
@@ -56,6 +59,10 @@ func (a *agentImpl) resume(ctx context.Context, runID string) (*Response, error)
 	}
 	if !ok {
 		return nil, fmt.Errorf("agent run %s not found", runID)
+	}
+	if run.Status == "paused" {
+		run.Status = "running"
+		run.State.Stage = agentAskStep
 	}
 	if run.Status == "done" {
 		var resp Response

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -64,3 +64,71 @@ func TestPendingReturnsUnfinishedAgentRuns(t *testing.T) {
 		t.Fatalf("Pending = %#v, want run-1", runs)
 	}
 }
+
+func TestApprovalDenialPausesCheckpointedRunAndResumeContinues(t *testing.T) {
+	ctx := context.Background()
+	cp := flow.StoreCheckpoint(store.NewStore(), "approval-agent")
+	calls := 0
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		calls++
+		if opts.ToolHandler != nil {
+			opts.ToolHandler(ctx, ai.ToolCall{ID: "call-1", Name: "external.approve", Input: map[string]any{"id": "42"}})
+		}
+		return &ai.Response{Reply: "model saw approval result"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	approved := false
+	a := newTestAgent(Name("approval-agent"), WithCheckpoint(cp),
+		WithTool("external.approve", "guarded external action", nil, func(context.Context, map[string]any) (string, error) { return "ok", nil }),
+		ApproveTool(func(tool string, input map[string]any) (bool, string) {
+			return approved, "waiting for operator"
+		}))
+	_, err := a.Ask(ctx, "send the guarded update")
+	if err == nil {
+		t.Fatal("Ask succeeded, want paused approval error")
+	}
+
+	runs, err := Pending(ctx, a)
+	if err != nil {
+		t.Fatalf("Pending: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("Pending returned %d runs, want 1: %#v", len(runs), runs)
+	}
+	if runs[0].Status != "paused" || runs[0].State.Stage != agentApprovalStep {
+		t.Fatalf("run status/stage = %s/%s, want paused/%s", runs[0].Status, runs[0].State.Stage, agentApprovalStep)
+	}
+	if got := string(runs[0].State.Data); got != "send the guarded update" {
+		t.Fatalf("paused run data = %q", got)
+	}
+
+	approved = true
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		calls++
+		if opts.ToolHandler != nil {
+			res := opts.ToolHandler(ctx, ai.ToolCall{ID: "call-2", Name: "external.approve", Input: map[string]any{"id": "42"}})
+			if res.Refused != "" {
+				t.Fatalf("resumed call was refused: %#v", res)
+			}
+		}
+		return &ai.Response{Reply: "done after approval"}, nil
+	}
+	resp, err := Resume(ctx, a, runs[0].ID)
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resp.Reply != "done after approval" {
+		t.Fatalf("Resume reply = %q", resp.Reply)
+	}
+	loaded, ok, err := cp.Load(ctx, runs[0].ID)
+	if err != nil || !ok {
+		t.Fatalf("Load resumed run ok=%v err=%v", ok, err)
+	}
+	if loaded.Status != "done" {
+		t.Fatalf("resumed run status = %q, want done", loaded.Status)
+	}
+	if calls != 2 {
+		t.Fatalf("model calls = %d, want 2", calls)
+	}
+}


### PR DESCRIPTION
## Summary
- persist checkpointed agent runs as paused when approval guardrails deny a tool call
- allow Resume to continue paused approval runs once the approval policy permits the action
- add regression coverage for pause, pending visibility, and resume completion

Closes #3210
Closes #3217

## Testing
- go build ./...
- go test ./agent
- go test ./... (fails in this environment: loopback targets forbidden in client/grpc and transport/grpc tests)
- golangci-lint run ./...