### PR TITLE
Update architect priorities after trace correlation

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -19,11 +19,10 @@ redirect the loop; direction always wins.
 items the loop can auto-merge): brand/positioning copy, breaking public-API
 changes, architectural rewrites. Those go to the human.
 
-## Developer experience (ranked)
+## Work queue (ranked)
 
-1. **Emit agent RunInfo as OpenTelemetry spans** ([#3316](https://github.com/micro/go-micro/issues/3316)) — provider-backed streaming just broadened across the OpenAI-compatible path, so the highest-value remaining Next-roadmap seam is making agent execution operable: model calls, tool calls, failures, and run IDs should correlate with the same traces as services and flows.
-2. **Add memory compaction and retrieval for long-running agents** ([#3321](https://github.com/micro/go-micro/issues/3321)) — after run timelines become observable, tackle the leading Later-roadmap gap: bounded, store-backed memory that keeps long agent runs useful without turning Go Micro into a prompt-layer framework.
-3. **Add human-in-the-loop pause and resume for agent workflows** ([#3329](https://github.com/micro/go-micro/issues/3329)) — once agents are observable and memory-bounded, close the next operability gap for scheduled/looping work: durable pending-input states that let humans approve or provide context and then resume the same service/agent/workflow runtime.
+1. **Add memory compaction and retrieval for long-running agents** ([#3321](https://github.com/micro/go-micro/issues/3321)) — with durable resume, broad streaming, CLI run inspection, and RunInfo trace correlation now shipped, tackle the leading Later-roadmap gap: bounded, store-backed memory that keeps long agent runs useful without turning Go Micro into a prompt-layer framework.
+2. **Add human-in-the-loop pause and resume for agent workflows** ([#3329](https://github.com/micro/go-micro/issues/3329)) — after memory is bounded, close the next operability gap for scheduled/looping work: durable pending-input states that let humans approve or provide context and then resume the same service/agent/workflow runtime.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:\n- Remove completed RunInfo-to-OpenTelemetry priority after #3316 closed.\n- Promote memory compaction/retrieval and human-in-the-loop pause/resume as the remaining queue.\n\nTesting:\n- go build ./...\n- go test ./... (environment warning: loopback-target restrictions failed client/grpc tests and the command timed out after 300s)\n- golangci-lint run ./... (fails on pre-existing gateway/mcp/resolver_test.go govet issue)\n\nCloses #3336