### PR TITLE
Consolidate developer flow harness

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -27,16 +27,8 @@ jobs:
           cache: true
       - name: Build
         run: go build ./...
-      - name: 0→1 scaffold contract
-        run: go test ./cmd/micro/cli/new -run TestZeroToOneContract -count=1
-      - name: Universe end-to-end (asserts; exits non-zero on failure)
-        run: go run ./internal/harness/universe
-      - name: Agent-flow harness
-        run: go run ./internal/harness/agent-flow
-      - name: Provider conformance (mock)
-        run: go run ./internal/harness/provider-conformance -providers mock
-      - name: 0→hero run/chat/inspect reference scenario
-        run: ./internal/harness/zero-to-hero-ci/run.sh
+      - name: 0→1 and 0→hero developer-flow harness
+        run: make harness
 
   harness-live:
     name: Provider harnesses (live LLM conformance)

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,10 @@ test-coverage:
 # This mirrors the default CI path so local dogfooding catches scaffold,
 # run/chat/inspect, and 0→hero regressions before a PR is opened.
 harness:
-	go test ./cmd/micro/cli/new -run TestZeroToOneContract -count=1
+	go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
 	./internal/harness/zero-to-hero-ci/run.sh
 	go run ./internal/harness/agent-flow
+	go run ./internal/harness/provider-conformance -providers mock
 
 # Run the same harnesses against every configured live provider. Providers
 # without API keys are skipped; configured providers must pass.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call \
   -H 'Content-Type: application/json' -d '{"name":"World"}'
 ```
 
+This scaffold → run → call path is covered by the no-secret CI harness. To run
+the same local contract (including the 0→hero services → agents → workflows path,
+chat/inspect CLI boundaries, and deploy dry-run), use:
+
+```bash
+make harness
+```
+
 ### Generate from a prompt — with an LLM key
 
 Set a provider key, describe what you want, and the AI designs services, writes handlers, compiles, and starts them:

--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -18,8 +18,8 @@ scripted so CI can run it on every push without external services or model keys.
    remote infrastructure.
 
 After the CLI boundary smoke checks, the script runs the deterministic harnesses
-that boot real services, agents, workflows, store-backed run history, and A2A
-with only the LLM mocked.
+that boot real services, agents, workflows, store-backed run history, plan/delegate,
+and A2A with only the LLM mocked.
 
 ## Local and CI entry points
 
@@ -31,7 +31,8 @@ contract locally with:
 make harness
 ```
 
-That target intentionally exercises the documented getting-started path before
-the 0→hero scenario, so the public scaffold → run/chat → inspect → deploy lifecycle stays
-executable outside CI as well. Live provider checks remain separate and gated by
-configured API keys (`make provider-conformance` or the scheduled/manual CI job).
+That target intentionally exercises both 0→1 scaffold variants, the 0→hero
+scenario, the event-driven agent-flow harness, and mock provider conformance, so
+the public scaffold → run/chat → inspect → deploy lifecycle stays executable
+outside CI as well. Live provider checks remain separate and gated by configured
+API keys (`make provider-conformance` or the scheduled/manual CI job).


### PR DESCRIPTION
Summary:
- Route the default Harness workflow through make harness so CI and local dogfooding exercise the same 0-to-1 and 0-to-hero developer-flow contract.
- Expand make harness to cover both scaffold variants and mock provider conformance alongside the zero-to-hero and agent-flow harnesses.
- Document the no-secret local harness command from the README getting-started path and zero-to-hero harness docs.

Testing:
- make harness
- go build ./...
- go test ./... (fails in this environment: loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3392
Closes #3398