### PR TITLE
gateway/mcp: swappable Resolver + mountable JSON-RPC HTTP handler

### DIFF
--- a/gateway/mcp/httpjsonrpc.go
+++ b/gateway/mcp/httpjsonrpc.go
@@ -1,0 +1,89 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// NewHandler returns an http.Handler serving the MCP protocol over HTTP as
+// JSON-RPC 2.0 (initialize, ping, tools/list, tools/call), backed by the
+// resolver. Mount it on your own server (e.g. POST /mcp): the gateway provides
+// the protocol; you keep your routes, middleware and any human-facing docs page.
+func NewHandler(r Resolver) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var rpc struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      json.RawMessage `json:"id"`
+			Method  string          `json:"method"`
+			Params  json.RawMessage `json:"params"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&rpc); err != nil {
+			writeRPCError(w, nil, ParseError, "Parse error", err.Error())
+			return
+		}
+		ctx := req.Context()
+		switch rpc.Method {
+		case "initialize":
+			writeRPCResult(w, rpc.ID, map[string]interface{}{
+				"protocolVersion": "2024-11-05",
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":      map[string]interface{}{"name": "go-micro-mcp", "version": "1.0.0"},
+			})
+		case "ping":
+			writeRPCResult(w, rpc.ID, map[string]interface{}{})
+		case "tools/list":
+			tools, err := r.List(ctx)
+			if err != nil {
+				writeRPCError(w, rpc.ID, InternalError, "Failed to list tools", err.Error())
+				return
+			}
+			list := make([]map[string]interface{}, 0, len(tools))
+			for _, t := range tools {
+				list = append(list, map[string]interface{}{
+					"name": t.Name, "description": t.Description, "inputSchema": t.InputSchema,
+				})
+			}
+			writeRPCResult(w, rpc.ID, map[string]interface{}{"tools": list})
+		case "tools/call":
+			var p struct {
+				Name      string                 `json:"name"`
+				Arguments map[string]interface{} `json:"arguments"`
+			}
+			if err := json.Unmarshal(rpc.Params, &p); err != nil {
+				writeRPCError(w, rpc.ID, InvalidParams, "Invalid params", err.Error())
+				return
+			}
+			result, err := r.Call(ctx, p.Name, p.Arguments)
+			if err != nil {
+				writeRPCError(w, rpc.ID, InternalError, "Tool call failed", err.Error())
+				return
+			}
+			writeRPCResult(w, rpc.ID, map[string]interface{}{
+				"content": []map[string]interface{}{{"type": "text", "text": result}},
+			})
+		default:
+			writeRPCError(w, rpc.ID, MethodNotFound, "Method not found", rpc.Method)
+		}
+	})
+}
+
+func writeRPCResult(w http.ResponseWriter, id json.RawMessage, result interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": rawOrNull(id), "result": result})
+}
+
+func writeRPCError(w http.ResponseWriter, id json.RawMessage, code int, msg, data string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": rawOrNull(id), "error": map[string]interface{}{"code": code, "message": msg, "data": data}})
+}
+
+func rawOrNull(id json.RawMessage) interface{} {
+	if len(id) == 0 {
+		return nil
+	}
+	return id
+}

--- a/gateway/mcp/resolver.go
+++ b/gateway/mcp/resolver.go
@@ -1,0 +1,118 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/client"
+	"go-micro.dev/v6/registry"
+)
+
+// ToolFunc executes a manually-registered tool.
+type ToolFunc func(ctx context.Context, args map[string]any) (string, error)
+
+// Resolver supplies the gateway's tools and executes calls. Swapping the
+// resolver changes where tools come from without touching the MCP protocol or
+// transport:
+//
+//   - NewManualResolver:   tools you register explicitly (full product control,
+//     including tools that are not go-micro services, executed via your own
+//     logic — auth, metering, …).
+//   - NewRegistryResolver: tools auto-discovered from registered services.
+//
+// The built-in store/broker tools are intentionally NOT exposed by any
+// resolver — they remain a development convenience on the legacy Serve() path,
+// never a product default.
+type Resolver interface {
+	// List returns the current tool catalog.
+	List(ctx context.Context) ([]Tool, error)
+	// Call executes a tool by name with JSON arguments, returning its text result.
+	Call(ctx context.Context, name string, args map[string]any) (string, error)
+}
+
+// ManualResolver exposes an explicitly-registered set of tools.
+type ManualResolver struct {
+	mu    sync.RWMutex
+	order []Tool
+	funcs map[string]ToolFunc
+}
+
+// NewManualResolver returns an empty manual resolver.
+func NewManualResolver() *ManualResolver {
+	return &ManualResolver{funcs: map[string]ToolFunc{}}
+}
+
+// Add registers (or replaces) a tool and its handler. Returns the resolver for
+// chaining.
+func (m *ManualResolver) Add(t Tool, fn ToolFunc) *ManualResolver {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.funcs[t.Name]; ok {
+		for i := range m.order {
+			if m.order[i].Name == t.Name {
+				m.order[i] = t
+			}
+		}
+	} else {
+		m.order = append(m.order, t)
+	}
+	m.funcs[t.Name] = fn
+	return m
+}
+
+// List returns the registered tools.
+func (m *ManualResolver) List(_ context.Context) ([]Tool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]Tool, len(m.order))
+	copy(out, m.order)
+	return out, nil
+}
+
+// Call runs the handler registered for name.
+func (m *ManualResolver) Call(ctx context.Context, name string, args map[string]any) (string, error) {
+	m.mu.RLock()
+	fn, ok := m.funcs[name]
+	m.mu.RUnlock()
+	if !ok {
+		return "", fmt.Errorf("tool not found: %s", name)
+	}
+	return fn(ctx, args)
+}
+
+// RegistryResolver auto-discovers tools from registered go-micro services and
+// executes them over RPC. It exposes only services — never the internal
+// store/broker tools.
+type RegistryResolver struct {
+	tools *ai.Tools
+}
+
+// NewRegistryResolver discovers services from reg and calls them with cl.
+func NewRegistryResolver(reg registry.Registry, cl client.Client) *RegistryResolver {
+	return &RegistryResolver{tools: ai.NewTools(reg, ai.ToolClient(cl))}
+}
+
+// List discovers the current service tools.
+func (r *RegistryResolver) List(_ context.Context) ([]Tool, error) {
+	discovered, err := r.tools.Discover()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Tool, 0, len(discovered))
+	for _, t := range discovered {
+		out = append(out, Tool{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: map[string]interface{}{"type": "object", "properties": t.Properties},
+		})
+	}
+	return out, nil
+}
+
+// Call executes a discovered service tool.
+func (r *RegistryResolver) Call(ctx context.Context, name string, args map[string]any) (string, error) {
+	res := r.tools.Handler()(ctx, ai.ToolCall{ID: "1", Name: name, Input: args})
+	return res.Content, nil
+}

--- a/gateway/mcp/resolver_test.go
+++ b/gateway/mcp/resolver_test.go
@@ -1,0 +1,58 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestManualResolverHandler(t *testing.T) {
+	res := NewManualResolver().Add(
+		Tool{Name: "echo", Description: "echoes text", InputSchema: map[string]interface{}{
+			"type": "object", "properties": map[string]interface{}{"text": map[string]interface{}{"type": "string"}},
+		}},
+		func(_ context.Context, args map[string]interface{}) (string, error) {
+			s, _ := args["text"].(string)
+			return "you said: " + s, nil
+		},
+	)
+	ts := httptest.NewServer(NewHandler(res))
+	defer ts.Close()
+
+	rpc := func(body string) map[string]interface{} {
+		resp, err := http.Post(ts.URL, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+		var out map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&out)
+		return out
+	}
+
+	// initialize
+	if out := rpc(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`); out["result"] == nil {
+		t.Fatalf("initialize: %v", out)
+	}
+	// tools/list
+	out := rpc(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	tools := out["result"].(map[string]interface{})["tools"].([]interface{})
+	if len(tools) != 1 || tools[0].(map[string]interface{})["name"] != "echo" {
+		t.Fatalf("tools/list: %v", out)
+	}
+	// tools/call
+	out = rpc(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`)
+	content := out["result"].(map[string]interface{})["content"].([]interface{})
+	got := content[0].(map[string]interface{})["text"].(string)
+	if got != "you said: hi" {
+		t.Fatalf("tools/call text = %q", got)
+	}
+	// unknown tool -> error
+	out = rpc(`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"nope","arguments":{}}}`)
+	if out["error"] == nil {
+		t.Fatalf("expected error for unknown tool, got %v", out)
+	}
+}


### PR DESCRIPTION
Separates the MCP **protocol/transport** (the gateway's job) from **what tools exist and how they execute** (the product's job).

-  interface with  (register tools explicitly, execute via your own logic) and  (auto-discover go-micro services via the proven ). Neither exposes the internal store/broker tools.
-  serving standard MCP JSON-RPC 2.0 over HTTP (///) — mountable on your own mux (e.g. ), so the library serves the protocol while the product keeps its routes, auth/metering and its own docs page.

Additive: the existing /REST path and tests are untouched. Motivation: dogfooding mu on go-micro — a product wants to expose its full tool set (services *and* non-services) over a mounted MCP endpoint without the gateway exposing raw store/broker internals.

---
_Generated by [Claude Code](https://claude.ai/code)_