### PR TITLE
blog: expand /blog/32 into a field guide on agent frameworks

### DIFF
--- a/internal/website/blog/32.md
+++ b/internal/website/blog/32.md
@@ -2,7 +2,7 @@
 layout: blog
 title: "An Agent Is a Service: Go Micro and tRPC-Agent-Go"
 permalink: /blog/32
-description: "Two Go frameworks for building agents, two genuinely different bets. tRPC-Agent-Go is an agent SDK you run alongside your services; Go Micro is one runtime where an agent is a service. Here's the fork in the road."
+description: "Two Go frameworks for building agents, two genuinely different approaches. tRPC-Agent-Go is an agent SDK you run alongside your services; Go Micro is one runtime where an agent is a service. Here's the fork in the road."
 ---
 
 # An Agent Is a Service: Go Micro and tRPC-Agent-Go
@@ -11,13 +11,13 @@ description: "Two Go frameworks for building agents, two genuinely different bet
 
 [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) is a strong, production-grade Go framework for building agents — maintained by tRPC-Group and validated inside Tencent. It's broad and serious: LLM, Chain, Parallel, Cycle, and Graph agents; function tools; MCP and A2A; AG-UI streaming; Redis memory and RAG; an evaluation framework; agent self-evolution; and OpenTelemetry. If you're on Tencent's tRPC stack, or you want graph-style orchestration with a large team behind it, it's a good choice.
 
-It's also the clearest example yet of a question worth answering directly: there are now several capable Go agent frameworks. What actually makes them different? With tRPC-Agent-Go the difference isn't a feature — it's a bet about where agents live.
+It's also the clearest example yet of a question worth answering directly: there are now several capable Go agent frameworks. What actually makes them different? With tRPC-Agent-Go the difference isn't a feature — it's about where agents live.
 
-## Two bets
+## Two approaches
 
 Most agent frameworks, tRPC-Agent-Go included, are an **agent SDK you run alongside your services**. You compose agents and tools into graphs and conditional workflows. Your microservices live somewhere else — in tRPC's case, the tRPC stack — and the agents call into them. Agents are a layer you add on top of a service tier you already have.
 
-Go Micro makes the opposite bet: **an agent is a service.** There's no separate orchestration substrate bolted onto a service tier, because they're the same runtime.
+Go Micro starts from the opposite premise: **an agent is a service.** There's no separate orchestration substrate bolted onto a service tier, because they're the same runtime.
 
 - **Every service endpoint is automatically an AI-callable tool**, from registry metadata. You don't wire tools into a graph — you write a service, and it's already a tool.
 - **An agent is a service** — it registers, is discovered, load-balances, exposes `Agent.Chat`, and is reachable over MCP and A2A like anything else.
@@ -46,7 +46,7 @@ tRPC-Agent-Go ships things Go Micro is still building: a first-class evaluation 
 
 This isn't winner-take-all at the protocol layer. Both speak **MCP** (tools) and **A2A** (agents), so a Go Micro agent and a tRPC-Agent-Go agent can call each other, and either can consume the other's tools. A natural pattern: run Go Micro as the service-and-agent runtime, and reach an agent built on tRPC-Agent-Go over A2A — or the reverse.
 
-Different frameworks, open protocols. The bet we're making is that when an agent has to operate inside a real system — discover services, call them, hold state, recover, be called by others — it *is* a distributed system, and the simplest place to build it is the runtime where services already live.
+Different frameworks, open protocols. The principle we're building on is that when an agent has to operate inside a real system — discover services, call them, hold state, recover, be called by others — it *is* a distributed system, and the simplest place to build it is the runtime where services already live.
 
 ---
 

--- a/internal/website/blog/32.md
+++ b/internal/website/blog/32.md
@@ -1,52 +1,83 @@
 ---
 layout: blog
-title: "An Agent Is a Service: Go Micro and tRPC-Agent-Go"
+title: "An Agent Is a Service: Where Agent Frameworks Are Going"
 permalink: /blog/32
-description: "Two Go frameworks for building agents, two genuinely different approaches. tRPC-Agent-Go is an agent SDK you run alongside your services; Go Micro is one runtime where an agent is a service. Here's the fork in the road."
+description: "A field guide to the agent-framework landscape — from LangChain and the first wave, through the two layers of a harness and the rise of loop engineering, to where the frameworks diverge. And why Go Micro's answer is that an agent is a service."
 ---
 
-# An Agent Is a Service: Go Micro and tRPC-Agent-Go
+# An Agent Is a Service: Where Agent Frameworks Are Going
 
 *June 30, 2026 • By the Go Micro Team*
 
-[tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) is a strong, production-grade Go framework for building agents — maintained by tRPC-Group and validated inside Tencent. It's broad and serious: LLM, Chain, Parallel, Cycle, and Graph agents; function tools; MCP and A2A; AG-UI streaming; Redis memory and RAG; an evaluation framework; agent self-evolution; and OpenTelemetry. If you're on Tencent's tRPC stack, or you want graph-style orchestration with a large team behind it, it's a good choice.
+There are now a lot of ways to build an agent. LangChain and LangGraph, LlamaIndex, CrewAI, Microsoft's AutoGen, Google's ADK, the model labs' own SDKs, and — most recently in our own backyard — [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) from Tencent. They are not all solving the same problem, and the places they differ tell you a lot about where this is heading.
 
-It's also the clearest example yet of a question worth answering directly: there are now several capable Go agent frameworks. What actually makes them different? With tRPC-Agent-Go the difference isn't a feature — it's about where agents live.
+This is a field guide to that landscape, and an honest account of where Go Micro sits in it.
 
-## Two approaches
+## The first wave: a model in a loop
 
-Most agent frameworks, tRPC-Agent-Go included, are an **agent SDK you run alongside your services**. You compose agents and tools into graphs and conditional workflows. Your microservices live somewhere else — in tRPC's case, the tRPC stack — and the agents call into them. Agents are a layer you add on top of a service tier you already have.
+The first wave of agent frameworks solved one thing: get a model to call tools in a loop until a task is done. LangChain, more than any other project, defined that category in 2022 — chains, then agents, then graphs. LlamaIndex came at it from the data and retrieval side. CrewAI and AutoGen leaned into multi-agent orchestration — crews and conversations of role-played agents. The model labs shipped their own agent SDKs so you could stay close to the metal.
 
-Go Micro starts from the opposite premise: **an agent is a service.** There's no separate orchestration substrate bolted onto a service tier, because they're the same runtime.
+That first problem — model, tools, a loop — is now largely commoditized. Every SDK does it, and they mostly do it well. Which means the interesting question has moved. It is no longer "how do I get a model to use a tool." It is everything that happens *around* the loop once the agent has to do real work: connect to real systems, hold state across restarts, recover from failure, be observed, be scheduled, and be reached by other agents. That is the part that decides whether an agent makes it out of a demo.
 
-- **Every service endpoint is automatically an AI-callable tool**, from registry metadata. You don't wire tools into a graph — you write a service, and it's already a tool.
-- **An agent is a service** — it registers, is discovered, load-balances, exposes `Agent.Chat`, and is reachable over MCP and A2A like anything else.
-- **Workflows are durable code paths**, not a graph DSL — deterministic `flow` steps where the path is known, dispatch to an agent where it isn't.
+LangChain itself is the clearest evidence. The framework was the distribution; the value moved to *operating* agents — which is why their commercial product is LangSmith (observability, evaluation, monitoring), not the framework. The lesson the pioneer taught is that the framework gets you to a running agent, and the hard, durable, valuable problems are in operating it.
 
-The premise is that the line between "your services" and "your agents" is accidental complexity. When they're the same primitives on one runtime, there's less to wire, less to keep in sync, and the path from a service to an agent that uses it is short.
+## "Agent = Model + Harness" — but a harness has two layers
 
-That's also why Go Micro deliberately *isn't* a graph DSL. Graphs are expressive, and for some teams that's exactly the model they want. But a graph is another thing to learn and maintain next to your services; "it's just services and durable flows" is a smaller surface to hold in your head.
+LangChain has a good framing for this: an agent is a model plus a *harness* — the runtime around the model that makes it useful. The framing is right. What is usually left implicit is that "harness" has two distinct layers, and almost all the frameworks live in the first one.
 
-## How to choose
+**The intra-agent harness** is the runtime around a *single model*: the system prompt, the tool definitions, context management and compaction, the sandbox, self-verification, and the continuation loop that keeps the model going until it is done. LangChain and LangGraph, deepagents, Claude Code, and the model labs' SDKs are excellent at this. It is real, hard work, and it is most of what people mean when they say "agent framework."
 
-| If you want… | Lean |
-|---|---|
-| A graph/workflow DSL for composing agents and tools | tRPC-Agent-Go |
-| To add agents alongside an existing tRPC / service stack | tRPC-Agent-Go |
-| First-class evaluation and self-evolution today, with a big team behind it | tRPC-Agent-Go |
-| One runtime where services, agents, and flows are the same primitives | Go Micro |
-| Existing services to become tools with zero glue, and agents that *are* services | Go Micro |
-| A small, independent framework you can hold in your head | Go Micro |
+**The operational harness** is the distributed substrate an agent *operates inside*: services exposed as typed tools, discovery and RPC, durable and resumable runs, observability, scheduling, and the protocols agents use to reach each other. This is the layer where a single agent stops being a script and becomes part of a system — where many agents, many services, and many workflows have to compose without falling over.
 
-## Honest gaps
+The first layer produces an agent. The second is where that agent has to live. Most frameworks build the first and leave the second to you — you bring your own services, your own discovery, your own durability, your own deployment. That is the gap that matters now, because the moment you have more than one agent or one service, the operational harness *is* the product.
 
-tRPC-Agent-Go ships things Go Micro is still building: a first-class evaluation framework, agent self-evolution, AG-UI, and RAG out of the box. Go Micro has the trace foundation (OpenTelemetry run timelines, `micro runs`) and has the verification/grader loop and richer memory on the roadmap — but if you need those today, they're further along there. We'd rather say that plainly than pretend the checklists match.
+## The loop is the new frontier
 
-## They interoperate
+If the first wave was "a model in a loop," the direction now is what LangChain has started calling [loop engineering](https://www.langchain.com/blog/the-art-of-loop-engineering): stacking loops around the agent. It is a useful map. There is the **agent loop** (model calls tools until done), the **verification loop** (a grader checks the output against a rubric and sends failures back with feedback), the **event-driven loop** (the agent is triggered by webhooks, schedules, or messages instead of a human typing), and the **hill-climbing loop** (production traces feed back to improve the prompts, tools, and graders over time).
 
-This isn't winner-take-all at the protocol layer. Both speak **MCP** (tools) and **A2A** (agents), so a Go Micro agent and a tRPC-Agent-Go agent can call each other, and either can consume the other's tools. A natural pattern: run Go Micro as the service-and-agent runtime, and reach an agent built on tRPC-Agent-Go over A2A — or the reverse.
+Notice that only the first of those four is the intra-agent harness. The other three — verification, event-driven triggers, learning from traces — are the operational harness. The frontier is moving from "answer a prompt" to **scheduled, looping, work-performing agents**: agents that run on a cadence, do real work, check their own output, and get better. That is exactly the layer that is underbuilt, and it is the layer that decides whether agents are dependable.
 
-Different frameworks, open protocols. The principle we're building on is that when an agent has to operate inside a real system — discover services, call them, hold state, recover, be called by others — it *is* a distributed system, and the simplest place to build it is the runtime where services already live.
+## Where the frameworks are going
+
+Survey the field and a shape emerges. LangChain and LangGraph pair graph-based orchestration with LangSmith for operations, funded to build the team that operates the platform. CrewAI and AutoGen are converging on multi-agent orchestration patterns. Google's ADK is a strong code-first framework with first-class evaluation, tuned for Gemini and Google Cloud. tRPC-Agent-Go brings a production-grade Go agent SDK — LLM, Chain, Parallel, Cycle, and Graph agents; tools; MCP and A2A; memory and RAG; evaluation; agent self-evolution; OpenTelemetry — maintained by Tencent's tRPC group and validated inside Tencent.
+
+They differ in the details, but most share two structural choices. They are an **agent SDK you run alongside your services** — the agents are a layer, and your service tier lives somewhere else and is called into. And they are **graph-centric** — you compose agents and tools into graphs and conditional workflows. That is a coherent, well-trodden approach, and for a lot of teams it is exactly right.
+
+Go Micro starts somewhere else.
+
+## Where Go Micro fits: an agent is a service
+
+Go Micro's position is a single claim: **an agent is a service.** Not a layer bolted onto a service tier — the same runtime.
+
+The reasoning is straightforward. The moment an agent has to discover services, call them, hold state, and recover from failure, it *is* a distributed system. That is precisely the problem a service framework already solves. So instead of building an agent SDK that sits next to your services, Go Micro makes agents and services the same primitives:
+
+- **Every service endpoint is automatically an AI-callable tool**, derived from registry metadata. You do not wire tools into a graph; you write a service and it is already a tool, reachable over MCP.
+- **An agent is a service.** It registers, is discovered, load-balances, exposes an `Agent.Chat` RPC, keeps store-backed memory, and is reachable over A2A — the same lifecycle as anything else you run.
+- **Workflows are durable code paths, not a graph DSL.** Use a `flow` of checkpointed steps where the path is known; dispatch to an agent where it is not. The deterministic parts are plain, resumable Go; the dynamic parts are agents.
+
+The premise is that the line between "your services" and "your agents" is accidental complexity. Remove it, and there is less to wire, less to keep in sync, and a much shorter path from a service to an agent that uses it. The operational harness — discovery, RPC, pub/sub, durable runs, observability, deployment — is not something you assemble around the framework. It *is* the framework.
+
+This is also why Go Micro is deliberately not a graph DSL. Graphs are expressive, and for some teams that visual, declarative model is the draw. But a graph is one more thing to learn and maintain next to your services. "It is just services and durable flows" is a smaller surface to hold in your head, and it composes with everything a service already does.
+
+## A concrete contrast: tRPC-Agent-Go
+
+Because it is the closest neighbour — a serious, production Go framework — tRPC-Agent-Go makes the fork concrete. It is an agent SDK that runs alongside your tRPC services, organised around graph, chain, parallel, and cycle agents. Go Micro is one runtime where the agent *is* the service and orchestration is durable flows.
+
+We will be honest about where they are ahead: tRPC-Agent-Go ships a first-class evaluation framework, agent self-evolution, AG-UI streaming, and RAG today. Go Micro has the trace foundation (OpenTelemetry run timelines, `micro runs`) and has the verification/grader loop and richer memory on the roadmap — but if you need those right now, they are further along there, with a large team behind them. Pretending the checklists match would help no one.
+
+What Go Micro offers in return is the thing an SDK-alongside-your-services cannot: services that become tools with zero glue, agents that are first-class services, and one set of primitives — service, agent, flow — instead of a service stack plus an agent layer plus a graph runtime.
+
+## The direction we're building
+
+If scheduled, looping, work-performing agents are where this goes, then the operational harness is the thing to get right, and loops are the organising idea. Go Micro already has the agent loop, durable event-driven flows, and the trace foundation for learning. The verification loop — grade a step's output against a rubric and route failures back with feedback — is the next primitive, building on the supervised loop and retry machinery already there. Durable agent runs, streaming end to end, and richer observability are on the same line. The aim is not to win a feature checklist; it is to be the runtime where an operating agent is dependable.
+
+There is one more piece of evidence we find hard to argue with: Go Micro is increasingly built by its own loop — an autonomous improvement loop running in CI, opening and merging its own changes against a thesis. An agent harness, operated by agents, building itself. If it is good enough to do that, it is good enough to operate yours.
+
+## Open protocols, different homes
+
+None of this is winner-take-all, and it should not be. Every serious framework here speaks **MCP** for tools and **A2A** for agents. A Go Micro agent and a tRPC-Agent-Go agent can call each other; either can consume the other's tools; an ADK or LangGraph agent can plug into a Go Micro runtime over A2A, and the reverse. The protocols are the commons.
+
+So the real question is not which framework wins. It is where your agents should *live*. The answer that Go Micro is built around is that when an agent has to operate inside a real system, it is a distributed system — and the simplest place to build it is the runtime where your services already live.
 
 ---
 

--- a/internal/website/blog/index.html
+++ b/internal/website/blog/index.html
@@ -14,7 +14,7 @@ permalink: /blog/
   <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
     <h2 style="margin: 0 0 0.5rem;"><a href="/blog/32">An Agent Is a Service: Go Micro and tRPC-Agent-Go</a></h2>
     <p class="meta" style="color: #666; font-size: 0.85rem;">June 30, 2026</p>
-    <p>Two Go frameworks for building agents, two genuinely different bets. tRPC-Agent-Go is an agent SDK you run alongside your services; Go Micro is one runtime where an agent is a service — every endpoint a tool, no graph DSL. The fork in the road, and how they interoperate.</p>
+    <p>Two Go frameworks for building agents, two genuinely different approaches. tRPC-Agent-Go is an agent SDK you run alongside your services; Go Micro is one runtime where an agent is a service — every endpoint a tool, no graph DSL. The fork in the road, and how they interoperate.</p>
     <a href="/blog/32">Read more &rarr;</a>
   </article>
 

--- a/internal/website/blog/index.html
+++ b/internal/website/blog/index.html
@@ -12,9 +12,9 @@ permalink: /blog/
 <div class="posts">
 
   <article style="margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #e5e5e5;">
-    <h2 style="margin: 0 0 0.5rem;"><a href="/blog/32">An Agent Is a Service: Go Micro and tRPC-Agent-Go</a></h2>
+    <h2 style="margin: 0 0 0.5rem;"><a href="/blog/32">An Agent Is a Service: Where Agent Frameworks Are Going</a></h2>
     <p class="meta" style="color: #666; font-size: 0.85rem;">June 30, 2026</p>
-    <p>Two Go frameworks for building agents, two genuinely different approaches. tRPC-Agent-Go is an agent SDK you run alongside your services; Go Micro is one runtime where an agent is a service — every endpoint a tool, no graph DSL. The fork in the road, and how they interoperate.</p>
+    <p>A field guide to the agent-framework landscape — LangChain and the first wave, the two layers of a harness, the rise of loop engineering, and where the frameworks (LangGraph, ADK, CrewAI, AutoGen, tRPC-Agent-Go) diverge. And why Go Micro's answer is that an agent is a service.</p>
     <a href="/blog/32">Read more &rarr;</a>
   </article>
 

--- a/internal/website/docs/guides/comparison.md
+++ b/internal/website/docs/guides/comparison.md
@@ -235,13 +235,13 @@ LLM / Chain / Parallel / Cycle / Graph agents, function tools, MCP, A2A, AG-UI, 
 memory and RAG, evaluation, agent self-evolution, and OpenTelemetry. It's a serious,
 well-resourced project.
 
-They overlap heavily on agents but make a different bet. tRPC-Agent-Go is an **agent
+They overlap heavily on agents but take a different approach. tRPC-Agent-Go is an **agent
 SDK you run alongside your services** — you compose agents and tools into graphs and
 conditional workflows, and your microservices (tRPC) live separately and are called
 into. Go Micro starts from the premise that **an agent is a service** — one runtime
 where every endpoint is automatically a tool, an agent registers and is discovered and
 load-balanced like anything else, and workflows are durable code paths rather than a
-graph DSL. The bet is that the line between "your services" and "your agents" is
+graph DSL. The premise is that the line between "your services" and "your agents" is
 accidental complexity; remove it and there's less to wire and keep in sync.
 
 | | Go Micro | tRPC-Agent-Go |


### PR DESCRIPTION
Expands `/blog/32` into a proper field guide on the agent-framework landscape (per feedback that it was too short and needed deeper context), and drops the word "bet" throughout (incl. the comparison guide).

The post now covers:
- **The first wave** — LangChain and the pioneers; how "a model in a loop" got commoditized and the value moved to *operating* agents (the LangSmith lesson).
- **Two layers of a harness** — intra-agent (single model) vs operational (the distributed substrate); most frameworks build the first.
- **Loop engineering** — the four loops and the move to scheduled, looping, work-performing agents.
- **Where the frameworks are going** — LangGraph, CrewAI, AutoGen, ADK, tRPC-Agent-Go; the common shape (SDK-alongside-services, graph-centric).
- **Go Micro's position** — an agent is a service; the honest tRPC-Agent-Go contrast (incl. where they're ahead); the direction we're building; MCP/A2A interop.

~1,800 words. Generous to competitors, leads with the thesis. The `comparison.md` reword (no "bet") rides along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_