### PR TITLE
Classify flow failure kinds

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -76,6 +76,7 @@ type Result struct {
 	Answer    string    `json:"answer,omitempty"`
 	ToolCalls []string  `json:"tool_calls,omitempty"`
 	Error     string    `json:"error,omitempty"`
+	ErrorKind string    `json:"error_kind,omitempty"`
 	Timestamp time.Time `json:"timestamp"`
 	Duration  float64   `json:"duration_seconds"`
 }
@@ -246,6 +247,7 @@ func (f *Flow) Execute(ctx context.Context, data string) error {
 		result.Duration = time.Since(start).Seconds()
 		if err != nil {
 			result.Error = err.Error()
+			result.ErrorKind = string(ai.ClassifyError(err))
 			f.record(result)
 			return err
 		}
@@ -261,6 +263,7 @@ func (f *Flow) Execute(ctx context.Context, data string) error {
 	if err != nil {
 		result.Duration = time.Since(start).Seconds()
 		result.Error = err.Error()
+		result.ErrorKind = string(ai.ClassifyError(err))
 		f.record(result)
 		return fmt.Errorf("discover tools: %w", err)
 	}
@@ -274,6 +277,7 @@ func (f *Flow) Execute(ctx context.Context, data string) error {
 
 	if err != nil {
 		result.Error = err.Error()
+		result.ErrorKind = string(ai.ClassifyError(err))
 		f.record(result)
 		return err
 	}

--- a/flow/otel.go
+++ b/flow/otel.go
@@ -23,6 +23,7 @@ const (
 	AttrFlowStatus    = "flow.status"
 	AttrFlowAttempts  = "flow.step.attempts"
 	AttrFlowLatencyMS = "flow.latency_ms"
+	AttrFlowErrorKind = "flow.error.kind"
 )
 
 func (f *Flow) tracer() trace.Tracer {
@@ -47,6 +48,7 @@ func (f *Flow) startRunSpan(ctx context.Context, run Run) (context.Context, func
 		)
 		if err != nil {
 			span.RecordError(err)
+			span.SetAttributes(attribute.String(AttrFlowErrorKind, string(ai.ClassifyError(err))))
 			span.SetStatus(codes.Error, err.Error())
 		} else {
 			span.SetStatus(codes.Ok, "")
@@ -74,6 +76,7 @@ func (f *Flow) runStepSpan(ctx context.Context, step Step, in State) (State, int
 	)
 	if err != nil {
 		span.RecordError(err)
+		span.SetAttributes(attribute.String(AttrFlowErrorKind, string(ai.ClassifyError(err))))
 		span.SetStatus(codes.Error, err.Error())
 	} else {
 		span.SetStatus(codes.Ok, "")

--- a/flow/steps.go
+++ b/flow/steps.go
@@ -63,11 +63,12 @@ type Step struct {
 
 // StepRecord is the recorded outcome of one step within a run.
 type StepRecord struct {
-	Name     string `json:"name"`
-	Status   string `json:"status"` // pending | in_progress | done | failed
-	Attempts int    `json:"attempts"`
-	Result   string `json:"result,omitempty"`
-	Error    string `json:"error,omitempty"`
+	Name      string `json:"name"`
+	Status    string `json:"status"` // pending | in_progress | done | failed
+	Attempts  int    `json:"attempts"`
+	Result    string `json:"result,omitempty"`
+	Error     string `json:"error,omitempty"`
+	ErrorKind string `json:"error_kind,omitempty"`
 }
 
 // Run is the persisted record of one flow execution — what a Checkpoint
@@ -431,6 +432,7 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 			spanErr = err
 			run.Steps[i].Status = "failed"
 			run.Steps[i].Error = err.Error()
+			run.Steps[i].ErrorKind = string(ai.ClassifyError(err))
 			run.Status = "failed"
 			if saveErr := f.save(ctx, run); saveErr != nil {
 				spanErr = saveErr
@@ -555,6 +557,7 @@ func resultFromRun(trigger string, run Run) Result {
 		r.ToolCalls = append(r.ToolCalls, s.Name+":"+s.Status)
 		if s.Error != "" {
 			r.Error = s.Error
+			r.ErrorKind = s.ErrorKind
 		}
 	}
 	if run.Status == "done" {

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -548,3 +548,37 @@ func TestStateSetScan(t *testing.T) {
 		t.Errorf("round-trip failed: %+v", got)
 	}
 }
+
+func TestFlowFailureRecordsErrorKind(t *testing.T) {
+	cp := StoreCheckpoint(store.NewMemoryStore(), "failure-kind")
+	f := New("failure-kind",
+		WithCheckpoint(cp),
+		Steps(Step{Name: "limited", Run: func(_ context.Context, in State) (State, error) {
+			return in, errors.New("rate limit exceeded")
+		}}),
+	)
+
+	err := f.Execute(context.Background(), "payload")
+	if err == nil {
+		t.Fatal("Execute error = nil, want failure")
+	}
+
+	runs, listErr := cp.List(context.Background())
+	if listErr != nil {
+		t.Fatalf("List: %v", listErr)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(runs))
+	}
+	if got := runs[0].Steps[0].ErrorKind; got != string(ai.ErrorKindRateLimited) {
+		t.Fatalf("step error kind = %q, want %q", got, ai.ErrorKindRateLimited)
+	}
+
+	results := f.Results()
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if got := results[0].ErrorKind; got != string(ai.ErrorKindRateLimited) {
+		t.Fatalf("result error kind = %q, want %q", got, ai.ErrorKindRateLimited)
+	}
+}


### PR DESCRIPTION
## Summary
- persist stable error_kind values on failed flow step records and execution results
- add flow OpenTelemetry error kind attributes for failed run and step spans
- cover rate-limit classification propagation in flow failure tests

Closes #3461
Closes #3463

## Testing
- go build ./...
- go test ./flow
- go test ./... (fails in this environment: loopback targets forbidden for grpc client/transport tests)
- golangci-lint run ./...