### PR TITLE
Update architect priorities after deploy contract

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,8 +21,7 @@ changes, architectural rewrites. Those go to the human.
 
 ## Developer experience (ranked)
 
-1. **CI-verify the deploy inner-loop contract** ([#3283](https://github.com/micro/go-micro/issues/3283)) — the roadmap's hardening and agentic-depth items have shipped, so the highest-value remaining seam is the last step of the promised CLI lifecycle: scaffold → run → chat → inspect → deploy. `micro deploy` exists, but the 0→hero guard currently checks run/chat/flow and inspect boundaries, not the deploy handoff; a hermetic deploy contract keeps the operational harness story cohesive without needing a real remote host.
-2. **Maintain a real-world 0-to-hero reference example** ([#3284](https://github.com/micro/go-micro/issues/3284)) — after the deploy boundary is guarded, the next developer-experience gap is a living example that proves services, agents, flows, and interop compose into an actual system. This should double as documentation and CI smoke coverage so the lived story stays aligned with the README, website, and blog canon.
+1. **Maintain a real-world 0-to-hero reference example** ([#3284](https://github.com/micro/go-micro/issues/3284)) — with the hardening, agentic-depth, and deploy inner-loop contract items now shipped, the highest-value remaining gap is a living example that proves services, agents, flows, and interop compose into an actual system. This should double as documentation and CI smoke coverage so the lived story stays aligned with the README, website, and blog canon.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:\n- Remove the completed deploy inner-loop priority after #3283 closed via #3287.\n- Keep #3284 as the top remaining 0→hero reference priority.\n\nTesting:\n- go build ./...\n- go test ./... (fails in this sandbox due loopback-forbidden grpc tests in client/grpc and transport/grpc)\n- golangci-lint run ./...\n\nCloses #3288