### PR TITLE
docs(priorities): advance architect queue

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,7 +21,9 @@ changes, architectural rewrites. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **CI-verify 0-to-1 and 0-to-hero developer flows** ([#3392](https://github.com/micro/go-micro/issues/3392)) — with cross-provider conformance and agent-loop failure handling now shipped, preserve the last open Now-phase contract as an executable harness covering scaffold → run → call plus the multi-service/agent path through chat, inspection, and deploy dry-run where practical. This keeps the CLI-first inner loop aligned with the README, website, and roadmap while the harness evolves.
+1. **Resume durable agent runs from checkpoints** ([#3401](https://github.com/micro/go-micro/issues/3401)) — with the Now-phase getting-started contract closed by #3399, the highest-value Next-phase gap is making agent work survive restarts the way flows already do. This tightens the services → agents → workflows lifecycle around real, long-running work: checkpoint enough run state to resume safely, preserve guardrails/cancellation/deadlines, and prove completed tool calls are not duplicated.
+2. **Broaden end-to-end agent streaming coverage** ([#3402](https://github.com/micro/go-micro/issues/3402)) — streaming is the next developer-visible seam after durability: provider tokens need to move consistently through `ai.Stream`, `micro chat`, `Agent.Chat`, and A2A streaming. CI-safe local coverage plus provider-gated conformance should lock down chunk ordering, terminal/error events, and fallback behavior.
+3. **Emit OpenTelemetry spans for agent runs** ([#3403](https://github.com/micro/go-micro/issues/3403)) — once long runs can resume and stream, operators need the same run story in traces that developers see via `micro runs`: lifecycle boundaries, model/tool calls, approvals, retries, failures, and cancellation correlated by run ID without leaking sensitive payloads.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:
- Remove the completed getting-started contract item from the architect queue.
- Add the next ranked issues for durable agent checkpoints, end-to-end streaming coverage, and agent run OpenTelemetry spans.

Assessment:
- Shipped: #3399 closed the Now-phase 0-to-1/0-to-hero harness contract, after recent work on provider conformance, agent timeouts, A2A skills, human-input docs, trace redaction, and zero-to-hero support examples.
- In flight: no open codex PRs were found during this pass.
- Ranking rationale: move from hardening into Next-phase agentic depth, prioritizing durability first because restart-safe agent work is the clearest operational-harness gap, then streaming as the highest developer-visible seam, then OTel run spans for operability.

Testing:
- git diff --check
- timeout 60s go test ./... (client/grpc loopback blocked by environment; command timed out after partial run)
- timeout 60s golangci-lint run ./... (timed out)

Closes #3400