### PR TITLE
docs(priorities): advance architect queue

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,9 +21,7 @@ changes, architectural rewrites. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **Verification / grader loop for flows** ([#3435](https://github.com/micro/go-micro/issues/3435)) — the Now-phase failure/resilience and 0→hero contracts have largely shipped, and cross-provider agent scenario conformance closed via #3438. The highest-value remaining lifecycle gap is a CI-verifiable workflow primitive that can grade a step's output against a rubric, route failures back with feedback, and retry within bounded failure semantics. This keeps the services → agents → workflows story operable: known workflow paths get deterministic structure, while agent/model outputs get an explicit trust boundary instead of ad hoc prompt checks.
-
-2. **Flow hill-climbing loop from run traces** ([#3439](https://github.com/micro/go-micro/issues/3439)) — after verification exists, use the run/trace foundation from recent telemetry and inspect work to analyze failures over time and propose prompt/grader improvements. Keep this behind the grader loop because hill-climbing depends on a stable evaluation signal; ranked second because it turns the harness's own continuous loop into a product-facing proof of durable, observable workflow improvement.
+1. **Flow hill-climbing loop from run traces** ([#3439](https://github.com/micro/go-micro/issues/3439)) — verification/grader flows shipped in #3443, and there are no open codex PRs currently carrying follow-up work. The highest-value remaining lifecycle gap is to use the run/trace foundation plus the new grader signal to analyze failures over time and propose prompt/grader improvements. This keeps the services → agents → workflows story operable by turning durable, observable runs into a product-facing proof of continuous workflow improvement rather than leaving evaluation as a one-off step.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:
- Drop completed verification/grader loop issue #3435 after #3443 merged.
- Promote #3439 as the sole top queue item for the flow hill-climbing loop.

Testing:
- go build ./...
- go test ./... (fails in client/grpc because loopback targets are forbidden by the environment)
- golangci-lint run ./...

Closes #3444