### PR TITLE
Improve compacting memory recall ranking

### DIFF
--- a/agent/memory.go
+++ b/agent/memory.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -123,16 +124,30 @@ func (m *storeMemory) Recall(query string, limit int) []ai.Message {
 		limit = 5
 	}
 	terms := recallTerms(query)
-	var out []ai.Message
-	for i := len(m.archive) - 1; i >= 0 && len(out) < limit; i-- {
+	type match struct {
+		msg   ai.Message
+		score int
+		index int
+	}
+	matches := make([]match, 0, len(m.archive))
+	for i := len(m.archive) - 1; i >= 0; i-- {
 		msg := m.archive[i]
-		text := strings.ToLower(fmt.Sprint(msg.Content))
-		for _, term := range terms {
-			if strings.Contains(text, term) {
-				out = append(out, msg)
-				break
-			}
+		if score := recallScore(msg, terms); score > 0 {
+			matches = append(matches, match{msg: msg, score: score, index: i})
 		}
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].score != matches[j].score {
+			return matches[i].score > matches[j].score
+		}
+		return matches[i].index > matches[j].index
+	})
+	if len(matches) > limit {
+		matches = matches[:limit]
+	}
+	out := make([]ai.Message, 0, len(matches))
+	for _, match := range matches {
+		out = append(out, match.msg)
 	}
 	return out
 }
@@ -226,6 +241,17 @@ func compactText(s string, max int) string {
 		return s[:max] + "…"
 	}
 	return s
+}
+
+func recallScore(msg ai.Message, terms []string) int {
+	text := strings.ToLower(fmt.Sprint(msg.Content))
+	score := 0
+	for _, term := range terms {
+		if strings.Contains(text, term) {
+			score++
+		}
+	}
+	return score
 }
 
 func recallTerms(query string) []string {

--- a/agent/memory_test.go
+++ b/agent/memory_test.go
@@ -62,6 +62,46 @@ func TestWithMemoryUsed(t *testing.T) {
 	}
 }
 
+func TestCompactingMemoryRecallRanksSpecificMatches(t *testing.T) {
+	m := NewCompactingMemory(store.NewMemoryStore(), "agent/rank/history", 3, 1).(MemoryRecall)
+	writer := m.(Memory)
+	writer.Add("user", "alpha budget is 42")
+	writer.Add("assistant", "noted")
+	writer.Add("user", "beta budget is 7")
+	writer.Add("assistant", "noted")
+	writer.Add("user", "alpha owner is sam")
+
+	recalled := m.Recall("alpha budget", 2)
+	if len(recalled) == 0 {
+		t.Fatal("expected recalled messages")
+	}
+	if got := recalled[0].Content.(string); !strings.Contains(got, "alpha budget is 42") {
+		t.Fatalf("top recall = %q, want alpha budget match", got)
+	}
+}
+
+func TestCompactingMemoryArchivePersistsAndReloads(t *testing.T) {
+	st := store.NewMemoryStore()
+	m := NewCompactingMemory(st, "agent/reload/history", 3, 1)
+	m.Add("user", "alpha budget is 42")
+	m.Add("assistant", "noted")
+	m.Add("user", "beta budget is 7")
+	m.Add("assistant", "noted")
+
+	reloaded := NewCompactingMemory(st, "agent/reload/history", 3, 1)
+	recall, ok := reloaded.(MemoryRecall)
+	if !ok {
+		t.Fatal("compacting memory should support recall")
+	}
+	recalled := recall.Recall("alpha budget", 1)
+	if len(recalled) != 1 {
+		t.Fatalf("recalled %d messages, want 1", len(recalled))
+	}
+	if got := recalled[0].Content.(string); !strings.Contains(got, "alpha budget is 42") {
+		t.Fatalf("reloaded recall = %q, want alpha budget", got)
+	}
+}
+
 // A custom tool is offered to the model and dispatched to its handler.
 func TestWithToolExposedAndDispatched(t *testing.T) {
 	var got map[string]any


### PR DESCRIPTION
## Summary
- Rank compacted-memory recall candidates by the number of query-term matches, with recency as a deterministic tiebreaker.
- Add tests for specific recall ordering and persisted archive recall after reload.

Closes #3273
Closes #3275

## Testing
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- go test ./agent -run 'TestCompactingMemory' -count=1 -timeout=30s\n- golangci-lint run ./...