### PR TITLE
Add deploy checkpoint to zero-to-hero harness

### DIFF
--- a/cmd/micro/cli/deploy/deploy.go
+++ b/cmd/micro/cli/deploy/deploy.go
@@ -43,6 +43,9 @@ func Deploy(c *cli.Context) error {
 	}
 
 	target, remotePath := resolveDeployTarget(c, target, cfg)
+	if c.Bool("dry-run") {
+		return printDeployPlan(c, target, cfg, remotePath)
+	}
 
 	return deploySSH(c, target, cfg, remotePath)
 }
@@ -96,6 +99,81 @@ func showDeployTargets(cfg *config.Config) error {
 	return fmt.Errorf("%s", sb.String())
 }
 
+func printDeployPlan(c *cli.Context, target string, cfg *config.Config, remotePath string) error {
+	dir := c.Args().Get(1)
+	if dir == "" {
+		dir = "."
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	if cfg == nil {
+		cfg, _ = config.Load(absDir)
+	}
+	if remotePath == "" {
+		remotePath = defaultRemotePath
+	}
+
+	services, err := deployServices(absDir, cfg, c.String("service"))
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("  \033[1mmicro deploy --dry-run\033[0m")
+	fmt.Println()
+	fmt.Printf("  Target      \033[36m%s\033[0m\n", target)
+	fmt.Printf("  Remote path %s\n", remotePath)
+	fmt.Printf("  Services    %s\n", strings.Join(services, ", "))
+	fmt.Println()
+	fmt.Println("  Plan:")
+	fmt.Println("    1. Build linux/amd64 service binaries")
+	fmt.Printf("    2. Copy binaries to %s/bin/\n", remotePath)
+	fmt.Println("    3. Enable and restart micro@<service> systemd units")
+	fmt.Println("    4. Check service health")
+	fmt.Println()
+	fmt.Println("  No SSH, rsync, systemd, or remote deployment was performed.")
+	return nil
+}
+
+func deployServices(absDir string, cfg *config.Config, filterService string) ([]string, error) {
+	if filterService != "" && cfg != nil {
+		found := false
+		for _, svc := range cfg.Services {
+			if svc.Name == filterService {
+				found = true
+				break
+			}
+		}
+		if !found && len(cfg.Services) > 0 {
+			return nil, fmt.Errorf("service '%s' not found in configuration", filterService)
+		}
+	}
+
+	if cfg != nil && len(cfg.Services) > 0 {
+		sorted, err := cfg.TopologicalSort()
+		if err != nil {
+			return nil, err
+		}
+		services := make([]string, 0, len(sorted))
+		for _, svc := range sorted {
+			if filterService == "" || svc.Name == filterService {
+				services = append(services, svc.Name)
+			}
+		}
+		return services, nil
+	}
+
+	services := []string{filepath.Base(absDir)}
+	if filterService != "" && filterService != services[0] {
+		return nil, fmt.Errorf("service '%s' not found (only '%s' available)", filterService, services[0])
+	}
+	return services, nil
+}
+
 func deploySSH(c *cli.Context, target string, cfg *config.Config, remotePath string) error {
 	dir := c.Args().Get(1)
 	if dir == "" {
@@ -121,19 +199,10 @@ func deploySSH(c *cli.Context, target string, cfg *config.Config, remotePath str
 	fmt.Println()
 	fmt.Printf("  Target     \033[36m%s\033[0m\n\n", target)
 
-	// Early validation: Check if the requested service exists before SSH checks
-	filterService := c.String("service")
-	if filterService != "" && cfg != nil {
-		found := false
-		for _, svc := range cfg.Services {
-			if svc.Name == filterService {
-				found = true
-				break
-			}
-		}
-		if !found && len(cfg.Services) > 0 {
-			return fmt.Errorf("service '%s' not found in configuration", filterService)
-		}
+	// Early validation: resolve services before SSH checks.
+	services, err := deployServices(absDir, cfg, c.String("service"))
+	if err != nil {
+		return err
 	}
 
 	// Step 1: Check SSH connectivity
@@ -153,28 +222,6 @@ func deploySSH(c *cli.Context, target string, cfg *config.Config, remotePath str
 	fmt.Println("\u2713")
 
 	// Step 3: Build binaries
-	var services []string
-	if cfg != nil && len(cfg.Services) > 0 {
-		sorted, err := cfg.TopologicalSort()
-		if err != nil {
-			return err
-		}
-		for _, svc := range sorted {
-			// If --service flag is provided, only include that service
-			if filterService == "" || svc.Name == filterService {
-				services = append(services, svc.Name)
-			}
-		}
-	} else {
-		// Single service project
-		services = []string{filepath.Base(absDir)}
-
-		// If --service flag was provided for a single-service project, validate it matches
-		if filterService != "" && filterService != services[0] {
-			return fmt.Errorf("service '%s' not found (only '%s' available)", filterService, services[0])
-		}
-	}
-
 	fmt.Printf("  Building binaries...       ")
 	if err := buildBinaries(absDir, cfg, c.Bool("build"), services); err != nil {
 		fmt.Println("\u2717")
@@ -492,6 +539,10 @@ The deploy process:
 			&cli.StringFlag{
 				Name:  "service",
 				Usage: "Deploy only a specific service (for multi-service projects)",
+			},
+			&cli.BoolFlag{
+				Name:  "dry-run",
+				Usage: "Print the deployment plan without building, connecting, copying, or restarting services",
 			},
 		},
 	})

--- a/cmd/micro/cli/deploy/deploy_test.go
+++ b/cmd/micro/cli/deploy/deploy_test.go
@@ -17,6 +17,7 @@ func newDeployTestContext(t *testing.T, args ...string) *cli.Context {
 	set.String("ssh", "", "")
 	set.String("service", "", "")
 	set.Bool("build", false, "")
+	set.Bool("dry-run", false, "")
 	if err := set.Parse(args); err != nil {
 		t.Fatalf("parse flags: %v", err)
 	}
@@ -116,5 +117,51 @@ deploy prod
 	}
 	if prod.SSH != "deploy@prod.example.com" || prod.Path != "/srv/micro" {
 		t.Fatalf("deploy target = %#v", prod)
+	}
+}
+
+func TestDeployDryRunPlansConfiguredTargetWithoutRemoteSideEffects(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(dir+"/micro.mu", []byte(`service api
+    path ./api
+
+deploy prod
+    ssh deploy@prod.example.com
+    path /srv/micro
+`), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	ctx := newDeployTestContext(t, "--dry-run", "prod")
+	if err := Deploy(ctx); err != nil {
+		t.Fatalf("dry-run deploy: %v", err)
+	}
+}
+
+func TestDeployDryRunValidatesRequestedService(t *testing.T) {
+	ctx := newDeployTestContext(t, "--dry-run", "--service", "missing", "prod")
+	cfg := &config.Config{Services: map[string]*config.Service{
+		"api": {Name: "api", Path: "./api"},
+	}}
+
+	err := printDeployPlan(ctx, "deploy@prod.example.com", cfg, defaultRemotePath)
+	if err == nil {
+		t.Fatal("expected dry-run to validate service names")
+	}
+	if !strings.Contains(err.Error(), "service 'missing' not found in configuration") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/micro/zero_to_hero_cli_test.go
+++ b/cmd/micro/zero_to_hero_cli_test.go
@@ -19,7 +19,7 @@ func TestZeroToHeroCLIBoundaries(t *testing.T) {
 		}
 	}
 
-	for _, want := range []string{"run", "chat", "flow", "inspect"} {
+	for _, want := range []string{"run", "chat", "flow", "inspect", "deploy"} {
 		if !commands[want] {
 			t.Fatalf("missing %q command", want)
 		}
@@ -29,5 +29,22 @@ func TestZeroToHeroCLIBoundaries(t *testing.T) {
 	}
 	if !subcommands["inspect"]["agent"] || !subcommands["inspect"]["flow"] {
 		t.Fatal("missing inspect boundary: inspect agent/flow")
+	}
+
+	var hasDeployDryRun bool
+	for _, command := range microcmd.DefaultCmd.App().Commands {
+		if command.Name != "deploy" {
+			continue
+		}
+		for _, flag := range command.Flags {
+			for _, name := range flag.Names() {
+				if name == "dry-run" {
+					hasDeployDryRun = true
+				}
+			}
+		}
+	}
+	if !hasDeployDryRun {
+		t.Fatal("missing deploy boundary: deploy --dry-run")
 	}
 }

--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -4,13 +4,18 @@ This directory owns the no-secret reference scenario for the Go Micro
 services → agents → workflows lifecycle. It is intentionally small and
 scripted so CI can run it on every push without external services or model keys.
 
-`run.sh` verifies three boundaries together:
+`run.sh` verifies four boundaries together:
 
 1. **Run** — `micro run` remains available as the local development entry point.
 2. **Chat** — `micro chat` remains available as the interactive agent entry point.
 3. **Inspect** — `micro inspect agent <name>` and `micro inspect flow <name>`
    remain available as the local run-history inspection step, with `micro flow
    runs` preserving durable workflow history inspection.
+4. **Deploy** — `micro deploy --dry-run <target>` remains available as the
+   deployment-boundary checkpoint. The dry run resolves configured deploy targets
+   and services and prints the remote build/copy/systemd/health plan without
+   building binaries, opening SSH connections, running `rsync`, or touching
+   remote infrastructure.
 
 After the CLI boundary smoke checks, the script runs the deterministic harnesses
 that boot real services, agents, workflows, store-backed run history, and A2A
@@ -27,6 +32,6 @@ make harness
 ```
 
 That target intentionally exercises the documented getting-started path before
-the 0→hero scenario, so the public scaffold → run/chat → inspect lifecycle stays
+the 0→hero scenario, so the public scaffold → run/chat → inspect → deploy lifecycle stays
 executable outside CI as well. Live provider checks remain separate and gated by
 configured API keys (`make provider-conformance` or the scheduled/manual CI job).

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -7,6 +7,7 @@ cd "$ROOT"
 # Keep the developer inner-loop boundaries executable and discoverable in CI
 # without secrets or long-running daemons.
 go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1
+go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
 
 # Deterministic no-secret reference scenarios. These use the real Go Micro
 # runtime and mock only the LLM provider.


### PR DESCRIPTION
Summary:
- Add micro deploy --dry-run so CI can verify the deployment boundary without SSH, rsync, systemd, or remote infrastructure.
- Extend the 0→hero CLI and harness checks to include deploy.
- Document what the deploy checkpoint guarantees.

Testing:
- go test ./cmd/micro ./internal/harness/... ./cmd/micro/cli/deploy
- make harness
- go build ./...
- go test ./... (fails in sandbox loopback-blocked gRPC tests)
- golangci-lint run ./...

Closes #3381
Closes #3383