### PR TITLE
Guard terminal agent checkpoint resumes

### DIFF
--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -88,6 +88,9 @@ func (a *agentImpl) resume(ctx context.Context, runID string) (*Response, error)
 		}
 		return &resp, nil
 	}
+	if terminalAgentRunStatus(run.Status) {
+		return nil, fmt.Errorf("agent run %s is terminal with status %q", runID, run.Status)
+	}
 	message := string(run.State.Data)
 	parentID := run.ParentID
 	a.mu.Lock()
@@ -153,11 +156,20 @@ func (a *agentImpl) pending(ctx context.Context) ([]flow.Run, error) {
 	}
 	out := runs[:0]
 	for _, run := range runs {
-		if run.Flow == a.opts.Name && run.Status != "done" {
+		if run.Flow == a.opts.Name && !terminalAgentRunStatus(run.Status) {
 			out = append(out, run)
 		}
 	}
 	return out, nil
+}
+
+func terminalAgentRunStatus(status string) bool {
+	switch status {
+	case "done", "canceled", "expired":
+		return true
+	default:
+		return false
+	}
 }
 
 func (a *agentImpl) checkpointToolWrap(next ai.ToolHandler) ai.ToolHandler {

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -185,6 +185,35 @@ func TestPendingReturnsUnfinishedAgentRuns(t *testing.T) {
 	}
 }
 
+func TestPendingSkipsTerminalCanceledAndExpiredAgentRuns(t *testing.T) {
+	ctx := context.Background()
+	cp := flow.StoreCheckpoint(store.NewStore(), "terminal-agent")
+	for _, run := range []flow.Run{
+		{ID: "active", Flow: "terminal-agent", Status: "failed", State: flow.State{Stage: agentAskStep, Data: []byte("retry me")}},
+		{ID: "done", Flow: "terminal-agent", Status: "done", State: flow.State{Stage: agentAskStep, Data: []byte("done")}},
+		{ID: "canceled", Flow: "terminal-agent", Status: "canceled", State: flow.State{Stage: agentAskStep, Data: []byte("canceled")}},
+		{ID: "expired", Flow: "terminal-agent", Status: "expired", State: flow.State{Stage: agentAskStep, Data: []byte("expired")}},
+	} {
+		if err := cp.Save(ctx, run); err != nil {
+			t.Fatalf("Save(%s): %v", run.ID, err)
+		}
+	}
+
+	a := newTestAgent(Name("terminal-agent"), WithCheckpoint(cp))
+	runs, err := Pending(ctx, a)
+	if err != nil {
+		t.Fatalf("Pending: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != "active" {
+		t.Fatalf("Pending = %#v, want only active failed run", runs)
+	}
+	for _, id := range []string{"canceled", "expired"} {
+		if _, err := Resume(ctx, a, id); err == nil || !strings.Contains(err.Error(), "terminal") {
+			t.Fatalf("Resume(%s) err = %v, want terminal status error", id, err)
+		}
+	}
+}
+
 func TestHumanInputPauseResumesSameRunWithInput(t *testing.T) {
 	ctx := context.Background()
 	cp := flow.StoreCheckpoint(store.NewStore(), "input-agent")

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -153,6 +153,9 @@ func (a *agentImpl) resumeWithStreamEvents(ctx context.Context, runID string, ev
 		}
 		return &resp, nil
 	}
+	if terminalAgentRunStatus(run.Status) {
+		return nil, errors.New("agent: checkpointed run is terminal with status " + run.Status)
+	}
 
 	a.mu.Lock()
 	defer a.mu.Unlock()


### PR DESCRIPTION
Summary:
- Treat canceled and expired agent checkpoints as terminal so pending recovery loops do not resume them.
- Reject direct and streaming resume attempts for terminal checkpoints while preserving completed-run replay behavior.
- Add coverage that pending only returns resumable checkpoints.

Testing:
- go build ./...
- go test ./agent -run 'TestPendingSkipsTerminal|TestResume' -count=1 -timeout=60s\n- go test ./... (fails in this environment: loopback targets forbidden in grpc client/transport tests)\n- golangci-lint run ./...\n\nCloses #3401\nCloses #3405