### PR TITLE
Add durable agent resume example

### DIFF
--- a/examples/agent-durable/README.md
+++ b/examples/agent-durable/README.md
@@ -1,0 +1,32 @@
+# Durable agent run resume
+
+This example shows the agent-side counterpart to `examples/flow-durable`: an
+agent run is checkpointed with the same `Checkpoint` interface used by flows,
+then resumed after an interruption without repeating a completed side effect.
+The sample uses an in-memory store to keep repeated local runs deterministic;
+use your service store for process-restart recovery.
+
+Run it with:
+
+```sh
+go run ./examples/agent-durable
+```
+
+The demo model calls `inventory.reserve`, then fails to mimic a process dying
+after the tool call was checkpointed. `micro.AgentPending` finds the unfinished
+run and `micro.AgentResume` continues it from the saved checkpoint. The final
+`tool executions: 1` line is the important bit: the reservation tool was not
+called a second time during resume.
+
+In a service, use the same pattern at startup:
+
+```go
+pending, _ := micro.AgentPending(ctx, agent)
+for _, run := range pending {
+    _, _ = micro.AgentResume(ctx, agent, run.ID)
+}
+```
+
+`context.Context` cancellation and deadlines are still honored by checkpoint
+loads/saves, model calls, and tool calls. Runs with terminal statuses such as
+`done`, `canceled`, and `expired` are not returned by `AgentPending`.

--- a/examples/agent-durable/main.go
+++ b/examples/agent-durable/main.go
@@ -1,0 +1,88 @@
+// Package main demonstrates durable agent runs: a checkpointed agent can
+// resume after a crash without re-executing completed tool calls.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	micro "go-micro.dev/v6"
+	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/store"
+)
+
+func main() {
+	ctx := context.Background()
+	checkpoint := micro.StoreCheckpoint(store.NewMemoryStore(), "durable-agent-demo")
+	model := &demoModel{failFirst: true}
+	ai.Register("durable-demo", func(opts ...ai.Option) ai.Model {
+		_ = model.Init(opts...)
+		return model
+	})
+	var reservations atomic.Int32
+
+	ag := micro.NewAgent("durable-agent-demo",
+		micro.AgentWithCheckpoint(checkpoint),
+		micro.AgentProvider("durable-demo"),
+		micro.AgentTool("inventory.reserve", "reserve inventory exactly once", map[string]any{
+			"sku": map[string]any{"type": "string"},
+		}, func(ctx context.Context, input map[string]any) (string, error) {
+			count := reservations.Add(1)
+			return fmt.Sprintf("reserved %s (execution %d)", input["sku"], count), nil
+		}),
+	)
+
+	_, err := ag.Ask(ctx, "reserve sku-123 and confirm")
+	fmt.Println("initial run:", err)
+
+	pending, err := micro.AgentPending(ctx, ag)
+	if err != nil {
+		panic(err)
+	}
+	if len(pending) == 0 {
+		panic("expected a checkpointed run to resume")
+	}
+
+	resp, err := micro.AgentResume(ctx, ag, pending[0].ID)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("resumed reply:", resp.Reply)
+	fmt.Println("tool executions:", reservations.Load())
+}
+
+type demoModel struct {
+	failFirst bool
+	opts      ai.Options
+}
+
+func (m *demoModel) Init(opts ...ai.Option) error {
+	m.opts = ai.NewOptions(opts...)
+	return nil
+}
+func (m *demoModel) Options() ai.Options { return m.opts }
+func (m *demoModel) String() string      { return "durable-demo" }
+
+func (m *demoModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (*ai.Response, error) {
+	if m.opts.ToolHandler != nil {
+		res := m.opts.ToolHandler(ctx, ai.ToolCall{
+			ID:    "reserve-1",
+			Name:  "inventory.reserve",
+			Input: map[string]any{"sku": "sku-123"},
+		})
+		if res.Content == "" {
+			return nil, errors.New("reservation tool returned no content")
+		}
+	}
+	if m.failFirst {
+		m.failFirst = false
+		return nil, errors.New("simulated process interruption after checkpointed tool call")
+	}
+	return &ai.Response{Reply: "sku-123 is reserved; no duplicate reservation was made"}, nil
+}
+
+func (m *demoModel) Stream(context.Context, *ai.Request, ...ai.GenerateOption) (ai.Stream, error) {
+	return nil, ai.ErrStreamingUnsupported
+}


### PR DESCRIPTION
## Summary
- Add a runnable durable agent example that checkpoints a tool call, resumes the pending run, and demonstrates the tool is not executed twice.
- Document the startup recovery pattern with AgentPending and AgentResume.

Closes #3401
Closes #3413

## Testing
- go run ./examples/agent-durable
- go build ./...
- go test ./... (fails in this environment because loopback grpc targets are blocked by envoy)
- golangci-lint run ./...