### PR TITLE
Fix A2A stream fallback for unsupported providers

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -28,6 +28,7 @@ package a2a
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -489,7 +490,7 @@ func (d *dispatcher) serveWithStream(w http.ResponseWriter, r *http.Request, inv
 		d.send(requestContext(r.Context()), w, req, invoke)
 	case "message/stream":
 		if streamInvoke != nil {
-			d.streamChunks(requestContext(r.Context()), w, req, streamInvoke)
+			d.streamChunks(requestContext(r.Context()), w, req, streamInvoke, invoke)
 			return
 		}
 		d.stream(requestContext(r.Context()), w, req, invoke)
@@ -538,7 +539,7 @@ func (d *dispatcher) stream(ctx context.Context, w http.ResponseWriter, req rpcR
 	}
 }
 
-func (d *dispatcher) streamChunks(ctx context.Context, w http.ResponseWriter, req rpcRequest, invoke StreamInvoke) {
+func (d *dispatcher) streamChunks(ctx context.Context, w http.ResponseWriter, req rpcRequest, invoke StreamInvoke, fallback Invoke) {
 	var p sendParams
 	if err := json.Unmarshal(req.Params, &p); err != nil {
 		writeRPC(w, req.ID, nil, &rpcError{Code: errInvalidParams, Message: "invalid params"})
@@ -551,6 +552,10 @@ func (d *dispatcher) streamChunks(ctx context.Context, w http.ResponseWriter, re
 	}
 	stream, err := invoke(ctx, text)
 	if err != nil {
+		if errors.Is(err, ai.ErrStreamingUnsupported) && fallback != nil {
+			d.stream(ctx, w, req, fallback)
+			return
+		}
 		writeRPC(w, req.ID, nil, &rpcError{Code: errInternal, Message: err.Error()})
 		return
 	}

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -465,6 +465,61 @@ func TestMessageStreamChunksPropagatesCancellationAndClosesStream(t *testing.T) 
 	}
 }
 
+func TestMessageStreamChunksFallsBackWhenUnsupported(t *testing.T) {
+	d := newDispatcher()
+	body := `{"jsonrpc":"2.0","id":1,"method":"message/stream","params":{"message":{"role":"user","parts":[{"kind":"text","text":"ping"}],"kind":"message"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	var streamed bool
+	var fallbackText string
+
+	d.serveWithStream(rr, req, func(ctx context.Context, text string) (string, error) {
+		fallbackText = text
+		return "pong", nil
+	}, func(ctx context.Context, text string) (ai.Stream, error) {
+		streamed = true
+		return nil, fmt.Errorf("%w: test provider", ai.ErrStreamingUnsupported)
+	})
+
+	if !streamed {
+		t.Fatal("stream invoke was not attempted")
+	}
+	if fallbackText != "ping" {
+		t.Fatalf("fallback text = %q, want ping", fallbackText)
+	}
+	if ct := rr.Result().Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("content-type = %q, want text/event-stream", ct)
+	}
+	var events []struct {
+		Result Task      `json:"result"`
+		Error  *rpcError `json:"error"`
+	}
+	for _, line := range strings.Split(strings.TrimSpace(rr.Body.String()), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		line = strings.TrimPrefix(line, "data: ")
+		var event struct {
+			Result Task      `json:"result"`
+			Error  *rpcError `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("decode event %q: %v", line, err)
+		}
+		events = append(events, event)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1; body %s", len(events), rr.Body.String())
+	}
+	if events[0].Error != nil {
+		t.Fatalf("fallback event error: %+v", events[0].Error)
+	}
+	if events[0].Result.Status.State != stateCompleted || textOf(events[0].Result.Artifacts[0].Parts) != "pong" {
+		t.Fatalf("fallback task = %+v, want completed pong", events[0].Result)
+	}
+}
+
 func TestTasksResubscribeStreamsCurrentAndSubsequentEvents(t *testing.T) {
 	d := newDispatcher()
 	initial := &Task{ID: "task-1", ContextID: "ctx-1", Kind: "task", Status: TaskStatus{State: stateWorking, Timestamp: time.Now().UTC().Format(time.RFC3339)}}


### PR DESCRIPTION
## Summary
- Fall back from A2A message/stream chunk forwarding to the normal invoke path when the agent provider returns ai.ErrStreamingUnsupported.
- Add coverage proving the SSE response completes successfully through fallback instead of surfacing an internal streaming error.

## Testing
- go build ./...
- go test ./gateway/a2a ./agent ./ai/...
- go test ./... (fails in client/grpc due loopback targets forbidden in environment)
- golangci-lint run ./...

Closes #3402
Closes #3409