### PR TITLE
Harden compacted agent memory resume

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -225,16 +225,18 @@ func (a *agentImpl) ask(ctx context.Context, message, parentRunID string) (*Resp
 		a.setup()
 	}
 
-	return a.askLocked(ctx, uuid.New().String(), message, parentRunID, nil)
+	return a.askLocked(ctx, uuid.New().String(), message, parentRunID, nil, true)
 }
 
-func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID string, existing *flow.Run) (*Response, error) {
+func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID string, existing *flow.Run, addUserMessage bool) (*Response, error) {
 	toolList, err := a.discoverTools()
 	if err != nil {
 		return nil, fmt.Errorf("discover tools: %w", err)
 	}
 
-	a.mem.Add("user", message)
+	if addUserMessage {
+		a.mem.Add("user", message)
+	}
 	a.steps = 0
 	a.calls = map[string]int{}
 	a.pause = nil

--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -95,7 +95,7 @@ func (a *agentImpl) resume(ctx context.Context, runID string) (*Response, error)
 	if a.model == nil {
 		a.setup()
 	}
-	return a.askLocked(ctx, run.ID, message, parentID, &run)
+	return a.askLocked(ctx, run.ID, message, parentID, &run, false)
 }
 
 // ResumeInput resumes a checkpointed agent run that paused via the built-in
@@ -140,7 +140,7 @@ func (a *agentImpl) resumeInput(ctx context.Context, runID, input string) (*Resp
 	if a.model == nil {
 		a.setup()
 	}
-	return a.askLocked(ctx, run.ID, message, run.ParentID, &run)
+	return a.askLocked(ctx, run.ID, message, run.ParentID, &run, true)
 }
 
 func (a *agentImpl) pending(ctx context.Context) ([]flow.Run, error) {

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -102,6 +102,72 @@ func TestResumeFailedCheckpointDoesNotReplayCompletedTool(t *testing.T) {
 	}
 }
 
+func TestResumeFailedCheckpointDoesNotDuplicateCompactedMemory(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	cp := flow.StoreCheckpoint(st, "memory-resume-agent")
+	failRetry := true
+	var sawRecall bool
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		for _, msg := range req.Messages {
+			if text, ok := msg.Content.(string); ok && strings.Contains(text, "alpha code is 42") {
+				sawRecall = true
+			}
+		}
+		if strings.Contains(req.Prompt, "use alpha code") && failRetry {
+			failRetry = false
+			return nil, errors.New("model connection dropped")
+		}
+		return &ai.Response{Reply: "ok"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("memory-resume-agent"), WithStore(st), WithCheckpoint(cp), CompactMemory(4, 1), MemoryRecallLimit(2))
+	for _, msg := range []string{"alpha code is 42", "beta note", "gamma note"} {
+		if _, err := a.Ask(ctx, msg); err != nil {
+			t.Fatalf("Ask(%q): %v", msg, err)
+		}
+	}
+
+	_, err := a.Ask(ctx, "use alpha code now")
+	if err == nil {
+		t.Fatal("Ask succeeded, want simulated provider failure")
+	}
+	if got := countMemoryContent(a.mem.Messages(), "use alpha code now"); got != 1 {
+		t.Fatalf("failed Ask stored prompt %d times, want 1", got)
+	}
+
+	runs, err := Pending(ctx, a)
+	if err != nil {
+		t.Fatalf("Pending: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("Pending returned %d runs, want 1", len(runs))
+	}
+	if _, err := Resume(ctx, a, runs[0].ID); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if got := countMemoryContent(a.mem.Messages(), "use alpha code now"); got != 1 {
+		t.Fatalf("resumed failed Ask stored prompt %d times, want no duplicate", got)
+	}
+	if !sawRecall {
+		t.Fatal("resume did not retrieve archived compacted memory")
+	}
+	if got := len(a.mem.Messages()); got > 4 {
+		t.Fatalf("compacted memory retained %d messages after resume, want <= 4", got)
+	}
+}
+
+func countMemoryContent(messages []ai.Message, needle string) int {
+	var count int
+	for _, msg := range messages {
+		if text, ok := msg.Content.(string); ok && strings.Contains(text, needle) {
+			count++
+		}
+	}
+	return count
+}
+
 func TestPendingReturnsUnfinishedAgentRuns(t *testing.T) {
 	ctx := context.Background()
 	cp := flow.StoreCheckpoint(store.NewStore(), "pending-agent")

--- a/gateway/mcp/resolver_test.go
+++ b/gateway/mcp/resolver_test.go
@@ -28,7 +28,10 @@ func TestManualResolverHandler(t *testing.T) {
 	ts := httptest.NewServer(NewHandler(res))
 	defer ts.Close()
 	rpc := func(body string) (int, map[string]interface{}) {
-		resp, _ := http.Post(ts.URL, "application/json", strings.NewReader(body))
+		resp, err := http.Post(ts.URL, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("post rpc: %v", err)
+		}
 		defer resp.Body.Close()
 		var out map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&out)

--- a/internal/website/docs/guides/agents-and-workflows.md
+++ b/internal/website/docs/guides/agents-and-workflows.md
@@ -83,6 +83,44 @@ a := micro.NewAgent("conductor",
 a.Ask(ctx, "Plan the launch, create the tasks, and have comms notify the owner.")
 ```
 
+### Long-running memory
+
+Agents use store-backed conversation memory by default, scoped under the agent's
+name. That makes short restarts boring: the next `Ask` reloads the retained
+history from the same store backend you already use for services and flows.
+Long-running agents can also keep model context bounded without losing useful
+prior context:
+
+```go
+a := micro.NewAgent("conductor",
+    micro.AgentServices("task"),
+    micro.AgentProvider("anthropic"),
+    micro.AgentCompactMemory(40, 12),      // max active messages, recent messages kept verbatim
+    micro.AgentMemoryRecallLimit(5),       // archived turns recalled per Ask
+)
+```
+
+`AgentCompactMemory(maxMessages, keepRecent)` switches the default memory to a
+deterministic compactor. Once active history grows past `maxMessages`, older
+turns move into the durable archive, a provider-neutral summary is injected into
+active context, and the newest `keepRecent` messages stay verbatim. On future
+asks, archived turns whose text matches the current request are recalled ahead of
+the active context. The built-in retrieval is intentionally simple and
+credential-free for CI; teams that need embeddings or a vector database can still
+provide their own `AgentMemory` implementation.
+
+This is harness memory, not prompt-layer orchestration: services remain the
+capabilities, agents remain the dynamic decision makers, and flows remain the
+durable predefined paths. Compaction only keeps a scheduled or looping agent from
+turning every past turn into model context while still letting it remember facts
+that matter to the current service → agent → workflow run.
+
+Checkpointed agent runs and compacted memory share the same store-backed shape.
+If a provider call fails after the prompt has been recorded, `agent.Resume` uses
+the checkpointed run id and does not append that same user turn a second time;
+completed tool results and recalled archived memory remain available for the
+retry.
+
 ## The patterns — most are already here
 
 Anthropic lists five workflow patterns. Go Micro implements the two richest ones natively, as services and tools, and the rest are ordinary compositions:


### PR DESCRIPTION
Summary:
- Avoid appending a checkpointed agent prompt a second time when resuming a failed run, preserving bounded compacted memory.
- Add coverage for compacted memory recall across checkpoint resume.
- Document long-running agent memory compaction and retrieval in the agents/workflows guide.
- Fix an MCP resolver test lint issue so golangci-lint remains green.

Testing:
- go build ./...
- go test ./agent ./gateway/mcp ./internal/website/docs/guides
- golangci-lint run ./...
- go test ./... (environment warnings: loopback targets forbidden in gRPC tests; sum.golang.org 502 during generated service tidy)

Closes #3321
Closes #3338