### PR TITLE
Add typed A2A skill endpoints

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -140,8 +140,11 @@ func (g *Gateway) Handler() http.Handler {
 	// Per-agent card (served at the agent's url and at its well-known path).
 	mux.HandleFunc("GET /agents/{name}", g.handleCard)
 	mux.HandleFunc("GET /agents/{name}/.well-known/agent.json", g.handleCard)
+	mux.HandleFunc("GET /agents/{name}/skills/{skill}", g.handleSkillCard)
+	mux.HandleFunc("GET /agents/{name}/skills/{skill}/.well-known/agent.json", g.handleSkillCard)
 	// Per-agent JSON-RPC endpoint.
 	mux.HandleFunc("POST /agents/{name}", g.handleRPC)
+	mux.HandleFunc("POST /agents/{name}/skills/{skill}", g.handleSkillRPC)
 	// Top-level well-known: serve the single agent's card if there's
 	// exactly one, otherwise point to the directory.
 	mux.HandleFunc("GET /.well-known/agent.json", g.handleWellKnown)
@@ -338,23 +341,17 @@ func Card(name, url, description string, services []string) AgentCard {
 			description = "Go Micro agent"
 		}
 	}
+	skills := skillsFromServices(services)
 	return AgentCard{
-		Name:            name,
-		Description:     description,
-		URL:             url,
-		Version:         "1.0.0",
-		ProtocolVersion: protocolVersion,
-		Capabilities:    Capabilities{Streaming: true, PushNotifications: true},
-		// The agent converses over a single Chat endpoint; advertise that
-		// as one skill, tagged with the services it manages.
+		Name:               name,
+		Description:        description,
+		URL:                url,
+		Version:            "1.0.0",
+		ProtocolVersion:    protocolVersion,
+		Capabilities:       Capabilities{Streaming: true, PushNotifications: true},
 		DefaultInputModes:  []string{"text/plain"},
 		DefaultOutputModes: []string{"text/plain"},
-		Skills: []Skill{{
-			ID:          "chat",
-			Name:        "Chat",
-			Description: "Converse with the agent to operate its services.",
-			Tags:        services,
-		}},
+		Skills:             skills,
 	}
 }
 
@@ -369,6 +366,19 @@ func (g *Gateway) lookupCard(name string) (AgentCard, bool) {
 		return AgentCard{}, false
 	}
 	return g.card(name, meta), true
+}
+
+func (g *Gateway) lookupSkillCard(name, skillID string) (AgentCard, Skill, bool) {
+	card, ok := g.lookupCard(name)
+	if !ok {
+		return AgentCard{}, Skill{}, false
+	}
+	for _, skill := range card.Skills {
+		if skill.ID == skillID {
+			return card, skill, true
+		}
+	}
+	return AgentCard{}, Skill{}, false
 }
 
 // ---------------------------------------------------------------------------
@@ -390,6 +400,17 @@ func (g *Gateway) handleCard(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	writeJSON(w, http.StatusOK, card)
+}
+
+func (g *Gateway) handleSkillCard(w http.ResponseWriter, r *http.Request) {
+	card, skill, ok := g.lookupSkillCard(r.PathValue("name"), r.PathValue("skill"))
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	card.URL = g.opts.BaseURL + "/agents/" + r.PathValue("name") + "/skills/" + skill.ID
+	card.Skills = []Skill{skill}
 	writeJSON(w, http.StatusOK, card)
 }
 
@@ -418,6 +439,18 @@ func (g *Gateway) handleRPC(w http.ResponseWriter, r *http.Request) {
 	}
 	g.disp.serve(w, r, func(ctx context.Context, text string) (string, error) {
 		return g.callAgent(ctx, name, text)
+	})
+}
+
+func (g *Gateway) handleSkillRPC(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	_, skill, ok := g.lookupSkillCard(name, r.PathValue("skill"))
+	if !ok {
+		writeRPC(w, nil, nil, &rpcError{Code: errInvalidParams, Message: "unknown agent skill: " + name + "/" + r.PathValue("skill")})
+		return
+	}
+	g.disp.serve(w, r, func(ctx context.Context, text string) (string, error) {
+		return g.callAgent(ctx, name, skillPrompt(skill, text))
 	})
 }
 
@@ -851,6 +884,68 @@ func (d *dispatcher) deliverPush(taskID string, task *Task) {
 	if err == nil && resp.Body != nil {
 		_ = resp.Body.Close()
 	}
+}
+
+func skillsFromServices(services []string) []Skill {
+	if len(services) == 0 {
+		return []Skill{{ID: "chat", Name: "Chat", Description: "Converse with the agent to operate its services."}}
+	}
+	seen := map[string]bool{}
+	var skills []Skill
+	for _, service := range services {
+		service = strings.TrimSpace(service)
+		if service == "" {
+			continue
+		}
+		id := skillID(service)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		skills = append(skills, Skill{
+			ID:          id,
+			Name:        skillName(service),
+			Description: fmt.Sprintf("Operate the %s service through this agent.", service),
+			Tags:        []string{service},
+		})
+	}
+	if len(skills) == 0 {
+		return []Skill{{ID: "chat", Name: "Chat", Description: "Converse with the agent to operate its services."}}
+	}
+	return skills
+}
+
+func skillID(service string) string {
+	service = strings.ToLower(strings.TrimSpace(service))
+	var b strings.Builder
+	dash := false
+	for _, r := range service {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			dash = false
+			continue
+		}
+		if !dash && b.Len() > 0 {
+			b.WriteByte('-')
+			dash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func skillName(service string) string {
+	parts := strings.FieldsFunc(service, func(r rune) bool { return r == '-' || r == '_' || r == '.' || r == '/' || r == ' ' })
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+func skillPrompt(skill Skill, text string) string {
+	return fmt.Sprintf("Use the %q skill (%s) for this request.\n\n%s", skill.Name, skill.ID, text)
 }
 
 func textOf(parts []Part) string {

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -51,7 +51,7 @@ func newGatewayWithAgent(t *testing.T) (*httptest.Server, func()) {
 		server.Name("echo"),
 		server.Address("127.0.0.1:0"),
 		server.Registry(reg),
-		server.Metadata(map[string]string{"type": "agent", "services": ""}),
+		server.Metadata(map[string]string{"type": "agent", "services": "task,project"}),
 	)
 	if err := pb.RegisterAgentHandler(srv, echoAgent{}); err != nil {
 		t.Fatalf("register agent handler: %v", err)
@@ -88,8 +88,40 @@ func TestAgentCardFromRegistry(t *testing.T) {
 	if card.URL != "http://gw/agents/echo" {
 		t.Errorf("card url = %q", card.URL)
 	}
-	if card.ProtocolVersion == "" || len(card.Skills) == 0 {
-		t.Errorf("card missing protocolVersion or skills: %+v", card)
+	if card.ProtocolVersion == "" {
+		t.Errorf("card missing protocolVersion: %+v", card)
+	}
+	if got := skillIDs(card.Skills); strings.Join(got, ",") != "task,project" {
+		t.Errorf("skill IDs = %v, want [task project]", got)
+	}
+}
+
+func TestSkillEndpointServesFocusedCardAndRoutesRPC(t *testing.T) {
+	ts, cleanup := newGatewayWithAgent(t)
+	defer cleanup()
+
+	resp, err := http.Get(ts.URL + "/agents/echo/skills/task/.well-known/agent.json")
+	if err != nil {
+		t.Fatalf("get skill card: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("skill card status = %d", resp.StatusCode)
+	}
+	var card AgentCard
+	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+		t.Fatalf("decode skill card: %v", err)
+	}
+	if card.URL != "http://gw/agents/echo/skills/task" || len(card.Skills) != 1 || card.Skills[0].ID != "task" {
+		t.Fatalf("skill card = %+v, want task-only card at skill URL", card)
+	}
+
+	task := rpcTask(t, ts.URL+"/agents/echo/skills/task", `{
+		"jsonrpc":"2.0","id":1,"method":"message/send",
+		"params":{"message":{"role":"user","kind":"message","messageId":"m1",
+			"parts":[{"kind":"text","text":"ping"}]}}}`)
+	if task.Status.State != stateCompleted || textOf(task.Artifacts[0].Parts) != "pong" {
+		t.Fatalf("skill task = %+v, want completed pong", task)
 	}
 }
 
@@ -643,4 +675,12 @@ func rpcTask(t *testing.T, url, body string) Task {
 		t.Fatalf("rpc error: %+v", resp.Error)
 	}
 	return resp.Result
+}
+
+func skillIDs(skills []Skill) []string {
+	ids := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		ids = append(ids, skill.ID)
+	}
+	return ids
 }

--- a/internal/website/docs/guides/a2a-protocol.md
+++ b/internal/website/docs/guides/a2a-protocol.md
@@ -69,9 +69,17 @@ A card looks like:
   "capabilities": { "streaming": true, "pushNotifications": true },
   "defaultInputModes": ["text/plain"],
   "defaultOutputModes": ["text/plain"],
-  "skills": [{ "id": "chat", "name": "Chat", "tags": ["task", "project"] }]
+  "skills": [
+    { "id": "task", "name": "Task", "tags": ["task"] },
+    { "id": "project", "name": "Project", "tags": ["project"] }
+  ]
 }
 ```
+
+Each managed service is advertised as its own typed skill. Clients can call the
+whole agent at `/agents/task-mgr`, or address one skill directly at
+`/agents/task-mgr/skills/task`; the skill endpoint serves a focused card and
+routes the request to the same agent with that skill selected.
 
 ## Calling an agent
 


### PR DESCRIPTION
## Summary
- advertise each managed service on A2A Agent Cards as a typed skill
- add focused per-skill card and JSON-RPC endpoints under /agents/{name}/skills/{skill}
- document the typed skill card shape and skill endpoint routing

## Testing
- go build ./...
- go test ./... (environment blocks loopback gRPC targets; unrelated failures in client/grpc and transport/grpc)
- golangci-lint run ./...

Closes #3342
Closes #3374