### PR TITLE
Add resumable StreamAsk checkpoints

### DIFF
--- a/agent/stream.go
+++ b/agent/stream.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"strings"
@@ -54,6 +55,19 @@ func StreamAsk(ctx context.Context, ag Agent, message string) (AgentStream, erro
 	return streamer.StreamAsk(ctx, message)
 }
 
+// ResumeStreamAsk resumes a checkpointed agent run and emits the same event
+// shape as StreamAsk. Completed runs are streamed from the persisted response;
+// unfinished runs continue from their checkpoint and emit tool events for any
+// work that still needs to run. Tool calls already recorded as done in the
+// checkpoint are reused by the agent checkpoint wrapper and are not re-executed.
+func ResumeStreamAsk(ctx context.Context, ag Agent, runID string) (AgentStream, error) {
+	a, ok := ag.(*agentImpl)
+	if !ok {
+		return nil, errors.New("agent: ResumeStreamAsk unsupported by implementation")
+	}
+	return a.resumeStreamAsk(ctx, runID)
+}
+
 // StreamAsk runs tools like Ask, emits ToolStart/ToolEnd events as they execute,
 // then emits chunks of the final answer followed by a Done event.
 func (a *agentImpl) StreamAsk(ctx context.Context, message string) (AgentStream, error) {
@@ -65,6 +79,29 @@ func (a *agentImpl) StreamAsk(ctx context.Context, message string) (AgentStream,
 		defer close(events)
 		defer close(done)
 		resp, err := a.askWithStreamEvents(ctx, message, events)
+		if err != nil {
+			s.setErr(err)
+			return
+		}
+		for _, tok := range splitStreamTokens(resp.Reply) {
+			if !sendStreamEvent(ctx, events, &StreamEvent{Type: StreamEventToken, Token: tok}) {
+				return
+			}
+		}
+		_ = sendStreamEvent(ctx, events, &StreamEvent{Type: StreamEventDone, Response: resp})
+	}()
+	return s, nil
+}
+
+func (a *agentImpl) resumeStreamAsk(ctx context.Context, runID string) (AgentStream, error) {
+	events := make(chan *StreamEvent, 16)
+	done := make(chan struct{})
+	s := &agentStream{events: events, done: done}
+
+	go func() {
+		defer close(events)
+		defer close(done)
+		resp, err := a.resumeWithStreamEvents(ctx, runID, events)
 		if err != nil {
 			s.setErr(err)
 			return
@@ -94,7 +131,51 @@ func (a *agentImpl) askWithStreamEvents(ctx context.Context, message string, eve
 		return result
 	}
 	a.setupWithToolHandler(handler)
+	defer a.setupWithToolHandler(nil)
 	return a.askLocked(ctx, uuid.New().String(), message, a.parentRunID, nil, true)
+}
+
+func (a *agentImpl) resumeWithStreamEvents(ctx context.Context, runID string, events chan<- *StreamEvent) (*Response, error) {
+	if a.opts.Checkpoint == nil {
+		return nil, errors.New("agent: ResumeStreamAsk requires a checkpoint")
+	}
+	run, ok, err := a.opts.Checkpoint.Load(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errors.New("agent: checkpointed run not found")
+	}
+	if run.Status == "done" {
+		var resp Response
+		if err := json.Unmarshal(run.State.Data, &resp); err != nil {
+			return nil, err
+		}
+		return &resp, nil
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.tools == nil {
+		a.tools = ai.NewTools(a.opts.Registry, ai.ToolClient(a.opts.Client))
+	}
+	base := a.toolHandler()
+	handler := func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		_ = sendStreamEvent(ctx, events, &StreamEvent{Type: StreamEventToolStart, ToolCall: call})
+		result := base(ctx, call)
+		_ = sendStreamEvent(ctx, events, &StreamEvent{Type: StreamEventToolEnd, ToolCall: call, Result: result})
+		return result
+	}
+	a.setupWithToolHandler(handler)
+	defer a.setupWithToolHandler(nil)
+	if run.Status == "paused" {
+		if run.State.Stage == agentInputStep {
+			return nil, errors.New("agent: checkpointed run is input-required; resume with ResumeInput")
+		}
+		run.Status = "running"
+		run.State.Stage = agentAskStep
+	}
+	return a.askLocked(ctx, run.ID, string(run.State.Data), run.ParentID, &run, false)
 }
 
 type agentStream struct {

--- a/agent/stream_test.go
+++ b/agent/stream_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/flow"
+	"go-micro.dev/v6/store"
 )
 
 func TestStreamAskEmitsToolEventsAndFinalTokens(t *testing.T) {
@@ -77,6 +79,87 @@ func TestStreamAskHelperRejectsUnsupportedAgent(t *testing.T) {
 	_, err := StreamAsk(context.Background(), unsupportedAgent{}, "hello")
 	if err == nil {
 		t.Fatal("StreamAsk helper should reject unsupported implementations")
+	}
+}
+
+func TestResumeStreamAskDoesNotReplayCompletedTool(t *testing.T) {
+	ctx := context.Background()
+	cp := flow.StoreCheckpoint(store.NewStore(), "stream-resume-agent")
+	toolRuns := 0
+	first := true
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if opts.ToolHandler != nil {
+			res := opts.ToolHandler(ctx, ai.ToolCall{ID: "call-1", Name: "charge", Input: map[string]any{"order": "42"}})
+			if res.Content != "charged" {
+				t.Fatalf("tool result = %q, want charged", res.Content)
+			}
+		}
+		if first {
+			first = false
+			return nil, errors.New("stream disconnected after tool")
+		}
+		return &ai.Response{Reply: "finished from streamed checkpoint"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("stream-resume-agent"), WithCheckpoint(cp),
+		WithTool("charge", "charge once", nil, func(context.Context, map[string]any) (string, error) {
+			toolRuns++
+			return "charged", nil
+		}))
+	stream, err := a.StreamAsk(ctx, "charge order 42")
+	if err != nil {
+		t.Fatalf("StreamAsk: %v", err)
+	}
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			break
+		}
+	}
+	if toolRuns != 1 {
+		t.Fatalf("tool executions after failed StreamAsk = %d, want 1", toolRuns)
+	}
+	runs, err := Pending(ctx, a)
+	if err != nil {
+		t.Fatalf("Pending: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("Pending returned %d runs, want 1", len(runs))
+	}
+
+	resumed, err := ResumeStreamAsk(ctx, a, runs[0].ID)
+	if err != nil {
+		t.Fatalf("ResumeStreamAsk: %v", err)
+	}
+	var toolEvents int
+	var done *Response
+	for {
+		event, err := resumed.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("resumed Recv: %v", err)
+		}
+		if event.Type == StreamEventToolStart || event.Type == StreamEventToolEnd {
+			toolEvents++
+		}
+		if event.Type == StreamEventDone {
+			done = event.Response
+		}
+	}
+	if toolRuns != 1 {
+		t.Fatalf("tool executions after ResumeStreamAsk = %d, want completed tool was not replayed", toolRuns)
+	}
+	if toolEvents != 2 {
+		t.Fatalf("resumed tool events = %d, want start/end for replayed checkpoint result", toolEvents)
+	}
+	if done == nil || done.Reply != "finished from streamed checkpoint" || done.RunID != runs[0].ID {
+		t.Fatalf("done response = %#v", done)
 	}
 }
 

--- a/internal/docs/AGENT_DESIGN.md
+++ b/internal/docs/AGENT_DESIGN.md
@@ -122,6 +122,19 @@ database "agent", table "{name}":
   history    — conversation history
 ```
 
+## Durable Ask / StreamAsk runs
+
+Agents can opt into the same checkpoint backend used by flows with
+`micro.AgentWithCheckpoint(...)`. When enabled, each `Ask` or `StreamAsk` run is
+persisted with its input, terminal status, response, and tool-call records. If
+the process or transport drops after a tool has completed but before the model
+returns a final answer, restart the agent with the same checkpoint store and
+call `micro.AgentResume(ctx, ag, runID)` or
+`micro.AgentResumeStreamAsk(ctx, ag, runID)`.
+Completed tool calls are served from the checkpoint instead of being executed
+again, while guardrails such as `MaxSteps`, loop detection, approval pauses, and
+`request_input` pauses continue to apply to the resumed run.
+
 ## Built-in Capabilities
 
 Beyond its scoped service tools, every agent gets two built-in tools. They are not service endpoints — they are capabilities the agent has over itself and over other agents. They are plain tools wired into the agent's tool handler; there is no separate harness, loop engine, or graph. The LLM calls them exactly like any other tool.

--- a/micro.go
+++ b/micro.go
@@ -26,6 +26,9 @@ type Agent = agent.Agent
 // AgentResponse is what an agent returns from Ask or a resumed run.
 type AgentResponse = agent.Response
 
+// AgentStream is a stream of tool execution events followed by final-answer chunks.
+type AgentStream = agent.AgentStream
+
 // AgentOption configures an Agent.
 type AgentOption = agent.Option
 
@@ -188,6 +191,12 @@ func AgentResume(ctx context.Context, a Agent, runID string) (*AgentResponse, er
 // AgentResumeInput resumes a checkpointed agent run waiting for human input.
 func AgentResumeInput(ctx context.Context, a Agent, runID, input string) (*AgentResponse, error) {
 	return agent.ResumeInput(ctx, a, runID, input)
+}
+
+// AgentResumeStreamAsk resumes a checkpointed agent run by id and streams the
+// resulting tool events and final answer.
+func AgentResumeStreamAsk(ctx context.Context, a Agent, runID string) (AgentStream, error) {
+	return agent.ResumeStreamAsk(ctx, a, runID)
 }
 
 // NewFlow creates an event-driven LLM orchestration unit.


### PR DESCRIPTION
## Summary
- add ResumeStreamAsk for checkpointed agent runs so streamed Ask executions can resume from durable state
- expose AgentResumeStreamAsk through the root micro package
- document durable Ask / StreamAsk resume semantics

## Testing
- go build ./...
- go test ./agent/...
- go test ./... (fails in this environment: loopback targets forbidden in grpc client/transport tests)
- golangci-lint run ./...

Closes #3349
Closes #3351