### PR TITLE
Trace agent model attempts

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -31,6 +31,8 @@ const (
 	AttrInputTokens    = "agent.tokens.input"
 	AttrOutputTokens   = "agent.tokens.output"
 	AttrTotalTokens    = "agent.tokens.total"
+	AttrAttempt        = "agent.model.attempt"
+	AttrMaxAttempts    = "agent.model.max_attempts"
 	AttrToolName       = "agent.tool.name"
 	AttrDelegate       = "agent.delegate"
 	AttrGuardrailBlock = "agent.guardrail.block"
@@ -38,20 +40,22 @@ const (
 )
 
 type RunEvent struct {
-	Time      time.Time `json:"time"`
-	RunID     string    `json:"run_id"`
-	ParentID  string    `json:"parent_id,omitempty"`
-	TraceID   string    `json:"trace_id,omitempty"`
-	SpanID    string    `json:"span_id,omitempty"`
-	Agent     string    `json:"agent"`
-	Kind      string    `json:"kind"`
-	Name      string    `json:"name,omitempty"`
-	Provider  string    `json:"provider,omitempty"`
-	Model     string    `json:"model,omitempty"`
-	LatencyMS int64     `json:"latency_ms,omitempty"`
-	Tokens    Usage     `json:"tokens,omitempty"`
-	Refused   string    `json:"refused,omitempty"`
-	Error     string    `json:"error,omitempty"`
+	Time        time.Time `json:"time"`
+	RunID       string    `json:"run_id"`
+	ParentID    string    `json:"parent_id,omitempty"`
+	TraceID     string    `json:"trace_id,omitempty"`
+	SpanID      string    `json:"span_id,omitempty"`
+	Agent       string    `json:"agent"`
+	Kind        string    `json:"kind"`
+	Name        string    `json:"name,omitempty"`
+	Provider    string    `json:"provider,omitempty"`
+	Model       string    `json:"model,omitempty"`
+	Attempt     int       `json:"attempt,omitempty"`
+	MaxAttempts int       `json:"max_attempts,omitempty"`
+	LatencyMS   int64     `json:"latency_ms,omitempty"`
+	Tokens      Usage     `json:"tokens,omitempty"`
+	Refused     string    `json:"refused,omitempty"`
+	Error       string    `json:"error,omitempty"`
 }
 
 type Usage = ai.Usage
@@ -144,7 +148,7 @@ func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.
 		if resp != nil {
 			usage = resp.Usage
 		}
-		e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "model", Provider: provider, Model: model, LatencyMS: dur, Tokens: usage}
+		e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "model", Provider: provider, Model: model, Attempt: info.Attempt, MaxAttempts: info.MaxAttempts, LatencyMS: dur, Tokens: usage}
 		if err != nil {
 			e.Error = err.Error()
 		}
@@ -162,6 +166,12 @@ func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.
 	resp, err := m.Model.Generate(ctx, req, opts...)
 	dur := time.Since(start).Milliseconds()
 	attrs := []attribute.KeyValue{attribute.Int64(AttrLatencyMS, dur)}
+	if info.Attempt > 0 {
+		attrs = append(attrs, attribute.Int(AttrAttempt, info.Attempt))
+	}
+	if info.MaxAttempts > 0 {
+		attrs = append(attrs, attribute.Int(AttrMaxAttempts, info.MaxAttempts))
+	}
 	usage := ai.Usage{}
 	if resp != nil {
 		usage = resp.Usage
@@ -175,7 +185,7 @@ func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.
 		span.SetStatus(codes.Ok, "")
 	}
 	span.End()
-	e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "model", Provider: provider, Model: model, LatencyMS: dur, Tokens: usage}
+	e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "model", Provider: provider, Model: model, Attempt: info.Attempt, MaxAttempts: info.MaxAttempts, LatencyMS: dur, Tokens: usage}
 	if err != nil {
 		e.Error = err.Error()
 	}
@@ -273,6 +283,12 @@ func runEventAttributes(e RunEvent) []attribute.KeyValue {
 	}
 	if e.Model != "" {
 		attrs = append(attrs, attribute.String(AttrModel, e.Model))
+	}
+	if e.Attempt > 0 {
+		attrs = append(attrs, attribute.Int(AttrAttempt, e.Attempt))
+	}
+	if e.MaxAttempts > 0 {
+		attrs = append(attrs, attribute.Int(AttrMaxAttempts, e.MaxAttempts))
 	}
 	if e.LatencyMS > 0 {
 		attrs = append(attrs, attribute.Int64(AttrLatencyMS, e.LatencyMS))

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,9 +12,12 @@ import (
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/store"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+const codesError = codes.Error
 
 type otelTestModel struct{ opts ai.Options }
 
@@ -89,6 +93,9 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 		if attrs[AttrRunID] != runID || attrs[AttrAgentName] != "runner" {
 			t.Fatalf("%s missing run correlation attributes: %#v", s.Name(), attrs)
 		}
+		if s.Name() == spanNameModelCall && (attrs[AttrAttempt] != "1" || attrs[AttrMaxAttempts] != "1") {
+			t.Fatalf("model span missing attempt attributes: %#v", attrs)
+		}
 	}
 	keys, err := store.Scope(st, "agent", "runner").List(store.ListPrefix("runs/"))
 	if err != nil {
@@ -122,6 +129,77 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	}
 	if len(events) == 0 || events[0].TraceID == "" || events[0].SpanID == "" {
 		t.Fatalf("events missing trace correlation: %#v", events)
+	}
+}
+
+type failingOtelModel struct{ opts ai.Options }
+
+func (m *failingOtelModel) Init(opts ...ai.Option) error {
+	for _, o := range opts {
+		o(&m.opts)
+	}
+	return nil
+}
+func (m *failingOtelModel) Options() ai.Options { return m.opts }
+func (m *failingOtelModel) String() string      { return "otelfail" }
+func (m *failingOtelModel) Stream(context.Context, *ai.Request, ...ai.GenerateOption) (ai.Stream, error) {
+	return nil, nil
+}
+func (m *failingOtelModel) Generate(context.Context, *ai.Request, ...ai.GenerateOption) (*ai.Response, error) {
+	return nil, errors.New("provider exploded")
+}
+
+func init() {
+	ai.Register("otelfail", func(opts ...ai.Option) ai.Model { return &failingOtelModel{opts: ai.NewOptions(opts...)} })
+}
+
+func TestAgentOpenTelemetrySpansModelFailure(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exp))
+	st := store.NewMemoryStore()
+	a := New(Name("failing-runner"), Provider("otelfail"), WithStore(st), TraceProvider(tp))
+	if _, err := a.Ask(context.Background(), "hello"); err == nil {
+		t.Fatal("Ask succeeded, want provider error")
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	var sawRunError, sawModelError bool
+	for _, s := range spans {
+		attrs := spanAttributes(s.Attributes())
+		switch s.Name() {
+		case spanNameRun:
+			if attrs[AttrAgentName] == "failing-runner" && s.Status().Code == codesError {
+				sawRunError = true
+			}
+		case spanNameModelCall:
+			if attrs[AttrAgentName] == "failing-runner" && attrs[AttrAttempt] == "1" && s.Status().Code == codesError {
+				sawModelError = true
+			}
+		}
+	}
+	if !sawRunError || !sawModelError {
+		t.Fatalf("missing error spans: run=%v model=%v spans=%d", sawRunError, sawModelError, len(spans))
+	}
+
+	summaries, err := ListRunSummaries(st, "failing-runner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summaries) != 1 || summaries[0].Status != "error" || summaries[0].LastError == "" {
+		t.Fatalf("unexpected failure summary: %#v", summaries)
+	}
+	events, err := LoadRunEvents(st, "failing-runner", summaries[0].RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawModelEvent bool
+	for _, event := range events {
+		if event.Kind == "model" && event.Attempt == 1 && event.MaxAttempts == 1 && event.Error != "" {
+			sawModelEvent = true
+		}
+	}
+	if !sawModelEvent {
+		t.Fatalf("missing failed model event with attempt metadata: %#v", events)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Add model attempt and max-attempt attributes to agent OpenTelemetry model spans and run timeline events.
- Cover provider failure spans and persisted error timelines with in-memory OpenTelemetry tests.

Testing:
- go build ./...
- go test ./agent
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3316
Closes #3332