### PR TITLE
Add configurable provider conformance dispatch

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -14,6 +14,20 @@ on:
   schedule:
     - cron: "17 6 * * *" # daily, so the world is exercised even without changes
   workflow_dispatch:
+    inputs:
+      providers:
+        description: "Comma-separated providers for live conformance (default: all supported)"
+        required: false
+        default: "anthropic,openai,gemini,groq,mistral,together,atlascloud"
+      harnesses:
+        description: "Comma-separated harnesses for live conformance"
+        required: false
+        default: "agent,universe,agent-flow,plan-delegate,a2a-stream-fallback"
+      require_configured:
+        description: "Fail selected live providers that do not have repository secrets"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   harness:
@@ -54,10 +68,22 @@ jobs:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           ATLASCLOUD_API_KEY: ${{ secrets.ATLASCLOUD_API_KEY }}
         run: |
-          go run ./internal/harness/provider-conformance \
-            -summary-json provider-conformance-summary.json \
-            -summary-markdown provider-conformance-summary.md \
+          PROVIDERS="${{ github.event.inputs.providers || 'anthropic,openai,gemini,groq,mistral,together,atlascloud' }}"
+          HARNESSES="${{ github.event.inputs.harnesses || 'agent,universe,agent-flow,plan-delegate,a2a-stream-fallback' }}"
+          REQUIRE_CONFIGURED="${{ github.event.inputs.require_configured || 'false' }}"
+
+          args=(
+            -providers "$PROVIDERS"
+            -harnesses "$HARNESSES"
+            -summary-json provider-conformance-summary.json
+            -summary-markdown provider-conformance-summary.md
             -capabilities-markdown provider-capabilities.md
+          )
+          if [ "$REQUIRE_CONFIGURED" = "true" ]; then
+            args+=( -require-configured )
+          fi
+
+          go run ./internal/harness/provider-conformance "${args[@]}"
       - name: Publish provider conformance summary
         if: always()
         run: |

--- a/internal/harness/provider-conformance/README.md
+++ b/internal/harness/provider-conformance/README.md
@@ -52,7 +52,8 @@ Provider keys are read from `MICRO_AI_API_KEY` or the provider-specific variable
 | AtlasCloud | `ATLASCLOUD_API_KEY` |
 
 Use `-require-configured` when you want a selected provider without a key to fail
-instead of skip:
+instead of skip. This is useful for manually checking that a required provider
+secret is actually wired into CI before relying on that provider as covered:
 
 ```sh
 go run ./internal/harness/provider-conformance \
@@ -63,8 +64,12 @@ go run ./internal/harness/provider-conformance \
 ## Scheduled CI behavior
 
 The `Harness (E2E)` workflow runs on pushes and pull requests with deterministic
-mock LLMs, including `provider-conformance -providers mock`. On the daily schedule and manual dispatch it also runs the live
-provider conformance job. That job:
+mock LLMs, including `provider-conformance -providers mock`. On the daily
+schedule and manual dispatch it also runs the live provider conformance job. A
+manual dispatch can narrow `providers` or `harnesses`, and can set
+`require_configured=true` to fail fast when an expected repository secret is
+missing; scheduled runs keep the safe default and report missing keys as skips.
+That job:
 
 1. runs the same `agent`, `universe`, `agent-flow`, `plan-delegate`, and `a2a-stream-fallback` harness list,
 2. reads the provider keys from repository secrets,

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -34,6 +34,8 @@ import (
 	_ "go-micro.dev/v6/ai/together"
 )
 
+const defaultHarnesses = "agent,universe,agent-flow,plan-delegate,a2a-stream-fallback"
+
 var providerEnv = map[string]string{
 	"anthropic":  "ANTHROPIC_API_KEY",
 	"openai":     "OPENAI_API_KEY",
@@ -45,8 +47,8 @@ var providerEnv = map[string]string{
 }
 
 func main() {
-	providersFlag := flag.String("providers", "anthropic,openai,gemini,groq,mistral,together,atlascloud", "comma-separated providers to check; use mock for deterministic local checks")
-	harnessesFlag := flag.String("harnesses", "agent,universe,agent-flow,plan-delegate,a2a-stream-fallback", "comma-separated harness names under internal/harness; agent runs the provider tool-call conformance test")
+	providersFlag := flag.String("providers", defaultProviders(), "comma-separated providers to check; use mock for deterministic local checks")
+	harnessesFlag := flag.String("harnesses", defaultHarnesses, "comma-separated harness names under internal/harness; agent runs the provider tool-call conformance test")
 	timeoutFlag := flag.Duration("timeout", 10*time.Minute, "timeout per provider/harness run")
 	requireConfiguredFlag := flag.Bool("require-configured", false, "fail when a selected live provider is missing an API key")
 	capabilitiesFlag := flag.Bool("capabilities", true, "print the registered provider capability matrix before running conformance")
@@ -169,6 +171,8 @@ func writeSummaryMarkdown(path string, summary conformanceSummary) error {
 	var b strings.Builder
 	b.WriteString("# Provider conformance summary\n\n")
 	fmt.Fprintf(&b, "Passed: %d. Skipped providers: %d. Failed: %d.\n\n", summary.Passed, summary.Skipped, summary.Failed)
+	fmt.Fprintf(&b, "Providers: %s.\n\n", markdownList(summary.Providers))
+	fmt.Fprintf(&b, "Harnesses: %s.\n\n", markdownList(summary.Harnesses))
 	b.WriteString("## Capability matrix\n\n")
 	b.WriteString(capabilityMarkdown(summary.Capabilities))
 	b.WriteString("\n## Harness results\n\n")
@@ -192,6 +196,17 @@ func capabilityMarkdown(rows []ai.CapabilityRow) string {
 		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n", row.Provider, mark(row.Model), mark(row.Image), mark(row.Video), mark(row.Stream))
 	}
 	return b.String()
+}
+
+func markdownList(values []string) string {
+	if len(values) == 0 {
+		return "—"
+	}
+	escaped := make([]string, 0, len(values))
+	for _, value := range values {
+		escaped = append(escaped, "`"+strings.ReplaceAll(value, "`", "\\`")+"`")
+	}
+	return strings.Join(escaped, ", ")
 }
 
 func markdownCell(s string) string {
@@ -277,6 +292,15 @@ func repoRoot() string {
 		}
 		wd = parent
 	}
+}
+
+func defaultProviders() string {
+	providers := make([]string, 0, len(providerEnv))
+	for provider := range providerEnv {
+		providers = append(providers, provider)
+	}
+	slices.Sort(providers)
+	return strings.Join(providers, ",")
 }
 
 func knownProviders() string {

--- a/internal/harness/provider-conformance/main_test.go
+++ b/internal/harness/provider-conformance/main_test.go
@@ -36,6 +36,18 @@ func TestValidateSelectionRejectsUnsafeHarnessName(t *testing.T) {
 	}
 }
 
+func TestDefaultProvidersTracksLiveProviderSet(t *testing.T) {
+	got := defaultProviders()
+	for _, want := range []string{"anthropic", "openai", "gemini", "groq", "mistral", "together", "atlascloud"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("defaultProviders() = %q, want %q", got, want)
+		}
+	}
+	if strings.Contains(got, "mock") {
+		t.Fatalf("defaultProviders() = %q, should not include mock in live scheduled defaults", got)
+	}
+}
+
 func TestCapabilityMatrixHasRegisteredProviders(t *testing.T) {
 	rows := ai.CapabilityRows()
 	if len(rows) == 0 {
@@ -105,6 +117,8 @@ func TestWriteSummaryMarkdown(t *testing.T) {
 	for _, want := range []string{
 		"# Provider conformance summary",
 		"Passed: 1. Skipped providers: 1. Failed: 0.",
+		"Providers: —.",
+		"Harnesses: —.",
 		"| mock | ✅ | — | — | — |",
 		"| mock | agent-flow | passed | — |",
 		"| live | — | skipped | missing \\| key |",
@@ -112,6 +126,14 @@ func TestWriteSummaryMarkdown(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("summary markdown = %q, want %q", got, want)
 		}
+	}
+}
+
+func TestMarkdownListEscapesBackticks(t *testing.T) {
+	got := markdownList([]string{"agent", "bad`name"})
+	want := "`agent`, `bad\\`name`"
+	if got != want {
+		t.Fatalf("markdownList() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds manual Harness workflow inputs for provider selection, harness selection, and strict missing-secret checks while preserving safe scheduled skips.
- Centralizes provider-conformance defaults and includes selected providers/harnesses in the Markdown summary.
- Documents keyed scheduled/manual conformance behavior.

Closes #3454
Closes #3458

## Testing
- go build ./...
- go test ./... (plain run hit environment loopback proxy failures; rerun with loopback proxy disabled passed)
- golangci-lint run ./...