### PR TITLE
docs(priorities): refresh architect queue

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,7 +21,8 @@ changes, architectural rewrites. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **Add scheduled cross-provider agent conformance** ([#3386](https://github.com/micro/go-micro/issues/3386)) — harden the top Now-phase risk by running the same CI-verifiable agent scenario across every supported provider, gated on provider keys and scheduled, so tool calling, multi-step execution, plan/delegate, and guardrails do not drift by model backend. This keeps the service-as-tool harness dependable before adding more depth on top.
+1. **Harden agent loop failure handling** ([#3391](https://github.com/micro/go-micro/issues/3391)) — now that scheduled cross-provider agent conformance shipped, close the next Now-phase reliability gap: context deadlines, cancellation, provider timeouts/rate limits, retry/backoff boundaries, and safe mid-run failure semantics across model calls, tool execution, plan/delegate, and guardrails. This makes the service-as-tool harness operable under real provider conditions before layering more agentic depth on top.
+2. **CI-verify 0-to-1 and 0-to-hero developer flows** ([#3392](https://github.com/micro/go-micro/issues/3392)) — preserve the getting-started contract as an executable harness covering scaffold → run → call plus the multi-service/agent path through chat, inspection, and deploy dry-run where practical. This keeps the CLI-first inner loop aligned with the README, website, and roadmap while the harness evolves.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:
- Replace the completed cross-provider conformance priority with the next Now-phase reliability item.
- Add the executable getting-started contract as the second ranked queue item.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback gRPC tests receive envoy "Loopback targets forbidden")
- golangci-lint run ./...

Closes #3390