### PR TITLE
Add tool-aware agent StreamAsk

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -139,6 +139,10 @@ func (a *agentImpl) String() string {
 }
 
 func (a *agentImpl) setup() {
+	a.setupWithToolHandler(nil)
+}
+
+func (a *agentImpl) setupWithToolHandler(handler ai.ToolHandler) {
 	var modelOpts []ai.Option
 	modelOpts = append(modelOpts, ai.WithAPIKey(a.opts.APIKey))
 	if a.opts.Model != "" {
@@ -146,10 +150,17 @@ func (a *agentImpl) setup() {
 	}
 
 	a.tools = ai.NewTools(a.opts.Registry, ai.ToolClient(a.opts.Client))
-	modelOpts = append(modelOpts, ai.WithToolHandler(a.toolHandler()))
+	if handler == nil {
+		handler = a.toolHandler()
+	}
+	modelOpts = append(modelOpts, ai.WithToolHandler(handler))
 	a.model = ai.New(a.opts.Provider, modelOpts...)
 	if a.model != nil {
 		a.model = a.tracedModel(a.model)
+	}
+
+	if a.mem != nil {
+		return
 	}
 
 	// Memory is pluggable. Use the configured one, otherwise the default

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -1,0 +1,156 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"go-micro.dev/v6/ai"
+)
+
+// StreamEventType identifies an event emitted by a tool-aware agent stream.
+type StreamEventType string
+
+const (
+	// StreamEventToolStart is emitted immediately before a tool call runs.
+	StreamEventToolStart StreamEventType = "tool_start"
+	// StreamEventToolEnd is emitted after a tool call returns or is refused.
+	StreamEventToolEnd StreamEventType = "tool_end"
+	// StreamEventToken carries a chunk of the final answer.
+	StreamEventToken StreamEventType = "token"
+	// StreamEventDone carries the completed agent response.
+	StreamEventDone StreamEventType = "done"
+)
+
+// StreamEvent is one event from StreamAsk.
+type StreamEvent struct {
+	Type     StreamEventType
+	Token    string
+	ToolCall ai.ToolCall
+	Result   ai.ToolResult
+	Response *Response
+}
+
+// AgentStream is a stream of tool execution events followed by final-answer chunks.
+type AgentStream interface {
+	Recv() (*StreamEvent, error)
+	Close() error
+}
+
+// StreamAsk runs an agent Ask turn with tool start/end events and streams the final answer.
+// It is additive for callers that hold the public Agent interface; concrete agents also
+// expose the same method directly.
+func StreamAsk(ctx context.Context, ag Agent, message string) (AgentStream, error) {
+	streamer, ok := ag.(interface {
+		StreamAsk(context.Context, string) (AgentStream, error)
+	})
+	if !ok {
+		return nil, errors.New("agent: StreamAsk unsupported by implementation")
+	}
+	return streamer.StreamAsk(ctx, message)
+}
+
+// StreamAsk runs tools like Ask, emits ToolStart/ToolEnd events as they execute,
+// then emits chunks of the final answer followed by a Done event.
+func (a *agentImpl) StreamAsk(ctx context.Context, message string) (AgentStream, error) {
+	events := make(chan *StreamEvent, 16)
+	done := make(chan struct{})
+	s := &agentStream{events: events, done: done}
+
+	go func() {
+		defer close(events)
+		defer close(done)
+		resp, err := a.askWithStreamEvents(ctx, message, events)
+		if err != nil {
+			s.setErr(err)
+			return
+		}
+		for _, tok := range splitStreamTokens(resp.Reply) {
+			if !sendStreamEvent(ctx, events, &StreamEvent{Type: StreamEventToken, Token: tok}) {
+				return
+			}
+		}
+		_ = sendStreamEvent(ctx, events, &StreamEvent{Type: StreamEventDone, Response: resp})
+	}()
+	return s, nil
+}
+
+func (a *agentImpl) askWithStreamEvents(ctx context.Context, message string, events chan<- *StreamEvent) (*Response, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.tools == nil {
+		a.tools = ai.NewTools(a.opts.Registry, ai.ToolClient(a.opts.Client))
+	}
+	base := a.toolHandler()
+	handler := func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		_ = sendStreamEvent(ctx, events, &StreamEvent{Type: StreamEventToolStart, ToolCall: call})
+		result := base(ctx, call)
+		_ = sendStreamEvent(ctx, events, &StreamEvent{Type: StreamEventToolEnd, ToolCall: call, Result: result})
+		return result
+	}
+	a.setupWithToolHandler(handler)
+	return a.askLocked(ctx, uuid.New().String(), message, a.parentRunID, nil, true)
+}
+
+type agentStream struct {
+	events <-chan *StreamEvent
+	done   <-chan struct{}
+	mu     sync.Mutex
+	err    error
+}
+
+func (s *agentStream) Recv() (*StreamEvent, error) {
+	ev, ok := <-s.events
+	if ok {
+		return ev, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return nil, s.err
+	}
+	return nil, io.EOF
+}
+
+func (s *agentStream) Close() error {
+	<-s.done
+	return nil
+}
+
+func (s *agentStream) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
+
+func sendStreamEvent(ctx context.Context, events chan<- *StreamEvent, ev *StreamEvent) bool {
+	select {
+	case events <- ev:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func splitStreamTokens(reply string) []string {
+	if reply == "" {
+		return nil
+	}
+	parts := strings.Fields(reply)
+	if len(parts) == 0 {
+		return []string{reply}
+	}
+	out := make([]string, 0, len(parts))
+	for i, part := range parts {
+		if i > 0 {
+			part = " " + part
+		}
+		out = append(out, part)
+	}
+	return out
+}

--- a/agent/stream_test.go
+++ b/agent/stream_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"go-micro.dev/v6/ai"
+)
+
+func TestStreamAskEmitsToolEventsAndFinalTokens(t *testing.T) {
+	calls := 0
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if opts.ToolHandler == nil {
+			t.Fatal("StreamAsk must configure a tool handler")
+		}
+		calls++
+		result := opts.ToolHandler(ctx, ai.ToolCall{ID: "call-1", Name: "echo", Input: map[string]any{"text": "hello"}})
+		return &ai.Response{
+			Reply:     "planning",
+			Answer:    "final answer",
+			ToolCalls: []ai.ToolCall{{ID: "call-1", Name: "echo", Input: map[string]any{"text": "hello"}, Result: result.Content}},
+		}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("streamer"), WithTool("echo", "echo text", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		return input["text"].(string), nil
+	}))
+	stream, err := a.StreamAsk(context.Background(), "say hello")
+	if err != nil {
+		t.Fatalf("StreamAsk: %v", err)
+	}
+
+	var types []StreamEventType
+	var tokens string
+	var done *Response
+	for {
+		event, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		types = append(types, event.Type)
+		if event.Type == StreamEventToken {
+			tokens += event.Token
+		}
+		if event.Type == StreamEventDone {
+			done = event.Response
+		}
+	}
+
+	want := []StreamEventType{StreamEventToolStart, StreamEventToolEnd, StreamEventToken, StreamEventToken, StreamEventToken, StreamEventDone}
+	if len(types) != len(want) {
+		t.Fatalf("event types = %v, want %v", types, want)
+	}
+	for i := range want {
+		if types[i] != want[i] {
+			t.Fatalf("event types = %v, want %v", types, want)
+		}
+	}
+	if tokens != "planning final answer" {
+		t.Fatalf("tokens = %q", tokens)
+	}
+	if done == nil || done.Reply != "planning\n\nfinal answer" {
+		t.Fatalf("done response = %#v", done)
+	}
+	if calls != 1 {
+		t.Fatalf("Generate calls = %d, want 1", calls)
+	}
+}
+
+func TestStreamAskHelperRejectsUnsupportedAgent(t *testing.T) {
+	_, err := StreamAsk(context.Background(), unsupportedAgent{}, "hello")
+	if err == nil {
+		t.Fatal("StreamAsk helper should reject unsupported implementations")
+	}
+}
+
+type unsupportedAgent struct{}
+
+func (unsupportedAgent) Name() string                                      { return "unsupported" }
+func (unsupportedAgent) Init(...Option)                                    {}
+func (unsupportedAgent) Options() Options                                  { return Options{} }
+func (unsupportedAgent) Ask(context.Context, string) (*Response, error)    { return nil, nil }
+func (unsupportedAgent) Stream(context.Context, string) (ai.Stream, error) { return nil, nil }
+func (unsupportedAgent) Run() error                                        { return nil }
+func (unsupportedAgent) Stop() error                                       { return nil }
+func (unsupportedAgent) String() string                                    { return "unsupported" }


### PR DESCRIPTION
Summary:
- Add an additive agent.StreamAsk entry point and helper that emit tool_start/tool_end events during an Ask run, then stream final-answer chunks and a done event.
- Preserve existing Agent interface compatibility by exposing StreamAsk as a concrete-method/helper extension rather than changing the interface.
- Add tests for tool event ordering, streamed final chunks, done response, and unsupported helper implementations.

Testing:
- go build ./...
- go test ./agent
- go test ./... (fails in this environment: loopback targets forbidden in grpc client/transport tests)
- golangci-lint run ./...

Closes #3341
Closes #3346