### PR TITLE
Maintain zero-to-hero support example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -80,10 +80,11 @@ A workflow as ordered, checkpointed steps that survives a crash and resumes wher
 - **Checkpoint** — each step is persisted; on `Resume`, completed steps are not re-run (no duplicate side effects)
 
 ### [support](./support/)
-A real-world support desk — the "zero to hero" shape in one runnable file:
-- **services** (`customers`, `tickets`, `notify`) become the agent's tools automatically
-- **flow** turns a `ticket.created` event into work for the agent (the event is the prompt)
-- **guardrail** — the agent triages freely but can't email a customer without passing the approval gate
+A maintained 0-to-hero reference path in one runnable file:
+- **scaffold** typed `customers`, `tickets`, and `notify` services
+- **run/chat** with a support agent that uses those services as tools
+- **inspect** the event-driven `intake` flow and approval gate
+- **CI** keeps the deterministic mock-model journey runnable with `go test ./examples/support`
 
 ## Coming Soon
 

--- a/examples/support/README.md
+++ b/examples/support/README.md
@@ -1,9 +1,25 @@
-# Support desk
+# Zero-to-hero support desk
 
-A real-world agent built the Go Micro way: a few services, an agent that
-manages them, an event that triggers it, and a human-in-the-loop gate on the
-one action that touches a customer. It's the "zero to hero" shape in one
-runnable file.
+A maintained 0-to-hero reference for the Go Micro lifecycle: scaffold a few
+typed services, run them in one process, let an agent chat with those services
+as tools, then inspect the durable flow that triggered the work. It is one
+runnable file and one CI smoke test, so the reference path stays honest as the
+framework evolves.
+
+## The path
+
+1. **Scaffold services** — `customers`, `tickets`, and `notify` are ordinary
+   typed Go Micro services. Their request/response structs and method comments
+   become the tool contract the agent sees.
+2. **Run the harness** — the example starts an in-memory registry, broker,
+   client, store, services, agent, and flow in one process; no external
+   dependencies or API key are required for the default run.
+3. **Chat through an agent** — the `support` agent receives the ticket event as
+   a prompt and calls service tools to look up the customer, triage the ticket,
+   and draft a reply.
+4. **Inspect the workflow** — the `intake` flow records the event-driven run and
+   prints the agent result, showing the service → agent → workflow lifecycle as
+   one runtime.
 
 ## The scenario
 
@@ -42,6 +58,12 @@ agent, which:
 
 ```bash
 go run main.go            # mock model — deterministic, no API key
+```
+
+The maintained check is the same deterministic path:
+
+```bash
+go test ./examples/support
 ```
 
 Against a live model, the agent reasons about the ticket itself instead of

--- a/examples/support/main_test.go
+++ b/examples/support/main_test.go
@@ -1,9 +1,32 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+)
 
 func TestRunSupportMockSmoke(t *testing.T) {
 	if err := runSupport("mock"); err != nil {
 		t.Fatalf("support example failed: %v", err)
+	}
+}
+
+func TestZeroToHeroReadmeDocumentsLifecycle(t *testing.T) {
+	b, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	doc := string(b)
+	for _, want := range []string{
+		"Scaffold services",
+		"Run the harness",
+		"Chat through an agent",
+		"Inspect the workflow",
+		"go test ./examples/support",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("README.md missing zero-to-hero step %q", want)
+		}
 	}
 }


### PR DESCRIPTION
Summary:
- Documents the support example as the maintained 0-to-hero services → agent → workflow path.
- Adds a README regression test that keeps the scaffold/run/chat/inspect path visible alongside the deterministic smoke test.

Testing:
- go build ./...
- go test ./examples/support
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3368
Closes #3378