### PR TITLE
Add A2A task continuation and push callbacks

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -20,9 +20,9 @@
 //
 // Scope of this version: the JSON-RPC binding — `message/send`
 // (returns a completed Task), `message/stream` (SSE with the completed
-// Task event), `tasks/get`, and Agent Card discovery. Multi-turn
-// `input-required`, `tasks/resubscribe`, and push notifications are
-// advertised as unsupported and are follow-ups.
+// Task event), `tasks/get`, multi-turn task continuation, push
+// notification delivery, and Agent Card discovery. `input-required` and
+// `tasks/resubscribe` are advertised as unsupported and are follow-ups.
 package a2a
 
 import (
@@ -225,6 +225,15 @@ type Task struct {
 	Kind      string     `json:"kind"` // "task"
 }
 
+// PushNotificationConfig tells the gateway where to POST task updates for a
+// task. The gateway stores one config per task and delivers best-effort JSON
+// task snapshots whenever that task changes.
+type PushNotificationConfig struct {
+	URL            string            `json:"url"`
+	Token          string            `json:"token,omitempty"`
+	Authentication map[string]string `json:"authentication,omitempty"`
+}
+
 // Task states (JSON-RPC binding wire values).
 const (
 	stateCompleted = "completed"
@@ -334,7 +343,7 @@ func Card(name, url, description string, services []string) AgentCard {
 		URL:             url,
 		Version:         "1.0.0",
 		ProtocolVersion: protocolVersion,
-		Capabilities:    Capabilities{Streaming: true, PushNotifications: false},
+		Capabilities:    Capabilities{Streaming: true, PushNotifications: true},
 		// The agent converses over a single Chat endpoint; advertise that
 		// as one skill, tagged with the services it manages.
 		DefaultInputModes:  []string{"text/plain"},
@@ -415,12 +424,15 @@ func (g *Gateway) handleRPC(w http.ResponseWriter, r *http.Request) {
 // retains recent tasks for tasks/get. It is shared by the gateway (one
 // per registry) and embedded agents (one per agent).
 type dispatcher struct {
-	mu    sync.Mutex
-	tasks map[string]*Task
-	order []string // task ids in insertion order, for bounded eviction
+	mu          sync.Mutex
+	tasks       map[string]*Task
+	pushConfigs map[string]PushNotificationConfig
+	order       []string // task ids in insertion order, for bounded eviction
 }
 
-func newDispatcher() *dispatcher { return &dispatcher{tasks: map[string]*Task{}} }
+func newDispatcher() *dispatcher {
+	return &dispatcher{tasks: map[string]*Task{}, pushConfigs: map[string]PushNotificationConfig{}}
+}
 
 func (d *dispatcher) serve(w http.ResponseWriter, r *http.Request, invoke Invoke) {
 	d.serveWithStream(w, r, invoke, nil)
@@ -448,6 +460,10 @@ func (d *dispatcher) serveWithStream(w http.ResponseWriter, r *http.Request, inv
 		d.stream(requestContext(r.Context()), w, req, invoke)
 	case "tasks/get":
 		d.get(w, req)
+	case "tasks/pushNotificationConfig/set":
+		d.setPushConfig(w, req)
+	case "tasks/pushNotificationConfig/get":
+		d.getPushConfig(w, req)
 	case "tasks/cancel":
 		// v1 tasks complete synchronously, so they're already terminal.
 		writeRPC(w, req.ID, nil, &rpcError{Code: errNotCancelable, Message: "task is not cancelable"})
@@ -562,7 +578,7 @@ func (d *dispatcher) run(ctx context.Context, params json.RawMessage, invoke Inv
 		reply = "error: " + err.Error()
 		state = stateFailed
 	}
-	task := taskFromReply(p.Message, reply, state)
+	task := d.taskFromReply(p.Message, reply, state)
 	d.store(task)
 	return task, nil
 }
@@ -585,6 +601,47 @@ func (d *dispatcher) get(w http.ResponseWriter, req rpcRequest) {
 		return
 	}
 	writeRPC(w, req.ID, task, nil)
+}
+
+type pushConfigParams struct {
+	ID                     string                 `json:"id"`
+	PushNotificationConfig PushNotificationConfig `json:"pushNotificationConfig"`
+}
+
+func (d *dispatcher) setPushConfig(w http.ResponseWriter, req rpcRequest) {
+	var p pushConfigParams
+	if err := json.Unmarshal(req.Params, &p); err != nil || p.ID == "" || p.PushNotificationConfig.URL == "" {
+		writeRPC(w, req.ID, nil, &rpcError{Code: errInvalidParams, Message: "invalid params"})
+		return
+	}
+	d.mu.Lock()
+	task := d.tasks[p.ID]
+	if task != nil {
+		d.pushConfigs[p.ID] = p.PushNotificationConfig
+	}
+	d.mu.Unlock()
+	if task == nil {
+		writeRPC(w, req.ID, nil, &rpcError{Code: errTaskNotFound, Message: "task not found"})
+		return
+	}
+	writeRPC(w, req.ID, map[string]any{"id": p.ID, "pushNotificationConfig": p.PushNotificationConfig}, nil)
+	go d.deliverPush(p.ID, task)
+}
+
+func (d *dispatcher) getPushConfig(w http.ResponseWriter, req rpcRequest) {
+	var p getParams
+	if err := json.Unmarshal(req.Params, &p); err != nil || p.ID == "" {
+		writeRPC(w, req.ID, nil, &rpcError{Code: errInvalidParams, Message: "invalid params"})
+		return
+	}
+	d.mu.Lock()
+	cfg, ok := d.pushConfigs[p.ID]
+	d.mu.Unlock()
+	if !ok {
+		writeRPC(w, req.ID, nil, &rpcError{Code: errTaskNotFound, Message: "push notification config not found"})
+		return
+	}
+	writeRPC(w, req.ID, map[string]any{"id": p.ID, "pushNotificationConfig": cfg}, nil)
 }
 
 // ---------------------------------------------------------------------------
@@ -615,30 +672,55 @@ func (g *Gateway) callAgent(ctx context.Context, name, message string) (string, 
 
 func (d *dispatcher) store(t *Task) {
 	d.mu.Lock()
-	defer d.mu.Unlock()
 	d.tasks[t.ID] = t
 	d.order = append(d.order, t.ID)
 	for len(d.order) > maxTasks {
 		oldest := d.order[0]
 		d.order = d.order[1:]
 		delete(d.tasks, oldest)
+		delete(d.pushConfigs, oldest)
 	}
+	d.mu.Unlock()
+	go d.deliverPush(t.ID, t)
 }
 
-func taskFromReply(input Message, reply, state string) *Task {
+func (d *dispatcher) taskFromReply(input Message, reply, state string) *Task {
 	contextID := input.ContextID
+	taskID := input.TaskID
+	var history []Message
+	if taskID != "" {
+		d.mu.Lock()
+		prev := d.tasks[taskID]
+		if prev != nil {
+			contextID = prev.ContextID
+			history = append(history, prev.History...)
+		}
+		d.mu.Unlock()
+	}
+	if taskID == "" {
+		taskID = uuid.New().String()
+	}
 	if contextID == "" {
 		contextID = uuid.New().String()
 	}
-	return taskFromReplyWithIDs(input, reply, state, uuid.New().String(), contextID)
+	return taskFromReplyWithIDsAndHistory(input, reply, state, taskID, contextID, history)
 }
 
 func taskFromReplyWithIDs(input Message, reply, state, taskID, contextID string) *Task {
+	return taskFromReplyWithIDsAndHistory(input, reply, state, taskID, contextID, nil)
+}
+
+func taskFromReplyWithIDsAndHistory(input Message, reply, state, taskID, contextID string, history []Message) *Task {
+	input.TaskID = taskID
+	input.ContextID = contextID
+	if input.Kind == "" {
+		input.Kind = "message"
+	}
 	task := &Task{
 		ID:        taskID,
 		ContextID: contextID,
 		Kind:      "task",
-		History:   []Message{input},
+		History:   append(append([]Message{}, history...), input),
 		Status:    TaskStatus{State: state, Timestamp: time.Now().UTC().Format(time.RFC3339)},
 		Artifacts: []Artifact{textArtifact(reply)},
 	}
@@ -651,6 +733,33 @@ func taskFromReplyWithIDs(input Message, reply, state, taskID, contextID string)
 		Kind:      "message",
 	})
 	return task
+}
+
+func (d *dispatcher) deliverPush(taskID string, task *Task) {
+	d.mu.Lock()
+	cfg, ok := d.pushConfigs[taskID]
+	d.mu.Unlock()
+	if !ok || cfg.URL == "" || task == nil {
+		return
+	}
+	body, err := json.Marshal(task)
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.URL, strings.NewReader(string(body)))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if cfg.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
 }
 
 func textOf(parts []Part) string {

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -120,6 +120,89 @@ func TestMessageSendAndGet(t *testing.T) {
 	}
 }
 
+func TestMessageSendContinuesExistingTask(t *testing.T) {
+	d := newDispatcher()
+	first := rpcTaskFromBody(t, d, `{
+		"jsonrpc":"2.0","id":1,"method":"message/send",
+		"params":{"message":{"role":"user","kind":"message","messageId":"m1",
+			"parts":[{"kind":"text","text":"first"}]}}}`, func(_ context.Context, text string) (string, error) {
+		return "reply to " + text, nil
+	})
+
+	secondBody := fmt.Sprintf(`{
+		"jsonrpc":"2.0","id":2,"method":"message/send",
+		"params":{"message":{"role":"user","kind":"message","messageId":"m2","taskId":"%s","contextId":"%s",
+			"parts":[{"kind":"text","text":"second"}]}}}`, first.ID, first.ContextID)
+	second := rpcTaskFromBody(t, d, secondBody, func(_ context.Context, text string) (string, error) {
+		return "reply to " + text, nil
+	})
+
+	if second.ID != first.ID || second.ContextID != first.ContextID {
+		t.Fatalf("continued task identity = %s/%s, want %s/%s", second.ID, second.ContextID, first.ID, first.ContextID)
+	}
+	if len(second.History) != 4 {
+		t.Fatalf("continued history len = %d, want 4: %+v", len(second.History), second.History)
+	}
+	if textOf(second.History[0].Parts) != "first" || textOf(second.History[2].Parts) != "second" {
+		t.Fatalf("continued history did not preserve turns: %+v", second.History)
+	}
+
+	got := rpcTaskFromDispatcher(t, d, first.ID)
+	if got.ID != first.ID || len(got.History) != 4 {
+		t.Fatalf("stored continued task = %+v", got)
+	}
+}
+
+func TestPushNotificationConfigDeliversTaskUpdates(t *testing.T) {
+	d := newDispatcher()
+	updates := make(chan Task, 2)
+	push := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Errorf("authorization = %q, want bearer token", got)
+		}
+		var task Task
+		if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
+			t.Errorf("decode push task: %v", err)
+			return
+		}
+		updates <- task
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer push.Close()
+
+	task := rpcTaskFromBody(t, d, `{
+		"jsonrpc":"2.0","id":1,"method":"message/send",
+		"params":{"message":{"role":"user","kind":"message","messageId":"m1",
+			"parts":[{"kind":"text","text":"ping"}]}}}`, func(_ context.Context, text string) (string, error) {
+		return "pong", nil
+	})
+
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","id":2,"method":"tasks/pushNotificationConfig/set","params":{"id":"%s","pushNotificationConfig":{"url":"%s","token":"secret"}}}`, task.ID, push.URL)
+	var setResp struct {
+		Result struct {
+			ID                     string                 `json:"id"`
+			PushNotificationConfig PushNotificationConfig `json:"pushNotificationConfig"`
+		} `json:"result"`
+		Error *rpcError `json:"error"`
+	}
+	rpcDispatcher(t, d, body, nil, &setResp)
+	if setResp.Error != nil {
+		t.Fatalf("set push config error: %+v", setResp.Error)
+	}
+	if setResp.Result.ID != task.ID || setResp.Result.PushNotificationConfig.URL != push.URL {
+		t.Fatalf("set push config result = %+v", setResp.Result)
+	}
+
+	select {
+	case got := <-updates:
+		if got.ID != task.ID || got.Status.State != stateCompleted || textOf(got.Artifacts[0].Parts) != "pong" {
+			t.Fatalf("push update = %+v, want completed task", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for push update")
+	}
+}
+
 func TestMessageSendUsesRequestContext(t *testing.T) {
 	d := newDispatcher()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -293,6 +376,29 @@ func rpcTaskFromDispatcher(t *testing.T, d *dispatcher, id string) Task {
 		t.Fatalf("tasks/get error: %+v", resp.Error)
 	}
 	return resp.Result
+}
+
+func rpcTaskFromBody(t *testing.T, d *dispatcher, body string, invoke Invoke) Task {
+	t.Helper()
+	var resp struct {
+		Result Task      `json:"result"`
+		Error  *rpcError `json:"error"`
+	}
+	rpcDispatcher(t, d, body, invoke, &resp)
+	if resp.Error != nil {
+		t.Fatalf("rpc error: %+v", resp.Error)
+	}
+	return resp.Result
+}
+
+func rpcDispatcher(t *testing.T, d *dispatcher, body string, invoke Invoke, v any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	d.serve(rr, req, invoke)
+	if err := json.NewDecoder(rr.Result().Body).Decode(v); err != nil {
+		t.Fatalf("decode dispatcher response: %v", err)
+	}
 }
 
 func TestUnknownMethod(t *testing.T) {

--- a/gateway/a2a/client.go
+++ b/gateway/a2a/client.go
@@ -60,14 +60,37 @@ func (c *Client) Card(ctx context.Context) (*AgentCard, error) {
 // If the agent returns a task that isn't yet terminal, Send polls
 // tasks/get until it completes or ctx is done.
 func (c *Client) Send(ctx context.Context, text string) (string, error) {
-	res, err := c.call(ctx, "message/send", sendParams{Message: Message{
+	task, err := c.SendMessage(ctx, Message{
 		Role:      "user",
 		Kind:      "message",
 		MessageID: uuid.New().String(),
 		Parts:     []Part{{Kind: "text", Text: text}},
-	}})
+	})
 	if err != nil {
 		return "", err
+	}
+	if task.Status.State != stateCompleted {
+		return "", fmt.Errorf("remote task %s ended in state %q", task.ID, task.Status.State)
+	}
+	return artifactsText(task.Artifacts), nil
+}
+
+// SendMessage sends an A2A message and returns the resulting terminal task.
+// To continue a multi-turn task, pass a Message with TaskID and ContextID set
+// to a prior task's id and context id.
+func (c *Client) SendMessage(ctx context.Context, message Message) (*Task, error) {
+	if message.MessageID == "" {
+		message.MessageID = uuid.New().String()
+	}
+	if message.Kind == "" {
+		message.Kind = "message"
+	}
+	if message.Role == "" {
+		message.Role = "user"
+	}
+	res, err := c.call(ctx, "message/send", sendParams{Message: message})
+	if err != nil {
+		return nil, err
 	}
 
 	// The result is a Message or a Task; the "kind" field disambiguates.
@@ -79,33 +102,61 @@ func (c *Client) Send(ctx context.Context, text string) (string, error) {
 	if probe.Kind == "message" {
 		var m Message
 		if err := json.Unmarshal(res, &m); err != nil {
-			return "", err
+			return nil, err
 		}
-		return textOf(m.Parts), nil
+		return &Task{
+			ID:        m.TaskID,
+			ContextID: m.ContextID,
+			Kind:      "task",
+			Status:    TaskStatus{State: stateCompleted, Timestamp: time.Now().UTC().Format(time.RFC3339)},
+			Artifacts: []Artifact{textArtifact(textOf(m.Parts))},
+			History:   []Message{m},
+		}, nil
 	}
 
 	var task Task
 	if err := json.Unmarshal(res, &task); err != nil {
-		return "", err
+		return nil, err
 	}
 	for !terminal(task.Status.State) {
 		select {
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return nil, ctx.Err()
 		case <-time.After(300 * time.Millisecond):
 		}
 		got, err := c.call(ctx, "tasks/get", getParams{ID: task.ID})
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		if err := json.Unmarshal(got, &task); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
-	if task.Status.State != stateCompleted {
-		return "", fmt.Errorf("remote task %s ended in state %q", task.ID, task.Status.State)
+	return &task, nil
+}
+
+// SetPushNotificationConfig asks the remote agent to POST updates for taskID to cfg.URL.
+func (c *Client) SetPushNotificationConfig(ctx context.Context, taskID string, cfg PushNotificationConfig) error {
+	_, err := c.call(ctx, "tasks/pushNotificationConfig/set", pushConfigParams{
+		ID:                     taskID,
+		PushNotificationConfig: cfg,
+	})
+	return err
+}
+
+// PushNotificationConfig returns the remote push notification config for taskID.
+func (c *Client) PushNotificationConfig(ctx context.Context, taskID string) (PushNotificationConfig, error) {
+	res, err := c.call(ctx, "tasks/pushNotificationConfig/get", getParams{ID: taskID})
+	if err != nil {
+		return PushNotificationConfig{}, err
 	}
-	return artifactsText(task.Artifacts), nil
+	var out struct {
+		PushNotificationConfig PushNotificationConfig `json:"pushNotificationConfig"`
+	}
+	if err := json.Unmarshal(res, &out); err != nil {
+		return PushNotificationConfig{}, err
+	}
+	return out.PushNotificationConfig, nil
 }
 
 // call performs one JSON-RPC request and returns the raw result.

--- a/gateway/a2a/client_test.go
+++ b/gateway/a2a/client_test.go
@@ -2,8 +2,11 @@ package a2a
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 // An agent that embeds NewAgentHandler is directly A2A-queryable — no
@@ -46,5 +49,64 @@ func TestClientSendAndCard(t *testing.T) {
 	}
 	if reply != "pong" {
 		t.Errorf("Send reply = %q, want pong", reply)
+	}
+}
+
+func TestClientContinuesTaskAndConfiguresPush(t *testing.T) {
+	card := Card("solo", "http://localhost:4000", "", []string{"task"})
+	h := NewAgentHandler(card, func(_ context.Context, text string) (string, error) {
+		return "echo:" + text, nil
+	})
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	updates := make(chan Task, 1)
+	push := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var task Task
+		if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
+			t.Errorf("decode push task: %v", err)
+			return
+		}
+		updates <- task
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer push.Close()
+
+	cl := NewClient(ts.URL)
+	first, err := cl.SendMessage(context.Background(), Message{
+		Parts: []Part{{Kind: "text", Text: "one"}},
+	})
+	if err != nil {
+		t.Fatalf("first SendMessage: %v", err)
+	}
+	second, err := cl.SendMessage(context.Background(), Message{
+		TaskID:    first.ID,
+		ContextID: first.ContextID,
+		Parts:     []Part{{Kind: "text", Text: "two"}},
+	})
+	if err != nil {
+		t.Fatalf("second SendMessage: %v", err)
+	}
+	if second.ID != first.ID || second.ContextID != first.ContextID || len(second.History) != 4 {
+		t.Fatalf("continued task = %+v, first %+v", second, first)
+	}
+	cfg := PushNotificationConfig{URL: push.URL}
+	if err := cl.SetPushNotificationConfig(context.Background(), second.ID, cfg); err != nil {
+		t.Fatalf("SetPushNotificationConfig: %v", err)
+	}
+	got, err := cl.PushNotificationConfig(context.Background(), second.ID)
+	if err != nil {
+		t.Fatalf("PushNotificationConfig: %v", err)
+	}
+	if got.URL != push.URL {
+		t.Fatalf("PushNotificationConfig URL = %q, want %q", got.URL, push.URL)
+	}
+	select {
+	case update := <-updates:
+		if update.ID != second.ID {
+			t.Fatalf("push update ID = %q, want %q", update.ID, second.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for push update")
 	}
 }

--- a/internal/website/docs/guides/a2a-protocol.md
+++ b/internal/website/docs/guides/a2a-protocol.md
@@ -66,7 +66,7 @@ A card looks like:
   "url": "https://agents.example.com/agents/task-mgr",
   "version": "1.0.0",
   "protocolVersion": "0.3.0",
-  "capabilities": { "streaming": false, "pushNotifications": false },
+  "capabilities": { "streaming": true, "pushNotifications": true },
   "defaultInputModes": ["text/plain"],
   "defaultOutputModes": ["text/plain"],
   "skills": [{ "id": "chat", "name": "Chat", "tags": ["task", "project"] }]
@@ -100,7 +100,40 @@ curl -s https://agents.example.com/agents/task-mgr \
 }
 ```
 
-Retrieve a task later with `tasks/get` (`params: { "id": "…" }`).
+Retrieve a task later with `tasks/get` (`params: { "id": "…" }`). To continue
+the same piece of work, send another `message/send` with the previous `taskId`
+and `contextId`. The gateway preserves the task id, context id, and prior
+history, then appends the new user turn and agent reply. That makes a remote
+A2A task fit the Go Micro lifecycle: services are still invoked through the
+agent's normal tools, the agent keeps task context across turns, and a workflow
+can poll one task id as the conversation progresses.
+
+## Push notifications
+
+Operators can register a task callback with
+`tasks/pushNotificationConfig/set`:
+
+```bash
+curl -s https://agents.example.com/agents/task-mgr \
+  -H 'content-type: application/json' \
+  -d '{
+    "jsonrpc": "2.0", "id": 2,
+    "method": "tasks/pushNotificationConfig/set",
+    "params": {
+      "id": "task-id",
+      "pushNotificationConfig": {
+        "url": "https://workflow.example.com/a2a/tasks",
+        "token": "optional-bearer-token"
+      }
+    }
+  }'
+```
+
+The gateway stores one callback per retained task and POSTs the latest task
+snapshot to that URL whenever the task changes. Delivery is best effort: failures
+do not fail the agent turn, and there is no retry queue in the in-memory gateway.
+Use `tasks/get` as the source of truth after a missed callback or receiver
+outage. If a token is configured, it is sent as `Authorization: Bearer <token>`.
 
 ## Calling out to other agents
 
@@ -132,11 +165,13 @@ yet terminal, it polls `tasks/get` until it completes.
 
 ## Scope
 
-This is the JSON-RPC binding for completed-task execution:
+This is the JSON-RPC binding for task execution:
 
 - **`message/send`** runs the agent and returns a completed `Task`.
 - **`message/stream`** streams the completed `Task` as an SSE `data:` event, giving A2A clients a streaming-compatible path while the underlying agent call remains synchronous.
 - **`tasks/get`** returns a recent task by id.
+- **Multi-turn continuation** keeps task state when a new message includes the previous `taskId`.
+- **`tasks/pushNotificationConfig/set` / `get`** stores and reads a task callback for best-effort update delivery.
 - **Agent Card** discovery, generated from the registry.
 
 Both directions work: the gateway exposes your agents, and `a2a.Client` (via `flow.A2A` or `delegate` to a URL) calls external ones.
@@ -145,9 +180,9 @@ Not yet supported (advertised as such on the card, so clients negotiate correctl
 
 - **`tasks/resubscribe`** for reconnecting to a live stream.
 - Multi-turn `input-required` tasks.
-- Push notifications.
 
-These are the natural follow-ups; the completed-task binding is what makes a Go Micro agent both reachable from, and able to reach, the A2A ecosystem today.
+These are the natural follow-ups; the task binding is what makes a Go Micro
+agent both reachable from, and able to reach, the A2A ecosystem today.
 
 ## See also
 


### PR DESCRIPTION
Summary:
- Add A2A multi-turn task continuation that preserves task ids, context ids, and prior history.
- Add best-effort A2A push notification config set/get support and client helpers.
- Document task state, callbacks, and failure behavior.

Testing:
- go build ./...
- go test ./... (environment warnings: loopback gRPC tests blocked by envoy; one generated-template dependency download returned proxy 502)
- golangci-lint run ./...

Closes #3212
Closes #3225