### PR TITLE
Add agent tool checkpoint replay protection

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -92,6 +92,11 @@ type agentImpl struct {
 	// Ask. The model provider only sees a refused tool result; the agent
 	// converts it into a durable paused run instead of completing the run.
 	pause *approvalPause
+
+	// currentRun points at the checkpoint record for the Ask currently
+	// holding mu. Tool execution updates it so resumed runs can reuse
+	// completed tool results without replaying side effects.
+	currentRun *flow.Run
 }
 
 // New creates a new Agent.
@@ -253,6 +258,8 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		Agent:    a.opts.Name,
 	})
 	run := a.newCheckpointRun(runID, message, parentRunID, existing)
+	a.currentRun = &run
+	defer func() { a.currentRun = nil }()
 	if err := a.saveRun(ctx, run); err != nil {
 		return nil, err
 	}
@@ -283,6 +290,9 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		run.Status = "failed"
 		run.Steps[0].Status = "failed"
 		run.Steps[0].Error = err.Error()
+		if a.currentRun != nil {
+			run.Steps = a.currentRun.Steps
+		}
 		_ = a.saveRun(ctx, run)
 		return nil, err
 	}
@@ -325,6 +335,12 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 	run.State.Stage = ""
 	if b, marshalErr := json.Marshal(res); marshalErr == nil {
 		run.State.Data = b
+	}
+	if a.currentRun != nil {
+		run.Steps = a.currentRun.Steps
+	}
+	if len(run.Steps) == 0 {
+		run.Steps = []flow.StepRecord{{Name: agentAskStep}}
 	}
 	run.Steps[0].Status = "done"
 	run.Steps[0].Attempts++

--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -102,8 +102,9 @@ func (a *agentImpl) toolHandler() ai.ToolHandler {
 
 	// Innermost first: base, then guardrails (approve → loop → step →
 	// plan), then developer wrappers outermost. Wrapping reverses order,
-	// so the result runs plan → step → loop → approve → base.
+	// so the result runs plan → step → loop → approve → checkpoint → base.
 	h := a.baseHandler()
+	h = a.checkpointToolWrap(h)
 	h = a.approveWrap(h)
 	h = a.loopWrap(h)
 	h = a.stepWrap(h)

--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/flow"
 )
 
@@ -35,6 +36,7 @@ func (a *agentImpl) newCheckpointRun(runID, message, parentRunID string, existin
 		}
 		run.Steps[0].Status = "in_progress"
 		run.Steps[0].Error = ""
+		run.Steps[0].Result = ""
 	}
 	return run
 }
@@ -96,4 +98,61 @@ func (a *agentImpl) pending(ctx context.Context) ([]flow.Run, error) {
 		}
 	}
 	return out, nil
+}
+
+func (a *agentImpl) checkpointToolWrap(next ai.ToolHandler) ai.ToolHandler {
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		if a.opts.Checkpoint == nil || a.currentRun == nil {
+			return next(ctx, call)
+		}
+		name := toolCheckpointName(call)
+		if rec, ok := findStep(a.currentRun.Steps, name); ok && rec.Status == "done" {
+			return ai.ToolResult{ID: call.ID, Value: rec.Result, Content: rec.Result}
+		}
+
+		idx := upsertStep(&a.currentRun.Steps, flow.StepRecord{Name: name, Status: "in_progress"})
+		_ = a.saveRun(ctx, *a.currentRun)
+		res := next(ctx, call)
+		a.currentRun.Steps[idx].Attempts++
+		if res.Refused != "" {
+			a.currentRun.Steps[idx].Status = "failed"
+			a.currentRun.Steps[idx].Error = res.Content
+			_ = a.saveRun(ctx, *a.currentRun)
+			return res
+		}
+		a.currentRun.Steps[idx].Status = "done"
+		a.currentRun.Steps[idx].Result = res.Content
+		a.currentRun.Steps[idx].Error = ""
+		_ = a.saveRun(ctx, *a.currentRun)
+		return res
+	}
+}
+
+func toolCheckpointName(call ai.ToolCall) string {
+	b, _ := json.Marshal(call.Input)
+	return "tool:" + call.Name + ":" + string(b)
+}
+
+func findStep(steps []flow.StepRecord, name string) (flow.StepRecord, bool) {
+	for _, step := range steps {
+		if step.Name == name {
+			return step, true
+		}
+	}
+	return flow.StepRecord{}, false
+}
+
+func upsertStep(steps *[]flow.StepRecord, rec flow.StepRecord) int {
+	for i := range *steps {
+		if (*steps)[i].Name == rec.Name {
+			(*steps)[i].Status = rec.Status
+			(*steps)[i].Error = rec.Error
+			return i
+		}
+	}
+	if len(*steps) == 0 || (*steps)[0].Name != agentAskStep {
+		*steps = append([]flow.StepRecord{{Name: agentAskStep, Status: "in_progress"}}, (*steps)...)
+	}
+	*steps = append(*steps, rec)
+	return len(*steps) - 1
 }

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go-micro.dev/v6/ai"
@@ -45,6 +46,58 @@ func TestResumeCompletedCheckpointDoesNotReplayModel(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("model calls after Resume = %d, want 1", calls)
+	}
+}
+
+func TestResumeFailedCheckpointDoesNotReplayCompletedTool(t *testing.T) {
+	ctx := context.Background()
+	cp := flow.StoreCheckpoint(store.NewStore(), "tool-resume-agent")
+	toolRuns := 0
+	first := true
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if opts.ToolHandler != nil {
+			res := opts.ToolHandler(ctx, ai.ToolCall{ID: "call-1", Name: "external.charge", Input: map[string]any{"order": "42"}})
+			if res.Content != "charged" {
+				t.Fatalf("tool result = %q, want charged", res.Content)
+			}
+		}
+		if first {
+			first = false
+			return nil, errors.New("model connection dropped after tool")
+		}
+		return &ai.Response{Reply: "finished from checkpoint"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("tool-resume-agent"), WithCheckpoint(cp),
+		WithTool("external.charge", "charge once", nil, func(context.Context, map[string]any) (string, error) {
+			toolRuns++
+			return "charged", nil
+		}))
+	_, err := a.Ask(ctx, "charge order 42")
+	if err == nil {
+		t.Fatal("Ask succeeded, want simulated failure")
+	}
+	if toolRuns != 1 {
+		t.Fatalf("tool executions after failed Ask = %d, want 1", toolRuns)
+	}
+
+	runs, err := Pending(ctx, a)
+	if err != nil {
+		t.Fatalf("Pending: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("Pending returned %d runs, want 1", len(runs))
+	}
+	resp, err := Resume(ctx, a, runs[0].ID)
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resp.Reply != "finished from checkpoint" {
+		t.Fatalf("Resume reply = %q", resp.Reply)
+	}
+	if toolRuns != 1 {
+		t.Fatalf("tool executions after Resume = %d, want completed tool was not replayed", toolRuns)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Persist completed agent tool calls in checkpointed runs and reuse their results on resume so side effects are not replayed.
- Keep checkpoint run step records intact across failed/resumed asks.
- Add coverage for failed agent resume skipping already-completed tool execution.

Testing:
- go build ./...
- go test ./agent
- go test ./... (fails in this environment due loopback targets forbidden in grpc transport/client tests and a cache timing flake)
- golangci-lint run ./...

Closes #3254
Closes #3258