### PR TITLE
agent: fix StreamAsk tool resolution (reuse tools instance)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -149,7 +149,12 @@ func (a *agentImpl) setupWithToolHandler(handler ai.ToolHandler) {
 		modelOpts = append(modelOpts, ai.WithModel(a.opts.Model))
 	}
 
-	a.tools = ai.NewTools(a.opts.Registry, ai.ToolClient(a.opts.Client))
+	// Reuse the existing tools instance: its name map is populated by
+	// discoverTools, and rebuilding it here would orphan a base handler that
+	// already captured the old instance (breaking StreamAsk tool resolution).
+	if a.tools == nil {
+		a.tools = ai.NewTools(a.opts.Registry, ai.ToolClient(a.opts.Client))
+	}
 	if handler == nil {
 		handler = a.toolHandler()
 	}


### PR DESCRIPTION
setupWithToolHandler unconditionally rebuilt a.tools. In askWithStreamEvents the base handler binds rpc:=a.tools.Handler() to the tools instance BEFORE setup rebuilds it, so discoverTools then populates a different instance's name map and every tool call fails name resolution (the model reports 'the tool name wasn't quite right' and never uses the result).

Reuse the existing a.tools instance (create only when nil) so the name map populated by discoverTools is the one the base handler resolves against. Verified: a StreamAsk run over a registered service now uses the tool result correctly where it previously failed.

---
_Generated by [Claude Code](https://claude.ai/code)_