### PR TITLE
gateway/mcp: richer resolver Call (CallResult/isError, coded errors) + notifications

### DIFF
--- a/gateway/mcp/httpjsonrpc.go
+++ b/gateway/mcp/httpjsonrpc.go
@@ -3,12 +3,14 @@ package mcp
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 )
 
 // NewHandler returns an http.Handler serving the MCP protocol over HTTP as
-// JSON-RPC 2.0 (initialize, ping, tools/list, tools/call), backed by the
-// resolver. Mount it on your own server (e.g. POST /mcp): the gateway provides
-// the protocol; you keep your routes, middleware and any human-facing docs page.
+// JSON-RPC 2.0 (initialize, ping, notifications/*, tools/list, tools/call),
+// backed by the resolver. Mount it on your own server (e.g. POST /mcp): the
+// gateway provides the protocol; you keep your routes, middleware and any
+// human-facing docs page.
 func NewHandler(r Resolver) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodPost {
@@ -25,6 +27,13 @@ func NewHandler(r Resolver) http.Handler {
 			writeRPCError(w, nil, ParseError, "Parse error", err.Error())
 			return
 		}
+
+		// Notifications (and any id-less request) expect no response body.
+		if strings.HasPrefix(rpc.Method, "notifications/") || len(rpc.ID) == 0 {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		ctx := req.Context()
 		switch rpc.Method {
 		case "initialize":
@@ -57,14 +66,24 @@ func NewHandler(r Resolver) http.Handler {
 				writeRPCError(w, rpc.ID, InvalidParams, "Invalid params", err.Error())
 				return
 			}
-			result, err := r.Call(ctx, p.Name, p.Arguments)
+			res, err := r.Call(ctx, p.Name, p.Arguments)
 			if err != nil {
-				writeRPCError(w, rpc.ID, InternalError, "Tool call failed", err.Error())
+				// Protocol/pre-check failure -> JSON-RPC error. An *RPCError
+				// carries a specific code; anything else is InternalError.
+				if rpcErr, ok := err.(*RPCError); ok {
+					writeRPCError(w, rpc.ID, rpcErr.Code, rpcErr.Message, rpcErr.Data)
+				} else {
+					writeRPCError(w, rpc.ID, InternalError, "Tool call failed", err.Error())
+				}
 				return
 			}
-			writeRPCResult(w, rpc.ID, map[string]interface{}{
-				"content": []map[string]interface{}{{"type": "text", "text": result}},
-			})
+			result := map[string]interface{}{
+				"content": []map[string]interface{}{{"type": "text", "text": res.Text}},
+			}
+			if res.IsError {
+				result["isError"] = true
+			}
+			writeRPCResult(w, rpc.ID, result)
 		default:
 			writeRPCError(w, rpc.ID, MethodNotFound, "Method not found", rpc.Method)
 		}
@@ -76,7 +95,7 @@ func writeRPCResult(w http.ResponseWriter, id json.RawMessage, result interface{
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": rawOrNull(id), "result": result})
 }
 
-func writeRPCError(w http.ResponseWriter, id json.RawMessage, code int, msg, data string) {
+func writeRPCError(w http.ResponseWriter, id json.RawMessage, code int, msg string, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": rawOrNull(id), "error": map[string]interface{}{"code": code, "message": msg, "data": data}})
 }

--- a/gateway/mcp/resolver.go
+++ b/gateway/mcp/resolver.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"go-micro.dev/v6/ai"
@@ -10,8 +9,23 @@ import (
 	"go-micro.dev/v6/registry"
 )
 
-// ToolFunc executes a manually-registered tool.
-type ToolFunc func(ctx context.Context, args map[string]any) (string, error)
+// CallResult is the outcome of a successful tool dispatch. A tool that ran but
+// produced an error sets IsError — per the MCP spec this is returned as a
+// tools/call result with isError:true, not a JSON-RPC protocol error.
+type CallResult struct {
+	Text    string
+	IsError bool
+}
+
+// Error lets the package's RPCError (see stdio.go) be returned by a resolver
+// to signal a protocol/pre-check failure with a specific JSON-RPC code; the
+// handler maps it straight to the JSON-RPC error.
+func (e *RPCError) Error() string { return e.Message }
+
+// ToolFunc executes a manually-registered tool. Return a *CallResult for tool
+// outcomes (set IsError for tool-level failures); return a non-nil error — an
+// *RPCError for a specific code — for protocol/pre-check failures.
+type ToolFunc func(ctx context.Context, args map[string]any) (*CallResult, error)
 
 // Resolver supplies the gateway's tools and executes calls. Swapping the
 // resolver changes where tools come from without touching the MCP protocol or
@@ -23,13 +37,12 @@ type ToolFunc func(ctx context.Context, args map[string]any) (string, error)
 //   - NewRegistryResolver: tools auto-discovered from registered services.
 //
 // The built-in store/broker tools are intentionally NOT exposed by any
-// resolver — they remain a development convenience on the legacy Serve() path,
-// never a product default.
+// resolver — they remain a development convenience on the legacy Serve() path.
 type Resolver interface {
 	// List returns the current tool catalog.
 	List(ctx context.Context) ([]Tool, error)
-	// Call executes a tool by name with JSON arguments, returning its text result.
-	Call(ctx context.Context, name string, args map[string]any) (string, error)
+	// Call executes a tool by name with JSON arguments.
+	Call(ctx context.Context, name string, args map[string]any) (*CallResult, error)
 }
 
 // ManualResolver exposes an explicitly-registered set of tools.
@@ -72,12 +85,12 @@ func (m *ManualResolver) List(_ context.Context) ([]Tool, error) {
 }
 
 // Call runs the handler registered for name.
-func (m *ManualResolver) Call(ctx context.Context, name string, args map[string]any) (string, error) {
+func (m *ManualResolver) Call(ctx context.Context, name string, args map[string]any) (*CallResult, error) {
 	m.mu.RLock()
 	fn, ok := m.funcs[name]
 	m.mu.RUnlock()
 	if !ok {
-		return "", fmt.Errorf("tool not found: %s", name)
+		return nil, &RPCError{Code: InvalidParams, Message: "Tool not found", Data: name}
 	}
 	return fn(ctx, args)
 }
@@ -112,7 +125,7 @@ func (r *RegistryResolver) List(_ context.Context) ([]Tool, error) {
 }
 
 // Call executes a discovered service tool.
-func (r *RegistryResolver) Call(ctx context.Context, name string, args map[string]any) (string, error) {
+func (r *RegistryResolver) Call(ctx context.Context, name string, args map[string]any) (*CallResult, error) {
 	res := r.tools.Handler()(ctx, ai.ToolCall{ID: "1", Name: name, Input: args})
-	return res.Content, nil
+	return &CallResult{Text: res.Content}, nil
 }

--- a/gateway/mcp/resolver_test.go
+++ b/gateway/mcp/resolver_test.go
@@ -10,49 +10,52 @@ import (
 )
 
 func TestManualResolverHandler(t *testing.T) {
-	res := NewManualResolver().Add(
-		Tool{Name: "echo", Description: "echoes text", InputSchema: map[string]interface{}{
-			"type": "object", "properties": map[string]interface{}{"text": map[string]interface{}{"type": "string"}},
-		}},
-		func(_ context.Context, args map[string]interface{}) (string, error) {
-			s, _ := args["text"].(string)
-			return "you said: " + s, nil
-		},
-	)
+	res := NewManualResolver().
+		Add(Tool{Name: "echo", Description: "echoes text"},
+			func(_ context.Context, args map[string]interface{}) (*CallResult, error) {
+				s, _ := args["text"].(string)
+				return &CallResult{Text: "you said: " + s}, nil
+			}).
+		Add(Tool{Name: "boom", Description: "errors"},
+			func(_ context.Context, _ map[string]interface{}) (*CallResult, error) {
+				return &CallResult{Text: "kaboom", IsError: true}, nil
+			}).
+		Add(Tool{Name: "blocked", Description: "coded error"},
+			func(_ context.Context, _ map[string]interface{}) (*CallResult, error) {
+				return nil, &RPCError{Code: -32000, Message: "insufficient credits"}
+			})
+
 	ts := httptest.NewServer(NewHandler(res))
 	defer ts.Close()
-
-	rpc := func(body string) map[string]interface{} {
-		resp, err := http.Post(ts.URL, "application/json", strings.NewReader(body))
-		if err != nil {
-			t.Fatalf("post: %v", err)
-		}
+	rpc := func(body string) (int, map[string]interface{}) {
+		resp, _ := http.Post(ts.URL, "application/json", strings.NewReader(body))
 		defer resp.Body.Close()
 		var out map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&out)
-		return out
+		return resp.StatusCode, out
 	}
 
-	// initialize
-	if out := rpc(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`); out["result"] == nil {
-		t.Fatalf("initialize: %v", out)
-	}
-	// tools/list
-	out := rpc(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
-	tools := out["result"].(map[string]interface{})["tools"].([]interface{})
-	if len(tools) != 1 || tools[0].(map[string]interface{})["name"] != "echo" {
+	if _, out := rpc(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`); len(out["result"].(map[string]interface{})["tools"].([]interface{})) != 3 {
 		t.Fatalf("tools/list: %v", out)
 	}
-	// tools/call
-	out = rpc(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`)
-	content := out["result"].(map[string]interface{})["content"].([]interface{})
-	got := content[0].(map[string]interface{})["text"].(string)
-	if got != "you said: hi" {
-		t.Fatalf("tools/call text = %q", got)
+	// tool result
+	_, out := rpc(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`)
+	if out["result"].(map[string]interface{})["content"].([]interface{})[0].(map[string]interface{})["text"] != "you said: hi" {
+		t.Fatalf("echo: %v", out)
 	}
-	// unknown tool -> error
-	out = rpc(`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"nope","arguments":{}}}`)
-	if out["error"] == nil {
-		t.Fatalf("expected error for unknown tool, got %v", out)
+	// tool-level error -> isError result, NOT protocol error
+	_, out = rpc(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"boom","arguments":{}}}`)
+	if out["error"] != nil || out["result"].(map[string]interface{})["isError"] != true {
+		t.Fatalf("boom should be isError result: %v", out)
+	}
+	// coded protocol error -> JSON-RPC error with the code
+	_, out = rpc(`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"blocked","arguments":{}}}`)
+	if out["error"] == nil || int(out["error"].(map[string]interface{})["code"].(float64)) != -32000 {
+		t.Fatalf("blocked should be -32000: %v", out)
+	}
+	// notification -> 204, no body
+	code, _ := rpc(`{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	if code != http.StatusNoContent {
+		t.Fatalf("notification status = %d, want 204", code)
 	}
 }


### PR DESCRIPTION
Makes the gateway faithful enough to back a real product MCP endpoint:

- Resolver.Call returns (*CallResult, error). Tool-level failures set CallResult.IsError and come back as a tools/call result with isError:true (MCP spec); protocol/pre-check failures (bad params, auth, quota) return an error, and an *RPCError carries a specific JSON-RPC code (e.g. -32000) instead of the generic InternalError.
- The HTTP handler answers notifications/* and id-less requests with 204 and no body.

Motivation: dogfooding mu -- routing /mcp through the gateway must preserve mu's metering error code and the isError result shape. Additive to the legacy Serve() path.

---
_Generated by [Claude Code](https://claude.ai/code)_