### PR TITLE
blog+docs: position go-micro vs tRPC-Agent-Go (agent = service)

### DIFF
--- a/internal/website/blog/32.md
+++ b/internal/website/blog/32.md
@@ -1,0 +1,58 @@
+---
+layout: blog
+title: "An Agent Is a Service: Go Micro and tRPC-Agent-Go"
+permalink: /blog/32
+description: "Two Go frameworks for building agents, two genuinely different bets. tRPC-Agent-Go is an agent SDK you run alongside your services; Go Micro is one runtime where an agent is a service. Here's the fork in the road."
+---
+
+# An Agent Is a Service: Go Micro and tRPC-Agent-Go
+
+*June 30, 2026 • By the Go Micro Team*
+
+[tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) is a strong, production-grade Go framework for building agents — maintained by tRPC-Group and validated inside Tencent. It's broad and serious: LLM, Chain, Parallel, Cycle, and Graph agents; function tools; MCP and A2A; AG-UI streaming; Redis memory and RAG; an evaluation framework; agent self-evolution; and OpenTelemetry. If you're on Tencent's tRPC stack, or you want graph-style orchestration with a large team behind it, it's a good choice.
+
+It's also the clearest example yet of a question worth answering directly: there are now several capable Go agent frameworks. What actually makes them different? With tRPC-Agent-Go the difference isn't a feature — it's a bet about where agents live.
+
+## Two bets
+
+Most agent frameworks, tRPC-Agent-Go included, are an **agent SDK you run alongside your services**. You compose agents and tools into graphs and conditional workflows. Your microservices live somewhere else — in tRPC's case, the tRPC stack — and the agents call into them. Agents are a layer you add on top of a service tier you already have.
+
+Go Micro makes the opposite bet: **an agent is a service.** There's no separate orchestration substrate bolted onto a service tier, because they're the same runtime.
+
+- **Every service endpoint is automatically an AI-callable tool**, from registry metadata. You don't wire tools into a graph — you write a service, and it's already a tool.
+- **An agent is a service** — it registers, is discovered, load-balances, exposes `Agent.Chat`, and is reachable over MCP and A2A like anything else.
+- **Workflows are durable code paths**, not a graph DSL — deterministic `flow` steps where the path is known, dispatch to an agent where it isn't.
+
+The premise is that the line between "your services" and "your agents" is accidental complexity. When they're the same primitives on one runtime, there's less to wire, less to keep in sync, and the path from a service to an agent that uses it is short.
+
+That's also why Go Micro deliberately *isn't* a graph DSL. Graphs are expressive, and for some teams that's exactly the model they want. But a graph is another thing to learn and maintain next to your services; "it's just services and durable flows" is a smaller surface to hold in your head.
+
+## How to choose
+
+| If you want… | Lean |
+|---|---|
+| A graph/workflow DSL for composing agents and tools | tRPC-Agent-Go |
+| To add agents alongside an existing tRPC / service stack | tRPC-Agent-Go |
+| First-class evaluation and self-evolution today, with a big team behind it | tRPC-Agent-Go |
+| One runtime where services, agents, and flows are the same primitives | Go Micro |
+| Existing services to become tools with zero glue, and agents that *are* services | Go Micro |
+| A small, independent framework you can hold in your head | Go Micro |
+
+## Honest gaps
+
+tRPC-Agent-Go ships things Go Micro is still building: a first-class evaluation framework, agent self-evolution, AG-UI, and RAG out of the box. Go Micro has the trace foundation (OpenTelemetry run timelines, `micro runs`) and has the verification/grader loop and richer memory on the roadmap — but if you need those today, they're further along there. We'd rather say that plainly than pretend the checklists match.
+
+## They interoperate
+
+This isn't winner-take-all at the protocol layer. Both speak **MCP** (tools) and **A2A** (agents), so a Go Micro agent and a tRPC-Agent-Go agent can call each other, and either can consume the other's tools. A natural pattern: run Go Micro as the service-and-agent runtime, and reach an agent built on tRPC-Agent-Go over A2A — or the reverse.
+
+Different frameworks, open protocols. The bet we're making is that when an agent has to operate inside a real system — discover services, call them, hold state, recover, be called by others — it *is* a distributed system, and the simplest place to build it is the runtime where services already live.
+
+---
+
+*Go Micro is an open source agent harness and service framework for Go. [Star us on GitHub](https://github.com/micro/go-micro).*
+
+<div class="post-nav">
+  <div><a href="/blog/31">&larr; How Go Micro Builds Itself</a></div>
+  <div><a href="/blog/">All Posts</a></div>
+</div>

--- a/internal/website/blog/index.html
+++ b/internal/website/blog/index.html
@@ -12,6 +12,13 @@ permalink: /blog/
 <div class="posts">
 
   <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
+    <h2 style="margin: 0 0 0.5rem;"><a href="/blog/32">An Agent Is a Service: Go Micro and tRPC-Agent-Go</a></h2>
+    <p class="meta" style="color: #666; font-size: 0.85rem;">June 30, 2026</p>
+    <p>Two Go frameworks for building agents, two genuinely different bets. tRPC-Agent-Go is an agent SDK you run alongside your services; Go Micro is one runtime where an agent is a service — every endpoint a tool, no graph DSL. The fork in the road, and how they interoperate.</p>
+    <a href="/blog/32">Read more &rarr;</a>
+  </article>
+
+  <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
     <h2 style="margin: 0 0 0.5rem;"><a href="/blog/31">How Go Micro Builds Itself</a></h2>
     <p class="meta" style="color: #666; font-size: 0.85rem;">June 25, 2026</p>
     <p>Go Micro is increasingly built by an autonomous loop of two AI agents — Codex writing scoped increments, Claude Code orchestrating, the human setting direction. Here's how the loop actually works, including the parts that broke.</p>

--- a/internal/website/docs/guides/comparison.md
+++ b/internal/website/docs/guides/comparison.md
@@ -227,6 +227,53 @@ and an ADK agent (in any language) can call each other over A2A, and either can
 consume the other's MCP tools. A common pattern is to run Go Micro as the service
 mesh / runtime and let ADK (or any A2A agent) plug into it.
 
+## vs tRPC-Agent-Go
+
+[tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) (maintained by tRPC-Group,
+validated inside Tencent) is a production-grade Go framework for agent systems:
+LLM / Chain / Parallel / Cycle / Graph agents, function tools, MCP, A2A, AG-UI, Redis
+memory and RAG, evaluation, agent self-evolution, and OpenTelemetry. It's a serious,
+well-resourced project.
+
+They overlap heavily on agents but make a different bet. tRPC-Agent-Go is an **agent
+SDK you run alongside your services** — you compose agents and tools into graphs and
+conditional workflows, and your microservices (tRPC) live separately and are called
+into. Go Micro starts from the premise that **an agent is a service** — one runtime
+where every endpoint is automatically a tool, an agent registers and is discovered and
+load-balanced like anything else, and workflows are durable code paths rather than a
+graph DSL. The bet is that the line between "your services" and "your agents" is
+accidental complexity; remove it and there's less to wire and keep in sync.
+
+| | Go Micro | tRPC-Agent-Go |
+|---|----------|---------------|
+| **Primary unit** | A harnessed service (an agent is a service with an LLM inside) | An agent |
+| **Orchestration** | Durable `flow` steps + `Loop` — plain code paths | Graph / Chain / Parallel / Cycle agents (graph DSL) |
+| **Services as tools** | Every endpoint is automatically an MCP tool | Function tools + MCP, wired explicitly |
+| **Service runtime** | Built in — agents *are* services (registry, RPC, load balancing, pub/sub) | Runs alongside your existing service stack (tRPC) |
+| **MCP / A2A** | Both, generated from the registry | Both |
+| **Evaluation / self-evolution** | Verification loop on the roadmap; not yet first-class | First-class today |
+| **Memory / RAG** | Store-backed memory (Postgres, NATS KV, file); RAG on the roadmap | In-memory / Redis memory; RAG today |
+| **Observability** | OpenTelemetry run timelines, `micro runs` | OpenTelemetry, Langfuse examples |
+| **Backing** | Independent, community | tRPC-Group / Tencent |
+
+### When to choose tRPC-Agent-Go
+- You want a graph/workflow DSL for composing agents and tools
+- You're on tRPC, or want to add agents alongside an existing service stack
+- You want first-class evaluation and self-evolution today, with a large team behind it
+
+### When to choose Go Micro
+- You want one runtime where services, agents, and flows are the same primitives —
+  registered, discoverable, and deployed the same way
+- You want your existing services to become agent tools with zero extra code
+- You prefer durable flows and plain code paths over a graph DSL, in a small,
+  independent framework you can hold in your head
+
+### They interoperate
+
+Both speak **MCP** and **A2A**, so a Go Micro agent and a tRPC-Agent-Go agent can call
+each other over A2A, and either can consume the other's MCP tools. You can run Go Micro
+as the service-and-agent runtime and still reach an agent built on tRPC-Agent-Go.
+
 ## Feature Deep Dive
 
 ### Service Discovery


### PR DESCRIPTION
A fair, honest positioning piece on the architectural fork with [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) — written to lead with *our* thesis, not punch down.

- **New blog post `/blog/32`** — "An Agent Is a Service: Go Micro and tRPC-Agent-Go." Frames the real difference: tRPC-Agent-Go is an agent SDK you run *alongside* your services (graph DSL); Go Micro is *one runtime where an agent is a service* (every endpoint a tool, durable flows not a graph DSL). Honest about where tRPC-Agent-Go is ahead (eval, self-evolution, RAG) and that they interoperate over MCP/A2A.
- **Parallel section in the existing `comparison.md` guide** — same structure as the Google ADK section (table + when-to-choose + interop), so it lives where readers already look.

Generous about a serious, Tencent-backed competitor; the contrast carries the message rather than disparagement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_