### PR TITLE
Respect provider retry-after backoff hints

### DIFF
--- a/ai/retry.go
+++ b/ai/retry.go
@@ -13,6 +13,12 @@ type StatusCoder interface {
 	StatusCode() int
 }
 
+// RetryAfterCoder is implemented by provider errors that expose a server
+// supplied retry delay, such as HTTP Retry-After on a 429/503 response.
+type RetryAfterCoder interface {
+	RetryAfter() time.Duration
+}
+
 // ErrorKind classifies provider-boundary failures into stable buckets callers
 // can inspect without parsing provider-specific error strings.
 type ErrorKind string
@@ -113,16 +119,7 @@ func GenerateWithRetry(ctx context.Context, m Model, req *Request, policy Genera
 		// Always back off between retries — exponential and capped — so an
 		// opt-in retry can never become a tight loop hammering the provider,
 		// even if Backoff was left at zero.
-		backoff := policy.Backoff
-		if backoff <= 0 {
-			backoff = 200 * time.Millisecond
-		}
-		if shift := attempt - 1; shift > 0 {
-			backoff <<= shift
-		}
-		if backoff > 30*time.Second {
-			backoff = 30 * time.Second
-		}
+		backoff := retryBackoff(err, attempt, policy.Backoff)
 		t := time.NewTimer(backoff)
 		select {
 		case <-ctx.Done():
@@ -134,6 +131,30 @@ func GenerateWithRetry(ctx context.Context, m Model, req *Request, policy Genera
 		}
 	}
 	return nil, &RetryError{Attempts: policy.MaxAttempts, Kind: ClassifyError(last), Err: last}
+}
+
+func retryBackoff(err error, attempt int, base time.Duration) time.Duration {
+	backoff := base
+	if backoff <= 0 {
+		backoff = 200 * time.Millisecond
+	}
+	if shift := attempt - 1; shift > 0 {
+		backoff <<= shift
+	}
+	if backoff > 30*time.Second {
+		backoff = 30 * time.Second
+	}
+
+	var retryAfter RetryAfterCoder
+	if errors.As(err, &retryAfter) {
+		if delay := retryAfter.RetryAfter(); delay > backoff {
+			backoff = delay
+		}
+	}
+	if backoff > 30*time.Second {
+		return 30 * time.Second
+	}
+	return backoff
 }
 
 // ClassifyError maps provider and context failures to stable operational kinds.

--- a/ai/retry_test.go
+++ b/ai/retry_test.go
@@ -139,6 +139,14 @@ type statusErr int
 func (e statusErr) Error() string   { return "provider status" }
 func (e statusErr) StatusCode() int { return int(e) }
 
+type retryAfterErr struct {
+	delay time.Duration
+}
+
+func (e retryAfterErr) Error() string             { return "rate limit exceeded" }
+func (e retryAfterErr) StatusCode() int           { return 429 }
+func (e retryAfterErr) RetryAfter() time.Duration { return e.delay }
+
 func TestClassifyErrorDistinguishesOperationalOutcomes(t *testing.T) {
 	tests := []struct {
 		name string
@@ -179,5 +187,37 @@ func TestGenerateWithRetryExposesRetryErrorKind(t *testing.T) {
 	}
 	if !errors.Is(err, statusErr(429)) {
 		t.Fatalf("retry error does not unwrap provider status: %v", err)
+	}
+}
+
+func TestGenerateWithRetryHonorsRetryAfterWhenLongerThanBackoff(t *testing.T) {
+	attempts := 0
+	model := retryModel{generate: func(context.Context, *Request, ...GenerateOption) (*Response, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, retryAfterErr{delay: 25 * time.Millisecond}
+		}
+		return &Response{Reply: "ok"}, nil
+	}}
+
+	start := time.Now()
+	resp, err := GenerateWithRetry(context.Background(), model, &Request{Prompt: "hi"}, GeneratePolicy{
+		MaxAttempts: 2,
+		Backoff:     time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("GenerateWithRetry returned error: %v", err)
+	}
+	if resp.Reply != "ok" {
+		t.Fatalf("reply = %q, want ok", resp.Reply)
+	}
+	if elapsed := time.Since(start); elapsed < 20*time.Millisecond {
+		t.Fatalf("retry delay = %s, want RetryAfter delay to dominate base backoff", elapsed)
+	}
+}
+
+func TestGenerateWithRetryCapsRetryAfter(t *testing.T) {
+	if got := retryBackoff(retryAfterErr{delay: time.Minute}, 1, time.Millisecond); got != 30*time.Second {
+		t.Fatalf("retryBackoff() = %s, want 30s cap", got)
 	}
 }


### PR DESCRIPTION
Summary:
- Add a RetryAfterCoder interface so provider errors can expose server-supplied retry delays such as Retry-After.
- Apply Retry-After delays when they are longer than the configured exponential backoff, while preserving the existing 30s retry cap.
- Cover Retry-After delay and cap behavior in AI retry tests.

Testing:
- go test ./ai
- go build ./...
- go test ./... (fails in environment: atlascloud invalid token, loopback targets forbidden for grpc client/transport)
- golangci-lint run ./...

Closes #3296
Closes #3308