### PR TITLE
Harden agent tool execution timeouts

### DIFF
--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -113,13 +113,14 @@ func Builtins(opts ...Option) (tools []ai.Tool, handle func(name string, input m
 // prevents runaway recursion).
 func (a *agentImpl) toolHandler() ai.ToolHandler {
 	if a.ephemeral {
-		return a.tools.Handler()
+		return a.toolTimeoutWrap(a.tools.Handler())
 	}
 
 	// Innermost first: base, then guardrails (approve → loop → step →
 	// plan), then developer wrappers outermost. Wrapping reverses order,
 	// so the result runs plan → step → loop → approve → checkpoint → base.
 	h := a.baseHandler()
+	h = a.toolTimeoutWrap(h)
 	h = a.checkpointToolWrap(h)
 	h = a.approveWrap(h)
 	h = a.loopWrap(h)
@@ -145,6 +146,21 @@ func contextWrap(next ai.ToolHandler) ai.ToolHandler {
 		default:
 		}
 		return next(ctx, call)
+	}
+}
+
+// toolTimeoutWrap gives each tool execution its own deadline while preserving
+// caller cancellation. Handlers still execute synchronously; tools that honor
+// context (custom tools, delegate RPC/A2A, and go-micro RPC clients) return
+// promptly with a bounded error result when the deadline expires.
+func (a *agentImpl) toolTimeoutWrap(next ai.ToolHandler) ai.ToolHandler {
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		if a.opts.ToolTimeout <= 0 {
+			return next(ctx, call)
+		}
+		toolCtx, cancel := context.WithTimeout(ctx, a.opts.ToolTimeout)
+		defer cancel()
+		return next(toolCtx, call)
 	}
 }
 
@@ -319,6 +335,9 @@ func (a *agentImpl) handleDelegate(ctx context.Context, call ai.ToolCall) ai.Too
 		WithRegistry(a.opts.Registry),
 		WithClient(a.opts.Client),
 		WithStore(a.opts.Store),
+		ModelCallTimeout(a.opts.ModelTimeout),
+		ModelRetry(a.opts.ModelMaxAttempts, a.opts.ModelRetryBackoff),
+		ToolCallTimeout(a.opts.ToolTimeout),
 		TraceProvider(a.opts.TraceProvider),
 	)
 	// Record lineage so the sub-agent's tool calls carry this run as parent.

--- a/agent/options.go
+++ b/agent/options.go
@@ -56,6 +56,10 @@ type Options struct {
 	// ModelRetryBackoff is the base delay between transient provider failures
 	// (grows exponentially per attempt when retries are enabled).
 	ModelRetryBackoff time.Duration
+	// ToolTimeout bounds each tool execution (0 disables). The timeout is
+	// applied before custom tools, delegate, and service RPC calls so context
+	// deadlines propagate consistently through the agent loop.
+	ToolTimeout time.Duration
 
 	// Memory is the agent's conversation memory. Nil = the default
 	// store-backed memory (durable across restarts).
@@ -112,6 +116,7 @@ func newOptions(opts ...Option) Options {
 		ModelTimeout:      30 * time.Second,
 		ModelMaxAttempts:  1, // retries opt-in via ModelRetry (see field doc)
 		ModelRetryBackoff: 100 * time.Millisecond,
+		ToolTimeout:       30 * time.Second,
 		// On by default and lenient: identical repeated calls are a
 		// no-progress loop, never useful. Set LoopLimit(0) to disable.
 		LoopLimit: 3,
@@ -202,6 +207,14 @@ func LoopLimit(n int) Option {
 // ModelCallTimeout sets the timeout for each provider Generate call.
 func ModelCallTimeout(d time.Duration) Option {
 	return func(o *Options) { o.ModelTimeout = d }
+}
+
+// ToolCallTimeout sets the timeout for each tool execution. It bounds custom
+// tools, built-in delegate calls, and service RPC tools with the same context
+// deadline so mid-run cancellation and slow tools produce safe error results
+// instead of unbounded agent runs. Set 0 to disable.
+func ToolCallTimeout(d time.Duration) Option {
+	return func(o *Options) { o.ToolTimeout = d }
 }
 
 // ModelRetry sets the provider retry budget and backoff for transient failures.

--- a/agent/resilience_test.go
+++ b/agent/resilience_test.go
@@ -102,3 +102,30 @@ func TestCanceledAskContextSkipsToolExecution(t *testing.T) {
 		t.Fatalf("plan persisted after canceled tool context: %q", plan)
 	}
 }
+
+func TestToolCallTimeoutPropagatesDeadlineToCustomTool(t *testing.T) {
+	var sawDeadline bool
+	a := newTestAgent(
+		Name("tool-timeout"),
+		ToolCallTimeout(10*time.Millisecond),
+		WithTool("slow", "slow tool", nil, func(ctx context.Context, input map[string]any) (string, error) {
+			if _, ok := ctx.Deadline(); ok {
+				sawDeadline = true
+			}
+			<-ctx.Done()
+			return "", ctx.Err()
+		}),
+	)
+
+	start := time.Now()
+	content := toolContent(a.toolHandler(), "slow", nil)
+	if !sawDeadline {
+		t.Fatal("custom tool did not receive a deadline")
+	}
+	if !strings.Contains(content, context.DeadlineExceeded.Error()) {
+		t.Fatalf("tool result = %q, want deadline exceeded", content)
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("tool call took %s, want bounded timeout", elapsed)
+	}
+}


### PR DESCRIPTION
Summary:
- Add per-tool execution deadlines across custom tools, service RPC tools, and delegate calls.
- Propagate timeout and retry policy into ephemeral delegated sub-agents.
- Cover custom tool deadline propagation with a resilience regression test.

Testing:
- go build ./...
- go test ./agent ./ai
- go test ./agent
- golangci-lint run ./...
- go test ./... (environment warning: loopback gRPC tests fail with envoy Loopback targets forbidden in client/grpc and transport/grpc)

Closes #3391
Closes #3394