### PR TITLE
ci: fold agent checks into provider conformance

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -33,6 +33,8 @@ jobs:
         run: go run ./internal/harness/universe
       - name: Agent-flow harness
         run: go run ./internal/harness/agent-flow
+      - name: Provider conformance (mock)
+        run: go run ./internal/harness/provider-conformance -providers mock
       - name: 0→hero run/chat/inspect reference scenario
         run: ./internal/harness/zero-to-hero-ci/run.sh
 
@@ -50,17 +52,6 @@ jobs:
         with:
           go-version: stable
           cache: true
-      - name: Agent provider conformance matrix
-        env:
-          GO_MICRO_AGENT_CONFORMANCE_LIVE: "1"
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
-          ATLASCLOUD_API_KEY: ${{ secrets.ATLASCLOUD_API_KEY }}
-        run: go test ./agent -run TestAgentProviderConformanceMatrix -count=1 -v
       - name: Provider conformance against live models
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/agent/conformance_test.go
+++ b/agent/conformance_test.go
@@ -33,12 +33,27 @@ func TestAgentProviderConformanceMatrix(t *testing.T) {
 		{name: "together", key: "TOGETHER_API_KEY", model: "GO_MICRO_CONFORMANCE_TOGETHER_MODEL", live: true},
 	}
 
+	selected := selectedConformanceProviders(os.Getenv("GO_MICRO_AGENT_CONFORMANCE_PROVIDERS"))
 	for _, provider := range providers {
 		provider := provider
+		if len(selected) > 0 && !selected[provider.name] {
+			continue
+		}
 		t.Run(provider.name, func(t *testing.T) {
 			runAgentConformanceScenario(t, provider)
 		})
 	}
+}
+
+func selectedConformanceProviders(csv string) map[string]bool {
+	out := map[string]bool{}
+	for _, part := range strings.Split(csv, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out[part] = true
+		}
+	}
+	return out
 }
 
 func runAgentConformanceScenario(t *testing.T, provider conformanceProvider) {

--- a/internal/harness/provider-conformance/README.md
+++ b/internal/harness/provider-conformance/README.md
@@ -7,9 +7,10 @@ suite is safe for local development, forks, and scheduled CI.
 
 ## What it exercises
 
-`go run ./internal/harness/provider-conformance` fans out over the harnesses in
-`internal/harness`:
+`go run ./internal/harness/provider-conformance` fans out over the provider-facing
+agent test and the harnesses in `internal/harness`:
 
+- `agent` — provider tool-call conformance through `agent.Ask`, including run metadata propagation.
 - `universe` — service discovery plus agent tool calls over the real runtime.
 - `agent-flow` — a workflow event that drives an agent to call services.
 - `plan-delegate` — plan persistence plus agent-to-agent delegation and service
@@ -59,13 +60,14 @@ go run ./internal/harness/provider-conformance \
 ## Scheduled CI behavior
 
 The `Harness (E2E)` workflow runs on pushes and pull requests with deterministic
-mock LLMs. On the daily schedule and manual dispatch it also runs the live
+mock LLMs, including `provider-conformance -providers mock`. On the daily schedule and manual dispatch it also runs the live
 provider conformance job. That job:
 
-1. reads the provider keys from repository secrets,
-2. skips providers whose secrets are absent,
-3. fails when any configured provider fails a harness, and
-4. uploads JSON and Markdown coverage artifacts for the run.
+1. runs the same `agent`, `universe`, `agent-flow`, and `plan-delegate` harness list,
+2. reads the provider keys from repository secrets,
+3. skips providers whose secrets are absent,
+4. fails when any configured provider fails a harness, and
+5. uploads JSON and Markdown coverage artifacts for the run.
 
 The job also appends the Markdown summary and capability matrix to the GitHub
 Actions step summary, making configured, skipped, and failed provider coverage

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -46,7 +46,7 @@ var providerEnv = map[string]string{
 
 func main() {
 	providersFlag := flag.String("providers", "anthropic,openai,gemini,groq,mistral,together,atlascloud", "comma-separated providers to check; use mock for deterministic local checks")
-	harnessesFlag := flag.String("harnesses", "universe,agent-flow,plan-delegate", "comma-separated harness names under internal/harness")
+	harnessesFlag := flag.String("harnesses", "agent,universe,agent-flow,plan-delegate", "comma-separated harness names under internal/harness; agent runs the provider tool-call conformance test")
 	timeoutFlag := flag.Duration("timeout", 10*time.Minute, "timeout per provider/harness run")
 	requireConfiguredFlag := flag.Bool("require-configured", false, "fail when a selected live provider is missing an API key")
 	capabilitiesFlag := flag.Bool("capabilities", true, "print the registered provider capability matrix before running conformance")
@@ -244,6 +244,9 @@ func validateSelection(providers, harnesses []string) error {
 	}
 
 	for _, harness := range harnesses {
+		if harness == "agent" {
+			continue
+		}
 		if strings.Contains(harness, string(os.PathSeparator)) || harness == "." || harness == ".." {
 			return fmt.Errorf("invalid harness name %q", harness)
 		}
@@ -323,6 +326,10 @@ func localRPCEnv(env []string) []string {
 }
 
 func runHarness(provider, harness string, timeout time.Duration) error {
+	if harness == "agent" {
+		return runAgentConformance(provider, timeout)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -350,6 +357,31 @@ func runHarness(provider, harness string, timeout time.Duration) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = localRPCEnv(os.Environ())
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("timed out after %s", timeout)
+		}
+		return err
+	}
+	return nil
+}
+
+func runAgentConformance(provider string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	testProvider := provider
+	if provider == "mock" {
+		testProvider = "fake"
+	}
+	cmd := exec.CommandContext(ctx, "go", "test", "./agent", "-run", "TestAgentProviderConformanceMatrix", "-count=1", "-v")
+	cmd.Dir = repoRoot()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = localRPCEnv(append(os.Environ(),
+		"GO_MICRO_AGENT_CONFORMANCE_LIVE=1",
+		"GO_MICRO_AGENT_CONFORMANCE_PROVIDERS="+testProvider,
+	))
 	if err := cmd.Run(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return fmt.Errorf("timed out after %s", timeout)


### PR DESCRIPTION
Summary:
- Add the agent tool-call conformance scenario to the provider-conformance harness so scheduled live runs exercise it per selected provider.
- Run deterministic provider conformance in the always-on Harness workflow.
- Document the expanded provider conformance behavior.

Testing:
- go build ./...
- go run ./internal/harness/provider-conformance -providers mock -timeout 2m
- go test ./internal/harness/provider-conformance -count=1
- go test ./agent -run TestAgentProviderConformanceMatrix/fake -count=1 -v
- go test ./... (warning: environment blocks loopback gRPC tests)
- golangci-lint run ./...

Closes #3386
Closes #3388