### PR TITLE
ai: add WithMaxTokens option

### DIFF
--- a/ai/anthropic/anthropic.go
+++ b/ai/anthropic/anthropic.go
@@ -77,7 +77,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 	// Build initial request
 	apiReq := map[string]any{
 		"model":      p.opts.Model,
-		"max_tokens": 8192,
+		"max_tokens": anthropicMaxTokens(p.opts),
 		"system":     req.SystemPrompt,
 		"messages":   threadAnthropicMessages(req),
 	}
@@ -124,7 +124,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 
 		followUpReq := map[string]any{
 			"model":      p.opts.Model,
-			"max_tokens": 8192,
+			"max_tokens": anthropicMaxTokens(p.opts),
 			"system":     req.SystemPrompt,
 			"messages":   messages,
 		}
@@ -281,4 +281,11 @@ func threadAnthropicMessages(req *ai.Request) []map[string]any {
 		msgs = append(msgs, map[string]any{"role": "user", "content": req.Prompt})
 	}
 	return msgs
+}
+
+func anthropicMaxTokens(o ai.Options) int {
+	if o.MaxTokens > 0 {
+		return o.MaxTokens
+	}
+	return 8192
 }

--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -103,6 +103,9 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		"model":    p.opts.Model,
 		"messages": messages,
 	}
+	if p.opts.MaxTokens > 0 {
+		apiReq["max_tokens"] = p.opts.MaxTokens
+	}
 
 	if len(tools) > 0 {
 		apiReq["tools"] = tools

--- a/ai/openai/openai.go
+++ b/ai/openai/openai.go
@@ -98,6 +98,9 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		"model":    p.opts.Model,
 		"messages": messages,
 	}
+	if p.opts.MaxTokens > 0 {
+		apiReq["max_tokens"] = p.opts.MaxTokens
+	}
 
 	if len(openaiTools) > 0 {
 		apiReq["tools"] = openaiTools
@@ -162,6 +165,9 @@ func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.Gener
 		"model":    p.opts.Model,
 		"messages": messages,
 		"stream":   true,
+	}
+	if p.opts.MaxTokens > 0 {
+		apiReq["max_tokens"] = p.opts.MaxTokens
 	}
 	reqBody, err := json.Marshal(apiReq)
 	if err != nil {

--- a/ai/options.go
+++ b/ai/options.go
@@ -16,6 +16,8 @@ type Options struct {
 	BaseURL string
 	// ToolHandler handles tool calls (optional, for automatic tool execution)
 	ToolHandler ToolHandler
+	// MaxTokens caps the length of the response (0 = provider default)
+	MaxTokens int
 }
 
 // GenerateOptions for generate call
@@ -89,5 +91,13 @@ func WithTools(t *Tools) Option {
 		if t != nil {
 			o.ToolHandler = t.Handler()
 		}
+	}
+}
+
+// WithMaxTokens caps the number of tokens in the response. 0 leaves the
+// provider default in place.
+func WithMaxTokens(n int) Option {
+	return func(o *Options) {
+		o.MaxTokens = n
 	}
 }


### PR DESCRIPTION
Adds an `Options.MaxTokens` field and `ai.WithMaxTokens(n)` so callers can cap response length. The atlascloud and openai providers (Generate + openai Stream) send `max_tokens` when set; anthropic uses it in place of its hardcoded 8192 default. No behaviour change when unset.

Needed to route token-capped background tasks through the ai package when dogfooding mu on go-micro.

---
_Generated by [Claude Code](https://claude.ai/code)_