### PR TITLE
docs(priorities): refresh architect queue

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,7 +21,7 @@ changes, architectural rewrites. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **Broaden end-to-end agent streaming coverage** ([#3402](https://github.com/micro/go-micro/issues/3402)) — with durable agent checkpoint/resume guarded by #3406, streaming is now the highest-value Next-phase developer-visible seam: provider tokens need to move consistently through `ai.Stream`, `micro chat`, `Agent.Chat`, and A2A streaming. CI-safe local coverage plus provider-gated conformance should lock down chunk ordering, terminal/error events, and fallback behavior.
+1. **Resume durable agent runs from checkpoints** ([#3401](https://github.com/micro/go-micro/issues/3401)) — streaming just landed via #3410, but the Next-phase durable agent loop is still the highest-value gap in the services → agents → workflows lifecycle: long-running agent work should survive interruption with the same checkpoint discipline flows already have, without duplicating completed tool calls or bypassing cancellation/deadline guardrails.
 2. **Emit OpenTelemetry spans for agent runs** ([#3403](https://github.com/micro/go-micro/issues/3403)) — once long runs can resume and stream, operators need the same run story in traces that developers see via `micro runs`: lifecycle boundaries, model/tool calls, approvals, retries, failures, and cancellation correlated by run ID without leaking sensitive payloads.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the


### PR DESCRIPTION
Summary:
- Removes completed streaming coverage work from the architect queue.
- Re-prioritizes durable agent checkpoint resume as the top open Next-phase item, followed by agent OpenTelemetry spans.

Testing:
- git diff --check
- go build ./... && go test ./... && golangci-lint run ./... (interrupted after prolonged dependency/build time with no failure output)

Closes #3411