### PR TITLE
Wire getting-started harness into make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo "  make test-race     - Run tests with race detector"
 	@echo "  make test-coverage - Run tests with coverage"
 	@echo "  make lint          - Run linter"
-	@echo "  make harness       - Run deterministic end-to-end harnesses"
+	@echo "  make harness       - Run deterministic getting-started and end-to-end harnesses"
 	@echo "  make provider-conformance - Run harnesses against configured live providers"
 	@echo "  make fmt           - Format code"
 	@echo "  make install-tools - Install development tools"
@@ -42,12 +42,14 @@ test-coverage:
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report: coverage.html"
 
-# Run the end-to-end harnesses (deterministic, mock LLM — no API key).
-# The universe harness exits non-zero on assertion failure.
+# Run the documented getting-started contracts plus the deterministic
+# services → agents → workflows harnesses (mock LLM — no API key).
+# This mirrors the default CI path so local dogfooding catches scaffold,
+# run/chat/inspect, and 0→hero regressions before a PR is opened.
 harness:
-	go run ./internal/harness/universe
+	go test ./cmd/micro/cli/new -run TestZeroToOneContract -count=1
+	./internal/harness/zero-to-hero-ci/run.sh
 	go run ./internal/harness/agent-flow
-	go run ./internal/harness/plan-delegate # 0→hero: services + agents + flow + plan/delegate
 
 # Run the same harnesses against every configured live provider. Providers
 # without API keys are skipped; configured providers must pass.

--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -15,3 +15,18 @@ scripted so CI can run it on every push without external services or model keys.
 After the CLI boundary smoke checks, the script runs the deterministic harnesses
 that boot real services, agents, workflows, store-backed run history, and A2A
 with only the LLM mocked.
+
+## Local and CI entry points
+
+The default GitHub harness workflow runs this script on every push and pull
+request after the 0→1 scaffold contract. Developers can run the same no-secret
+contract locally with:
+
+```sh
+make harness
+```
+
+That target intentionally exercises the documented getting-started path before
+the 0→hero scenario, so the public scaffold → run/chat → inspect lifecycle stays
+executable outside CI as well. Live provider checks remain separate and gated by
+configured API keys (`make provider-conformance` or the scheduled/manual CI job).


### PR DESCRIPTION
Summary:
- Make `make harness` run the 0→1 scaffold contract and the 0→hero run/chat/inspect script before the agent-flow harness.
- Document the local no-secret entry point for the zero-to-hero CI harness.

Testing:
- `make harness`
- `go build ./...`
- `go test ./...` (fails in this environment because gRPC loopback tests are routed through the proxy and receive `Loopback targets forbidden`)
- `golangci-lint run ./...`

Closes #3354
Closes #3359