### PR TITLE
events: WithStore option for a durable, replayable stream

### DIFF
--- a/events/memory.go
+++ b/events/memory.go
@@ -19,7 +19,11 @@ func NewStream(opts ...Option) (Stream, error) {
 	for _, o := range opts {
 		o(&options)
 	}
-	return &mem{store: store.NewMemoryStore()}, nil
+	st := options.Store
+	if st == nil {
+		st = store.NewMemoryStore()
+	}
+	return &mem{store: st}, nil
 }
 
 type subscriber struct {

--- a/events/options.go
+++ b/events/options.go
@@ -1,10 +1,24 @@
 package events
 
-import "time"
+import (
+	"time"
 
-type Options struct{}
+	"go-micro.dev/v6/store"
+)
+
+type Options struct {
+	// Store persists published events for durability and replay. If nil, an
+	// in-memory store is used and events do not survive a restart.
+	Store store.Store
+}
 
 type Option func(o *Options)
+
+// WithStore backs the stream with a durable store (e.g. the file store), so
+// published events persist and can be replayed across restarts.
+func WithStore(s store.Store) Option {
+	return func(o *Options) { o.Store = s }
+}
 
 type StoreOptions struct {
 	TTL    time.Duration


### PR DESCRIPTION
The events stream is store-backed (Publish writes to the store, Consume replays from it by offset), but NewStream hardcoded an in-memory store and ignored its Options — so it could never be made durable.

Add an Options.Store field + WithStore(store.Store) option, and have NewStream use it (defaulting to the memory store). Backed by the file store, published events now persist and replay across restarts with no external infrastructure.

Verified: events build/vet/test green; a new stream over a file store replays a previously-published event.

---
_Generated by [Claude Code](https://claude.ai/code)_