### PR TITLE
Refresh roadmap after A2A task support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,8 @@ The full, current roadmap lives at **[go-micro.dev/docs/roadmap](https://go-micr
 ## Where we are (v6)
 
 Services, agents (`plan`/`delegate`, guardrails, memory, tool middleware), durable
-flows, the MCP and A2A gateways (both directions), x402 paid tools, secure by
+flows, the MCP and A2A gateways (both directions, including A2A streaming,
+push notifications, and multi-turn continuation), x402 paid tools, secure by
 default.
 
 ## Principles
@@ -41,14 +42,14 @@ default.
 ## Next — agentic depth
 
 - **Durable agent loop** — resume a long run via `Checkpoint` (flows already do).
-- **Streaming** — `ai.Stream` + A2A `message/stream`, end to end.
+- **Streaming** — broaden provider-backed `ai.Stream` coverage and keep chat/A2A streaming end to end.
 - **Agent observability** — `RunInfo` → OpenTelemetry spans.
 
 ## Later
 
 - Memory management (summarization, retrieval/RAG); human-in-the-loop pause/resume;
-  x402 live-facilitator conformance and paid remote tools with spend caps; A2A
-  streaming, push notifications, and multi-turn tasks.
+  richer A2A live-stream reconnection (`tasks/resubscribe`) and `input-required`
+  handoffs.
 
 ## Developer experience (ongoing)
 

--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,12 +21,9 @@ changes, architectural rewrites. Those go to the human.
 
 ## Later (ranked)
 
-1. **A2A push notifications and multi-turn task support** (#3212) — extend the A2A
-   gateway/client path beyond streaming lifecycle updates into push and multi-turn
-   task state. Roadmap → A2A push notifications and multi-turn tasks; now the
-   highest-value remaining item because x402 spend caps and live facilitator
-   conformance have shipped, leaving deeper agent-to-agent task continuity as the
-   clearest remaining interop gap for long-running, cross-runtime work.
+No open queued items. The previous top item, **A2A push notifications and
+multi-turn task support** (#3212), is closed; the next architecture-review pass
+should seed a fresh issue-backed item from the roadmap and improvement radar.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._

--- a/internal/website/docs/roadmap.md
+++ b/internal/website/docs/roadmap.md
@@ -13,7 +13,7 @@ The foundation is in place:
 - **Services** — register, discover, RPC, events; every endpoint is automatically an MCP tool.
 - **Agents** — a model with memory and tools that manages services, with `plan`, `delegate`, and guardrails (`MaxSteps`, `LoopLimit`, `ApproveTool`) built in, plus tool-execution middleware (`WrapTool`) and run metadata.
 - **Flows** — durable, event-driven workflows: ordered steps that checkpoint and resume after a crash.
-- **Interop** — the MCP gateway (services as tools) and the A2A gateway (agents as agents, both directions), both generated from the registry; x402 for paid tools.
+- **Interop** — the MCP gateway (services as tools) and the A2A gateway (agents as agents, both directions, including A2A streaming, push notifications, and multi-turn continuation), both generated from the registry; x402 for paid tools.
 - **Secure by default** — TLS verification on, state scoped per component.
 
 ## Principles
@@ -37,15 +37,14 @@ The priority is that what exists works everywhere, under real conditions.
 ## Next — agentic depth
 
 - **Durable agent loop.** Flows resume; the agent's own loop does not yet. Reuse `Checkpoint` so a long-running agent survives a restart and continues.
-- **Streaming.** `ai.Stream` is stubbed across providers; real chat and long-task UX need it, end to end through A2A `message/stream`.
+- **Streaming.** Broaden provider-backed `ai.Stream` coverage and keep chat plus A2A `message/stream` working end to end for real chat and long-task UX.
 - **Agent observability.** Wire the new `RunInfo` into OpenTelemetry spans so a run — steps, tool calls, delegation — is traceable. This is also what anyone running it in production will need.
 
 ## Later
 
 - **Memory management** — summarization and retrieval (RAG) beyond a fixed buffer.
 - **Human-in-the-loop** — pause and resume mid-run (`input-required`), beyond the binary `ApproveTool` gate.
-- **x402** — conformance against a live facilitator; paid remote tools as agent tools with spend caps.
-- **A2A** — streaming, push notifications, multi-turn tasks.
+- **A2A** — richer live-stream reconnection (`tasks/resubscribe`) and `input-required` handoffs.
 
 ## Developer experience (ongoing)
 


### PR DESCRIPTION
## Summary
- Mark A2A streaming, push notifications, and multi-turn continuation as shipped in roadmap docs.
- Update remaining A2A roadmap scope to focus on resubscribe and input-required handoffs.
- Clear the stale priority queue item because #3212 is already closed.

## Testing
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./... (default timeout exceeded during package loading)
- golangci-lint run --timeout 10m ./...

Closes #3228