### PR TITLE
Verify durable agent resume example

### DIFF
--- a/examples/agent-durable/README.md
+++ b/examples/agent-durable/README.md
@@ -18,6 +18,19 @@ run and `micro.AgentResume` continues it from the saved checkpoint. The final
 `tool executions: 1` line is the important bit: the reservation tool was not
 called a second time during resume.
 
+## When to use this instead of a durable flow
+
+Use a durable flow when the path is known ahead of time: ordered service calls,
+retries, timers, compensation, and a precise resume stage such as `reserve` or
+`charge`. Use a checkpointed agent run when the path is open-ended and the model
+may choose tools dynamically, but completed tool side effects still must not be
+replayed after a crash or provider failure.
+
+They compose: keep deterministic business process in `flow-durable`, then hand
+off the judgment-heavy step to a checkpointed agent when the workflow needs
+model-directed tool use. Both use the same `Checkpoint` backend, so inspection
+and recovery can share one run-history store.
+
 In a service, use the same pattern at startup:
 
 ```go

--- a/examples/agent-durable/main_test.go
+++ b/examples/agent-durable/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDurableAgentExampleResumesWithoutReplayingTool(t *testing.T) {
+	out := captureStdout(t, main)
+	if !strings.Contains(out, "simulated process interruption after checkpointed tool call") {
+		t.Fatalf("example output %q did not show the initial interrupted run", out)
+	}
+	if !strings.Contains(out, "resumed reply: sku-123 is reserved; no duplicate reservation was made") {
+		t.Fatalf("example output %q did not show the resumed response", out)
+	}
+	if !strings.Contains(out, "tool executions: 1") {
+		t.Fatalf("example output %q did not prove the tool was not replayed", out)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = w
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = old
+	<-done
+	_ = r.Close()
+	return buf.String()
+}

--- a/internal/website/docs/guides/agent-harness.md
+++ b/internal/website/docs/guides/agent-harness.md
@@ -69,6 +69,14 @@ if err != nil {
 _ = resp
 ```
 
+Choose the boundary deliberately: use a durable flow when the steps are known
+(`reserve`, `charge`, `confirm`) and each step has deterministic retry/resume
+semantics. Use a checkpointed agent run when the model is deciding which tools to
+call or how many turns it needs, but the side effects of completed tool calls
+still need crash-safe resume. Flows and agents share the same `Checkpoint`
+interface, so a flow can safely dispatch to a checkpointed agent for the
+open-ended part.
+
 For human-in-the-loop runs that pause through the built-in `request_input` tool,
 resume with the operator's response:
 


### PR DESCRIPTION
## Summary
- add a test around the durable agent example to verify checkpoint resume does not replay completed tool side effects
- document when to use checkpointed agent runs versus durable flows in the example and agent harness guide

Closes #3449
Closes #3451

## Testing
- go build ./...
- go test ./... (fails in this environment: cache expiration timing and loopback-forbidden grpc tests)
- golangci-lint run ./...