### PR TITLE
Update architect priorities after A2A continuation

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -19,11 +19,14 @@ redirect the loop; direction always wins.
 items the loop can auto-merge): brand/positioning copy, breaking public-API
 changes, architectural rewrites. Those go to the human.
 
+## Now (ranked)
+
+1. **Harden agent model-call resilience** ([#3233](https://github.com/micro/go-micro/issues/3233)) — complete the remaining hardening seam from the roadmap: deadline/cancellation propagation, bounded retry/backoff, and inspectable timeout/rate-limit/cancellation outcomes for the agent loop. This is the highest-value next item because durable runs, streaming, observability, memory, HITL, x402, and A2A continuation now exist; the shared operational harness still needs to fail safely under real provider conditions.
+2. **CI-verify the 0-to-1 getting-started path** ([#3234](https://github.com/micro/go-micro/issues/3234)) — add a deterministic no-key check for scaffold → run/build → call so the README/blog promise that building a service stays effortless cannot regress while the agent stack deepens.
+
 ## Later (ranked)
 
-No open queued items. The previous top item, **A2A push notifications and
-multi-turn task support** (#3212), is closed; the next architecture-review pass
-should seed a fresh issue-backed item from the roadmap and improvement radar.
+3. **Add A2A resubscribe and input-required handoff support** ([#3235](https://github.com/micro/go-micro/issues/3235)) — after push notifications and multi-turn continuation shipped, finish the remaining long-running A2A interoperability gap: reconnecting to live task streams and carrying human-input-required handoffs through the gateway.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:
- Re-seeds the architect-maintained priority queue after the previous A2A task-support item closed.
- Ranks model-call resilience first, 0-to-1 CI verification second, and A2A resubscribe/input-required handoffs third.
- Filed scoped issues #3233, #3234, and #3235 for the queued work.

Testing:
- go build ./...
- go test ./... (environment loopback restriction blocks grpc loopback tests)
- golangci-lint run ./...

Closes #3232