### PR TITLE
Emit agent run events on OTel spans

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -253,7 +253,38 @@ func (a *agentImpl) recordSpanEvent(span trace.Span, e RunEvent) {
 		e.TraceID = sc.TraceID().String()
 		e.SpanID = sc.SpanID().String()
 	}
+	span.AddEvent("agent."+e.Kind, trace.WithTimestamp(e.Time), trace.WithAttributes(runEventAttributes(e)...))
 	a.recordRunEvent(e)
+}
+
+func runEventAttributes(e RunEvent) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String(AttrRunID, e.RunID),
+		attribute.String(AttrAgentName, e.Agent),
+	}
+	if e.ParentID != "" {
+		attrs = append(attrs, attribute.String(AttrParentRunID, e.ParentID))
+	}
+	if e.Name != "" {
+		attrs = append(attrs, attribute.String("agent.event.name", e.Name))
+	}
+	if e.Provider != "" {
+		attrs = append(attrs, attribute.String(AttrProvider, e.Provider))
+	}
+	if e.Model != "" {
+		attrs = append(attrs, attribute.String(AttrModel, e.Model))
+	}
+	if e.LatencyMS > 0 {
+		attrs = append(attrs, attribute.Int64(AttrLatencyMS, e.LatencyMS))
+	}
+	attrs = appendUsage(attrs, e.Tokens)
+	if e.Refused != "" {
+		attrs = append(attrs, attribute.Bool(AttrGuardrailBlock, true), attribute.String(AttrRefusal, e.Refused))
+	}
+	if e.Error != "" {
+		attrs = append(attrs, attribute.String("agent.error", e.Error))
+	}
+	return attrs
 }
 
 func (a *agentImpl) recordRunEvent(e RunEvent) {

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -71,6 +71,16 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	if runID == "" {
 		t.Fatal("run span missing run id attribute")
 	}
+	var runEvents []trace.Event
+	for _, s := range spans {
+		if s.Name() == spanNameRun {
+			runEvents = s.Events()
+			break
+		}
+	}
+	if !spanEventHasRunInfo(runEvents, "agent.run", runID, "runner") || !spanEventHasRunInfo(runEvents, "agent.done", runID, "runner") {
+		t.Fatalf("run span missing run-info events: %#v", runEvents)
+	}
 	for _, s := range spans {
 		if s.Name() != spanNameModelCall && s.Name() != spanNameToolCall {
 			continue
@@ -113,6 +123,19 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	if len(events) == 0 || events[0].TraceID == "" || events[0].SpanID == "" {
 		t.Fatalf("events missing trace correlation: %#v", events)
 	}
+}
+
+func spanEventHasRunInfo(events []trace.Event, name, runID, agentName string) bool {
+	for _, event := range events {
+		if event.Name != name {
+			continue
+		}
+		attrs := spanAttributes(event.Attributes)
+		if attrs[AttrRunID] == runID && attrs[AttrAgentName] == agentName {
+			return true
+		}
+	}
+	return false
 }
 
 func spanAttributes(attrs []attribute.KeyValue) map[string]string {


### PR DESCRIPTION
Summary:
- Add OpenTelemetry span events for persisted agent run timeline events so run/done/error/model/tool records are visible directly on spans with RunInfo correlation attributes.
- Cover run span events in the agent OpenTelemetry test.

Testing:
- go build ./...
- go test ./agent
- go test ./... (fails in this environment because loopback gRPC targets are forbidden by the sandbox proxy)
- golangci-lint run ./...

Closes #3256
Closes #3266