### PR TITLE
Redact agent run inputs from traces

### DIFF
--- a/agent/options.go
+++ b/agent/options.go
@@ -91,6 +91,11 @@ type Options struct {
 	// and tool calls. Nil disables instrumentation.
 	TraceProvider trace.TracerProvider
 
+	// TraceInputs controls whether agent observability records include raw
+	// user messages. It is false by default so spans and persisted run
+	// timelines carry correlation and shape without leaking prompts.
+	TraceInputs bool
+
 	// tools are developer-registered custom tools (see WithTool).
 	tools []customTool
 	// wrappers are developer-registered tool-execution wrappers
@@ -294,4 +299,12 @@ func WithTool(name, description string, properties map[string]any, handler ToolF
 // added only when a provider is configured.
 func TraceProvider(tp trace.TracerProvider) Option {
 	return func(o *Options) { o.TraceProvider = tp }
+}
+
+// TraceInputs opts in to recording raw user messages on agent run events.
+// By default inputs are redacted from OpenTelemetry spans and persisted run
+// timelines; use this only when the observability backend is approved to store
+// prompt content.
+func TraceInputs(enabled bool) Option {
+	return func(o *Options) { o.TraceInputs = enabled }
 }

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -37,6 +37,7 @@ const (
 	AttrDelegate       = "agent.delegate"
 	AttrGuardrailBlock = "agent.guardrail.block"
 	AttrRefusal        = "agent.refusal"
+	AttrInputChars     = "agent.input.chars"
 )
 
 type RunEvent struct {
@@ -56,6 +57,7 @@ type RunEvent struct {
 	Tokens      Usage     `json:"tokens,omitempty"`
 	Refused     string    `json:"refused,omitempty"`
 	Error       string    `json:"error,omitempty"`
+	InputChars  int       `json:"input_chars,omitempty"`
 }
 
 type Usage = ai.Usage
@@ -98,9 +100,13 @@ func (a *agentImpl) tracer() trace.Tracer {
 func (a *agentImpl) startRun(ctx context.Context, message string) (context.Context, func(error)) {
 	info, _ := ai.RunInfoFrom(ctx)
 	start := time.Now()
+	runEvent := RunEvent{Time: start, RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "run", InputChars: len(message)}
+	if a.opts.TraceInputs {
+		runEvent.Name = message
+	}
 
 	if a.opts.TraceProvider == nil {
-		a.recordRunEvent(RunEvent{Time: start, RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "run", Name: message})
+		a.recordRunEvent(runEvent)
 		return ctx, func(err error) {
 			latency := time.Since(start).Milliseconds()
 			if err != nil {
@@ -113,7 +119,7 @@ func (a *agentImpl) startRun(ctx context.Context, message string) (context.Conte
 
 	ctx, span := a.tracer().Start(ctx, spanNameRun, trace.WithSpanKind(trace.SpanKindInternal), trace.WithAttributes(
 		attribute.String(AttrRunID, info.RunID), attribute.String(AttrParentRunID, info.ParentID), attribute.String(AttrAgentName, info.Agent)))
-	a.recordSpanEvent(span, RunEvent{Time: start, RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "run", Name: message})
+	a.recordSpanEvent(span, runEvent)
 	return ctx, func(err error) {
 		latency := time.Since(start).Milliseconds()
 		span.SetAttributes(attribute.Int64(AttrLatencyMS, latency))
@@ -292,6 +298,9 @@ func runEventAttributes(e RunEvent) []attribute.KeyValue {
 	}
 	if e.LatencyMS > 0 {
 		attrs = append(attrs, attribute.Int64(AttrLatencyMS, e.LatencyMS))
+	}
+	if e.InputChars > 0 {
+		attrs = append(attrs, attribute.Int(AttrInputChars, e.InputChars))
 	}
 	attrs = appendUsage(attrs, e.Tokens)
 	if e.Refused != "" {

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -132,6 +132,75 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	}
 }
 
+func TestAgentRunObservabilityRedactsInputByDefault(t *testing.T) {
+	secret := "deploy production with token sk-secret"
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exp))
+	st := store.NewMemoryStore()
+	a := New(Name("redactor"), Provider("oteltest"), WithStore(st), TraceProvider(tp))
+	if _, err := a.Ask(context.Background(), secret); err != nil {
+		t.Fatal(err)
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	var sawInputChars bool
+	for _, s := range spans {
+		for _, event := range s.Events() {
+			attrs := spanAttributes(event.Attributes)
+			if attrs["agent.event.name"] == secret {
+				t.Fatalf("span event leaked raw input: %#v", event)
+			}
+			if attrs[AttrInputChars] == fmt.Sprint(len(secret)) {
+				sawInputChars = true
+			}
+		}
+	}
+	if !sawInputChars {
+		t.Fatal("run event missing redacted input length attribute")
+	}
+
+	summaries, err := ListRunSummaries(st, "redactor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := LoadRunEvents(st, "redactor", summaries[0].RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.Name == secret {
+			t.Fatalf("persisted run event leaked raw input: %#v", event)
+		}
+		if event.Kind == "run" && event.InputChars != len(secret) {
+			t.Fatalf("run event InputChars = %d, want %d", event.InputChars, len(secret))
+		}
+	}
+}
+
+func TestAgentTraceInputsOptInRecordsInput(t *testing.T) {
+	message := "operator-approved diagnostic prompt"
+	st := store.NewMemoryStore()
+	a := New(Name("input-opt-in"), Provider("oteltest"), WithStore(st), TraceInputs(true))
+	if _, err := a.Ask(context.Background(), message); err != nil {
+		t.Fatal(err)
+	}
+
+	summaries, err := ListRunSummaries(st, "input-opt-in")
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := LoadRunEvents(st, "input-opt-in", summaries[0].RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.Kind == "run" && event.Name == message {
+			return
+		}
+	}
+	t.Fatalf("opt-in run event did not record message: %#v", events)
+}
+
 type failingOtelModel struct{ opts ai.Options }
 
 func (m *failingOtelModel) Init(opts ...ai.Option) error {


### PR DESCRIPTION
Summary:
- Redact raw agent Ask inputs from run timeline and OpenTelemetry events by default while retaining input length for observability.
- Add an explicit TraceInputs opt-in for approved environments that can store prompt content.
- Add tests for default redaction and opt-in input recording.

Testing:
- go build ./...
- go test ./agent
- go test ./... (fails in this environment due loopback targets forbidden in grpc tests)
- golangci-lint run ./...

Closes #3362
Closes #3364