### PR TITLE
Trace agent checkpoint resume events

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	pb "go-micro.dev/v6/agent/proto"
@@ -271,6 +272,9 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		return nil, err
 	}
 	ctx, endRun := a.startRun(ctx, message)
+	if existing != nil {
+		a.recordTimelineEvent(ctx, RunEvent{Time: time.Now(), RunID: runID, ParentID: parentRunID, Agent: a.opts.Name, Kind: "resume", Name: run.State.Stage})
+	}
 	defer func() { endRun(err) }()
 
 	messages := a.mem.Messages()

--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -49,6 +49,12 @@ func (a *agentImpl) saveRun(ctx context.Context, run flow.Run) error {
 	if err := a.opts.Checkpoint.Save(ctx, run); err != nil {
 		return fmt.Errorf("agent %s checkpoint save: %w", a.opts.Name, err)
 	}
+	if info, ok := ai.RunInfoFrom(ctx); ok {
+		a.recordTimelineEvent(ctx, RunEvent{
+			Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent,
+			Kind: "checkpoint", Name: run.State.Stage, Status: run.Status,
+		})
+	}
 	return nil
 }
 

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -22,23 +22,25 @@ const (
 	spanNameModelCall = "agent.model.call"
 	spanNameToolCall  = "agent.tool.call"
 
-	AttrRunID          = "agent.run.id"
-	AttrParentRunID    = "agent.run.parent_id"
-	AttrAgentName      = "agent.name"
-	AttrProvider       = "agent.model.provider"
-	AttrModel          = "agent.model.name"
-	AttrLatencyMS      = "agent.latency_ms"
-	AttrInputTokens    = "agent.tokens.input"
-	AttrOutputTokens   = "agent.tokens.output"
-	AttrTotalTokens    = "agent.tokens.total"
-	AttrAttempt        = "agent.model.attempt"
-	AttrMaxAttempts    = "agent.model.max_attempts"
-	AttrToolName       = "agent.tool.name"
-	AttrDelegate       = "agent.delegate"
-	AttrGuardrailBlock = "agent.guardrail.block"
-	AttrRefusal        = "agent.refusal"
-	AttrInputChars     = "agent.input.chars"
-	AttrErrorKind      = "agent.error.kind"
+	AttrRunID            = "agent.run.id"
+	AttrParentRunID      = "agent.run.parent_id"
+	AttrAgentName        = "agent.name"
+	AttrProvider         = "agent.model.provider"
+	AttrModel            = "agent.model.name"
+	AttrLatencyMS        = "agent.latency_ms"
+	AttrInputTokens      = "agent.tokens.input"
+	AttrOutputTokens     = "agent.tokens.output"
+	AttrTotalTokens      = "agent.tokens.total"
+	AttrAttempt          = "agent.model.attempt"
+	AttrMaxAttempts      = "agent.model.max_attempts"
+	AttrToolName         = "agent.tool.name"
+	AttrDelegate         = "agent.delegate"
+	AttrGuardrailBlock   = "agent.guardrail.block"
+	AttrRefusal          = "agent.refusal"
+	AttrInputChars       = "agent.input.chars"
+	AttrErrorKind        = "agent.error.kind"
+	AttrCheckpointStatus = "agent.checkpoint.status"
+	AttrCheckpointStage  = "agent.checkpoint.stage"
 )
 
 type RunEvent struct {
@@ -57,6 +59,7 @@ type RunEvent struct {
 	LatencyMS   int64     `json:"latency_ms,omitempty"`
 	Tokens      Usage     `json:"tokens,omitempty"`
 	Refused     string    `json:"refused,omitempty"`
+	Status      string    `json:"status,omitempty"`
 	Error       string    `json:"error,omitempty"`
 	ErrorKind   string    `json:"error_kind,omitempty"`
 	InputChars  int       `json:"input_chars,omitempty"`
@@ -289,6 +292,15 @@ func classifyToolError(err string) string {
 	}
 }
 
+func (a *agentImpl) recordTimelineEvent(ctx context.Context, e RunEvent) {
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		a.recordSpanEvent(span, e)
+		return
+	}
+	a.recordRunEvent(e)
+}
+
 func (a *agentImpl) recordSpanEvent(span trace.Span, e RunEvent) {
 	if sc := span.SpanContext(); sc.IsValid() {
 		e.TraceID = sc.TraceID().String()
@@ -336,6 +348,14 @@ func runEventAttributes(e RunEvent) []attribute.KeyValue {
 	}
 	if e.ErrorKind != "" {
 		attrs = append(attrs, attribute.String(AttrErrorKind, e.ErrorKind))
+	}
+	if e.Kind == "checkpoint" {
+		if e.Status != "" {
+			attrs = append(attrs, attribute.String(AttrCheckpointStatus, e.Status))
+		}
+		if e.Name != "" {
+			attrs = append(attrs, attribute.String(AttrCheckpointStage, e.Name))
+		}
 	}
 	return attrs
 }

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/flow"
 	"go-micro.dev/v6/store"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -385,6 +386,74 @@ func TestAgentRunTimelineRecordsModelAndToolWithoutTraceProvider(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing %s event in timeline: %#v", kind, events)
 		}
+	}
+}
+
+func TestAgentCheckpointAndResumeTimelineEvents(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exp))
+	st := store.NewMemoryStore()
+	cp := flow.StoreCheckpoint(st, "resume-otel-agent")
+	first := true
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if first {
+			first = false
+			return nil, errors.New("temporary provider failure")
+		}
+		return &ai.Response{Reply: "resumed"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("resume-otel-agent"), WithStore(st), WithCheckpoint(cp), TraceProvider(tp))
+	_, err := a.Ask(context.Background(), "resume me")
+	if err == nil {
+		t.Fatal("Ask succeeded, want simulated failure")
+	}
+
+	runs, err := cp.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("checkpointed runs = %d, want 1", len(runs))
+	}
+	resp, err := Resume(context.Background(), a, runs[0].ID)
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resp.Reply != "resumed" {
+		t.Fatalf("reply = %q, want resumed", resp.Reply)
+	}
+
+	events, err := LoadRunEvents(st, "resume-otel-agent", runs[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{"checkpoint": false, "resume": false}
+	for _, e := range events {
+		if _, ok := seen[e.Kind]; ok {
+			seen[e.Kind] = true
+		}
+	}
+	for kind, ok := range seen {
+		if !ok {
+			t.Fatalf("missing %s event in timeline: %#v", kind, events)
+		}
+	}
+
+	var resumeSpanEvent bool
+	for _, s := range exp.GetSpans().Snapshots() {
+		if s.Name() != spanNameRun {
+			continue
+		}
+		for _, e := range s.Events() {
+			if e.Name == "agent.resume" {
+				resumeSpanEvent = true
+			}
+		}
+	}
+	if !resumeSpanEvent {
+		t.Fatal("run span missing agent.resume event")
 	}
 }
 


### PR DESCRIPTION
Summary:
- Record checkpoint lifecycle events in agent run timelines and active OpenTelemetry run spans.
- Record resume events when checkpointed agent runs are replayed, preserving run/span correlation.
- Add coverage for checkpoint and resume timeline/span observability.

Testing:
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden for grpc client/transport tests)
- golangci-lint run ./...

Closes #3455
Closes #3467