### PR TITLE
run: surface MCP tools in the micro run banner by default

### DIFF
--- a/cmd/micro/run/run.go
+++ b/cmd/micro/run/run.go
@@ -498,10 +498,13 @@ func printBanner(services []*serviceProcess, gw *server.Gateway, watching bool, 
 		fmt.Printf("  Dashboard   \033[36mhttp://localhost%s\033[0m\n", gw.Addr())
 		fmt.Printf("  API         \033[36mhttp://localhost%s/api/{service}/{method}\033[0m\n", gw.Addr())
 		fmt.Printf("  Agent       \033[36mhttp://localhost%s/agent\033[0m\n", gw.Addr())
+		// MCP tools are served on the gateway by default — every endpoint is an
+		// AI-callable tool, so surface it rather than hiding it behind a flag.
+		fmt.Printf("  MCP Tools   \033[36mhttp://localhost%s/mcp/tools\033[0m\n", gw.Addr())
 		fmt.Printf("  Health      \033[36mhttp://localhost%s/health\033[0m\n", gw.Addr())
 		if mcpAddr != "" {
-			fmt.Printf("  MCP         \033[36mhttp://localhost%s\033[0m\n", mcpAddr)
-			fmt.Printf("  MCP Tools   \033[36mhttp://localhost%s/mcp/tools\033[0m\n", mcpAddr)
+			// Optional standalone MCP protocol server (e.g. for MCP clients).
+			fmt.Printf("  MCP Server  \033[36mhttp://localhost%s\033[0m (full MCP protocol)\n", mcpAddr)
 			fmt.Printf("  WebSocket   \033[36mws://localhost%s/mcp/ws\033[0m\n", mcpAddr)
 		}
 	}


### PR DESCRIPTION
Closes a "what we say vs what we do" gap around `micro run`, found while auditing the README against the agent-harness strategy.

**Finding:** the README (and the CLI help) correctly say plain `micro run` serves `/mcp/tools` on `:8080` — and it *does* (`registerHandlers` mounts it unconditionally; it's how the agent playground calls tools). But the **startup banner** only printed an MCP line when `--mcp-address` was set, so the live `micro run` experience hid the harness's signature feature ("every endpoint is automatically an MCP tool") even though it was running. That's why it's easy to forget what's on `:8080`.

**Fix:** the banner now always advertises `MCP Tools  http://localhost:8080/mcp/tools` alongside Dashboard / API / Agent, matching the README and the promise. The optional standalone full-MCP-protocol server (`--mcp-address`) is kept as a clearly separate line.

No behavior or security change — the endpoint already exists; this only changes banner output.

(README itself audited as accurate and well-aligned with the harness strategy — no changes needed there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_