### PR TITLE
docs: align DevRel public surface facts

### DIFF
--- a/internal/website/blog/5.md
+++ b/internal/website/blog/5.md
@@ -11,7 +11,7 @@ description: "Unified service creation, cleaner handler registration, and modula
 
 *March 4, 2026 — By the Go Micro Team*
 
-Go Micro has always prioritized getting out of your way. But over time, the API accumulated multiple ways to do the same thing — `micro.NewService()`, `micro.NewService()`, `service.New()`, three different handler registration patterns. If you're building something for AI agents or running a modular monolith, you shouldn't have to choose between equivalent APIs.
+Go Micro has always prioritized getting out of your way. But over time, the API accumulated multiple ways to do the same thing — `micro.New(name)`, `micro.NewService(micro.Name(...))`, `service.New()`, three different handler registration patterns. If you're building something for AI agents or running a modular monolith, you shouldn't have to choose between equivalent APIs.
 
 We've cleaned it up. Here's what changed and why.
 
@@ -33,7 +33,7 @@ service := micro.NewService("greeter")
 service := micro.NewService("greeter", micro.Address(":8080"))
 ```
 
-Name is always the first argument. Options follow. `NewService` still works (it's deprecated, not removed), but every example, doc, and guide now uses `micro.NewService()`.
+Name is always the first argument. Options follow. `micro.New` still works as a deprecated alias, but every example, doc, and guide now uses `micro.NewService("name")`.
 
 ## Clean Handler Registration
 
@@ -107,7 +107,7 @@ Your Go comments become tool descriptions. Your struct tags become parameter sch
 
 If you're building new services, use `micro.NewService("name", opts...)` and `service.Handle()`. That's it.
 
-If you have existing code using `micro.NewService()` or `service.Server().Handle()`, everything still works — we didn't break anything. But the docs, examples, and guides all point to the new patterns now.
+If you have existing code using `micro.New("name")` or `service.Server().Handle()`, it still works. For v6, update name-less `micro.NewService(opts...)` calls to `micro.NewService("name", opts...)`. The docs, examples, and guides all point to the new patterns now.
 
 The goal is simple: when someone asks "how do I create a service?", there should be exactly one answer.
 

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -16,7 +16,7 @@ Go Micro has three core abstractions:
 
 ## Prerequisites
 
-- **Go 1.21+** for development. The `curl` install below gives you the `micro` binary without Go, but `micro run` compiles your services, so you'll want Go installed to build them.
+- **Go 1.24+** for development. The `curl` install below gives you the `micro` binary without Go, but `micro run` compiles your services, so you'll want Go installed to build them.
 - An **LLM provider key** (Anthropic, OpenAI, Gemini, …) *only* for the AI features — `micro run --prompt`, `micro chat`, and agents. Plain services need no key. Set it before running, e.g. `export ANTHROPIC_API_KEY=sk-ant-...`.
 
 ## Install

--- a/internal/website/docs/guides/plan-delegate.md
+++ b/internal/website/docs/guides/plan-delegate.md
@@ -13,7 +13,7 @@ They are exposed to the model as ordinary tools. There is no separate graph runt
 
 ## Prerequisites
 
-- Go 1.21+
+- Go 1.24+
 - An API key for any supported provider (Anthropic, OpenAI, Gemini, Groq, Mistral, Together, Atlas Cloud)
 
 ```bash


### PR DESCRIPTION
Summary:
- Correct stale constructor wording in the DX cleanup blog.
- Update public docs prerequisites to match the repository Go 1.24 baseline.

Testing:
- go build ./...
- go test ./... (fails here because the environment blocks loopback gRPC targets)
- golangci-lint run ./...

Closes #3426