### PR TITLE
CI-verify the zero-to-hero agent workflow

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -33,8 +33,8 @@ jobs:
         run: go run ./internal/harness/universe
       - name: Agent-flow harness
         run: go run ./internal/harness/agent-flow
-      - name: 0→hero plan-delegate workflow harness
-        run: go run ./internal/harness/plan-delegate
+      - name: 0→hero run/chat/inspect reference scenario
+        run: ./internal/harness/zero-to-hero-ci/run.sh
 
   harness-live:
     name: Provider harnesses (live LLM conformance)

--- a/cmd/micro/zero_to_hero_cli_test.go
+++ b/cmd/micro/zero_to_hero_cli_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	microcmd "go-micro.dev/v6/cmd"
+)
+
+func TestZeroToHeroCLIBoundaries(t *testing.T) {
+	commands := map[string]bool{}
+	subcommands := map[string]map[string]bool{}
+	for _, command := range microcmd.DefaultCmd.App().Commands {
+		commands[command.Name] = true
+		for _, subcommand := range command.Subcommands {
+			if subcommands[command.Name] == nil {
+				subcommands[command.Name] = map[string]bool{}
+			}
+			subcommands[command.Name][subcommand.Name] = true
+		}
+	}
+
+	for _, want := range []string{"run", "chat", "flow"} {
+		if !commands[want] {
+			t.Fatalf("missing %q command", want)
+		}
+	}
+	if !subcommands["flow"]["runs"] {
+		t.Fatal("missing inspect boundary: flow runs")
+	}
+}

--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -1,0 +1,16 @@
+# 0→hero CI harness
+
+This directory owns the no-secret reference scenario for the Go Micro
+services → agents → workflows lifecycle. It is intentionally small and
+scripted so CI can run it on every push without external services or model keys.
+
+`run.sh` verifies three boundaries together:
+
+1. **Run** — `micro run` remains available as the local development entry point.
+2. **Chat** — `micro chat` remains available as the interactive agent entry point.
+3. **Inspect** — `micro flow runs` remains available for durable workflow run
+   history inspection.
+
+After the CLI boundary smoke checks, the script runs the deterministic harnesses
+that boot real services, agents, workflows, store-backed run history, and A2A
+with only the LLM mocked.

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+# Keep the developer inner-loop boundaries executable and discoverable in CI
+# without secrets or long-running daemons.
+go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1
+
+# Deterministic no-secret reference scenarios. These use the real Go Micro
+# runtime and mock only the LLM provider.
+go test ./internal/harness/universe ./internal/harness/plan-delegate -run 'Test.*Harness|TestPlanDelegateEndToEnd|TestPlanDelegateFlowHandoff' -count=1


### PR DESCRIPTION
## Summary
- Add a maintained no-secret 0→hero CI reference scenario for the services → agents → workflows lifecycle.
- Smoke-test the CLI run/chat/inspect boundaries via registered commands.
- Wire the harness workflow to run the reference scenario on push and PR.

Closes #3241
Closes #3251

## Testing
- go build ./...
- go test ./... (fails in this sandbox: loopback gRPC connections are blocked by envoy)
- ./internal/harness/zero-to-hero-ci/run.sh
- golangci-lint run ./...