### PR TITLE
Harden x402 spend caps

### DIFF
--- a/internal/website/docs/guides/x402-payments.md
+++ b/internal/website/docs/guides/x402-payments.md
@@ -100,7 +100,22 @@ c := &x402.Client{
 resp, err := c.Do(req) // a 402 is paid and retried; over-budget calls error instead
 ```
 
-`Payer` is an interface (`Pay(ctx, Requirements) (payment string, error)`) — the consumer counterpart to `Facilitator`. The budget accumulates across calls, so a long-running agent can be handed a fixed allowance for a task. (The agent-level `AgentMaxSpend` option, wiring this into the agent loop next to `MaxSteps`/`ApproveTool`, is the next step.)
+`Payer` is an interface (`Pay(ctx, Requirements) (payment string, error)`) — the consumer counterpart to `Facilitator`. The budget accumulates across calls, so a long-running agent can be handed a fixed allowance for a task. Budget is reserved before payment is created, which means parallel paid calls cannot race past the cap; if payment creation or verification fails, the reservation is released. (The agent-level `AgentMaxSpend` option, wiring this into the agent loop next to `MaxSteps`/`ApproveTool`, is the next step.)
+
+### Live facilitator conformance
+
+The regular test suite uses in-process facilitators and does not need network credentials. To smoke-test a hosted facilitator, run the opt-in live conformance test with a real payment payload and matching requirements:
+
+```sh
+GO_MICRO_X402_LIVE_FACILITATOR_URL=https://facilitator.example \
+GO_MICRO_X402_LIVE_PAYMENT='...' \
+GO_MICRO_X402_LIVE_PAY_TO=0xYourAddress \
+GO_MICRO_X402_LIVE_NETWORK=base \
+GO_MICRO_X402_LIVE_AMOUNT=1 \
+go test ./wrapper/x402 -run TestLiveFacilitatorConformance -count=1
+```
+
+Leave those variables unset in normal CI; the live test skips unless the facilitator URL, payment payload, and pay-to address are all provided.
 
 ## Notes
 

--- a/wrapper/x402/client.go
+++ b/wrapper/x402/client.go
@@ -83,7 +83,9 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	reqd := ch.Accepts[0]
 	amount, _ := strconv.ParseInt(reqd.MaxAmountRequired, 10, 64)
 
-	// Spend cap: refuse before paying if this would exceed the budget.
+	// Spend cap: reserve before paying so concurrent calls cannot all pass
+	// the check and overspend the caller's allowance. Roll the reservation
+	// back if payment construction, replay, or verification fails.
 	c.mu.Lock()
 	if c.Budget > 0 && c.spent+amount > c.Budget {
 		spent := c.spent
@@ -91,13 +93,26 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("x402: paying %d for %s would exceed budget (spent %d of %d)",
 			amount, reqd.Resource, spent, c.Budget)
 	}
+	c.spent += amount
 	c.mu.Unlock()
+	reserved := true
+	rollback := func() {
+		if !reserved {
+			return
+		}
+		c.mu.Lock()
+		c.spent -= amount
+		c.mu.Unlock()
+		reserved = false
+	}
 
 	if c.Payer == nil {
+		rollback()
 		return nil, fmt.Errorf("x402: payment required for %s but no Payer configured", reqd.Resource)
 	}
 	payment, err := c.Payer.Pay(req.Context(), reqd)
 	if err != nil {
+		rollback()
 		return nil, fmt.Errorf("x402: pay: %w", err)
 	}
 
@@ -108,6 +123,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	}
 	retry, err := http.NewRequestWithContext(req.Context(), req.Method, req.URL.String(), rbody)
 	if err != nil {
+		rollback()
 		return nil, err
 	}
 	for k, v := range req.Header {
@@ -117,14 +133,14 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 	resp2, err := c.httpClient().Do(retry)
 	if err != nil {
+		rollback()
 		return nil, err
 	}
 	if resp2.StatusCode == http.StatusPaymentRequired {
+		rollback()
 		return resp2, fmt.Errorf("x402: payment for %s was rejected", reqd.Resource)
 	}
 
-	c.mu.Lock()
-	c.spent += amount
-	c.mu.Unlock()
+	reserved = false
 	return resp2, nil
 }

--- a/wrapper/x402/client_test.go
+++ b/wrapper/x402/client_test.go
@@ -118,3 +118,62 @@ func TestClientFreeEndpoint(t *testing.T) {
 		t.Errorf("free call should spend nothing, got %d", c.Spent())
 	}
 }
+
+// Concurrent callers reserve budget before paying, so a spend cap cannot be
+// overshot by parallel tool calls that all observe the same pre-spend balance.
+func TestClientBudgetReservedConcurrently(t *testing.T) {
+	srv := paidServer("10000")
+	defer srv.Close()
+
+	c := &Client{Payer: &mockPayer{}, Budget: 10000}
+	errCh := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+			resp, err := c.Do(req)
+			if resp != nil {
+				resp.Body.Close()
+			}
+			errCh <- err
+		}()
+	}
+
+	var paid, refused int
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			refused++
+		} else {
+			paid++
+		}
+	}
+	if paid != 1 || refused != 1 {
+		t.Fatalf("paid=%d refused=%d, want one paid and one refused", paid, refused)
+	}
+	if c.Spent() != 10000 {
+		t.Errorf("spent = %d, want 10000", c.Spent())
+	}
+}
+
+// A reserved budget slot is released when payment cannot be produced, so a
+// transient payer failure does not permanently consume an agent's allowance.
+func TestClientBudgetReservationRollsBackOnPayError(t *testing.T) {
+	srv := paidServer("10000")
+	defer srv.Close()
+
+	c := &Client{Payer: payerFunc(func(context.Context, Requirements) (string, error) {
+		return "", context.Canceled
+	}), Budget: 10000}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if _, err := c.Do(req); err == nil {
+		t.Fatal("expected pay error")
+	}
+	if c.Spent() != 0 {
+		t.Errorf("failed payment should roll back spend, got %d", c.Spent())
+	}
+}
+
+type payerFunc func(context.Context, Requirements) (string, error)
+
+func (f payerFunc) Pay(ctx context.Context, req Requirements) (string, error) {
+	return f(ctx, req)
+}

--- a/wrapper/x402/live_facilitator_test.go
+++ b/wrapper/x402/live_facilitator_test.go
@@ -1,0 +1,52 @@
+package x402
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestLiveFacilitatorConformance is an opt-in smoke test for hosted x402
+// facilitators. It is skipped by default so local and CI runs never need live
+// credentials, but operators can run it against Coinbase, Alchemy, or a
+// self-hosted facilitator by providing a real payment payload and matching
+// requirements.
+func TestLiveFacilitatorConformance(t *testing.T) {
+	url := os.Getenv("GO_MICRO_X402_LIVE_FACILITATOR_URL")
+	payment := os.Getenv("GO_MICRO_X402_LIVE_PAYMENT")
+	payTo := os.Getenv("GO_MICRO_X402_LIVE_PAY_TO")
+	if url == "" || payment == "" || payTo == "" {
+		t.Skip("set GO_MICRO_X402_LIVE_FACILITATOR_URL, GO_MICRO_X402_LIVE_PAYMENT, and GO_MICRO_X402_LIVE_PAY_TO to run live x402 facilitator conformance")
+	}
+
+	network := getenv("GO_MICRO_X402_LIVE_NETWORK", "base")
+	amount := getenv("GO_MICRO_X402_LIVE_AMOUNT", "1")
+	asset := os.Getenv("GO_MICRO_X402_LIVE_ASSET")
+	resource := getenv("GO_MICRO_X402_LIVE_RESOURCE", "go-micro-x402-live-conformance")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	res, err := (&HTTPFacilitator{URL: url}).Verify(ctx, payment, Requirements{
+		Scheme:            "exact",
+		Network:           network,
+		MaxAmountRequired: amount,
+		Resource:          resource,
+		PayTo:             payTo,
+		Asset:             asset,
+		MaxTimeoutSeconds: 60,
+	})
+	if err != nil {
+		t.Fatalf("live facilitator verify: %v", err)
+	}
+	if !res.Valid {
+		t.Fatalf("live facilitator rejected payment: %s", res.Reason)
+	}
+}
+
+func getenv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}


### PR DESCRIPTION
Summary:
- Reserve x402 client budget before payment creation/retry so concurrent paid calls cannot overspend the cap, and roll reservations back on payment/retry failures.
- Add tests for concurrent budget enforcement and rollback on payer failure.
- Add an opt-in live facilitator conformance smoke test gated by GO_MICRO_X402_LIVE_* credentials and document how to run it.

Testing:
- go build ./...
- go test ./... (fails in this environment due loopback targets forbidden in existing grpc client/transport tests)
- golangci-lint run ./...

Closes #3211
Closes #3221