### PR TITLE
Update architect priorities after conformance

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,13 +21,12 @@ changes, architectural rewrites. Those go to the human.
 
 ## Now (ranked)
 
-1. **Add cross-provider agent conformance checks** ([#3240](https://github.com/micro/go-micro/issues/3240)) — the resilience seam closed, so the next highest-value hardening gap is proving one representative agent/tool scenario across providers with key-gated CI/scheduled checks. This protects the harness promise that agents behave consistently on one runtime even as provider adapters evolve.
-2. **CI-verify the 0-to-1 getting-started path** ([#3234](https://github.com/micro/go-micro/issues/3234)) — add a deterministic no-key check for scaffold → run/build → call so the README/blog promise that building a service stays effortless cannot regress while the agent stack deepens.
-3. **CI-verify the 0-to-hero agent workflow** ([#3241](https://github.com/micro/go-micro/issues/3241)) — after the basic service contract is guarded, make the full services → agents → workflows story executable in CI with a maintained no-secret reference scenario for run → chat → inspect boundaries.
+1. **CI-verify the 0-to-1 getting-started path** ([#3234](https://github.com/micro/go-micro/issues/3234)) — add a deterministic no-key check for scaffold → run/build → call so the README/blog promise that building a service stays effortless cannot regress while the agent stack deepens.
+2. **CI-verify the 0-to-hero agent workflow** ([#3241](https://github.com/micro/go-micro/issues/3241)) — after the basic service contract is guarded, make the full services → agents → workflows story executable in CI with a maintained no-secret reference scenario for run → chat → inspect boundaries.
 
 ## Later (ranked)
 
-4. **Add A2A resubscribe and input-required handoff support** ([#3235](https://github.com/micro/go-micro/issues/3235)) — after push notifications and multi-turn continuation shipped, finish the remaining long-running A2A interoperability gap: reconnecting to live task streams and carrying human-input-required handoffs through the gateway.
+3. **Add A2A resubscribe and input-required handoff support** ([#3235](https://github.com/micro/go-micro/issues/3235)) — after push notifications and multi-turn continuation shipped, finish the remaining long-running A2A interoperability gap: reconnecting to live task streams and carrying human-input-required handoffs through the gateway.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:
- Remove the completed cross-provider conformance queue item after #3244 closed #3240.
- Promote the remaining open items so the queue reflects the next hardening priorities.

Testing:
- go build ./... (passed before go test in chained verification)
- go test ./... (fails in client/grpc in this environment: Loopback targets forbidden)
- golangci-lint run ./... (passed)

Closes #3245