### PR TITLE
Add agent memory summarizer hook

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -178,7 +178,7 @@ func (a *agentImpl) setupWithToolHandler(handler ai.ToolHandler) {
 	case a.ephemeral:
 		a.mem = NewInMemory(a.opts.HistoryLimit)
 	case a.opts.MemoryCompaction.MaxMessages > 0:
-		a.mem = NewCompactingMemory(a.stateStore(), "history", a.opts.MemoryCompaction.MaxMessages, a.opts.MemoryCompaction.KeepRecent)
+		a.mem = NewCompactingMemoryWithOptions(a.stateStore(), "history", a.opts.MemoryCompaction)
 	default:
 		a.mem = NewMemory(a.stateStore(), "history", a.opts.HistoryLimit)
 	}

--- a/agent/memory.go
+++ b/agent/memory.go
@@ -24,6 +24,12 @@ type Memory interface {
 	Clear()
 }
 
+// MemorySummaryFunc turns older conversation messages into a compact
+// replacement message for active context. It is called while the default
+// memory is locked, so implementations should be deterministic and avoid
+// calling back into the same memory instance.
+type MemorySummaryFunc func([]ai.Message) ai.Message
+
 // MemoryCompaction configures deterministic, store-backed context compaction
 // for the default memory implementation. When the retained conversation grows
 // past MaxMessages, older turns are collapsed into a summary message while the
@@ -31,6 +37,7 @@ type Memory interface {
 type MemoryCompaction struct {
 	MaxMessages int
 	KeepRecent  int
+	Summarize   MemorySummaryFunc
 }
 
 // MemoryRecall is implemented by memory backends that can retrieve durable
@@ -54,6 +61,14 @@ func NewMemory(s store.Store, key string, limit int) Memory {
 // turns into a deterministic summary when the conversation exceeds maxMessages,
 // and lets callers recall relevant prior turns with Recall.
 func NewCompactingMemory(s store.Store, key string, maxMessages, keepRecent int) Memory {
+	return NewCompactingMemoryWithOptions(s, key, MemoryCompaction{MaxMessages: maxMessages, KeepRecent: keepRecent})
+}
+
+// NewCompactingMemoryWithOptions returns store-backed memory configured with
+// explicit compaction options, including an optional summarization hook.
+func NewCompactingMemoryWithOptions(s store.Store, key string, compaction MemoryCompaction) Memory {
+	maxMessages := compaction.MaxMessages
+	keepRecent := compaction.KeepRecent
 	if keepRecent <= 0 {
 		keepRecent = maxMessages / 2
 	}
@@ -69,6 +84,7 @@ func NewCompactingMemory(s store.Store, key string, maxMessages, keepRecent int)
 		compaction: MemoryCompaction{
 			MaxMessages: maxMessages,
 			KeepRecent:  keepRecent,
+			Summarize:   compaction.Summarize,
 		},
 	}
 	m.load()
@@ -213,14 +229,25 @@ func (m *storeMemory) compact() {
 	older := msgs[:cut]
 	recent := msgs[cut:]
 	m.archive = append(m.archive, older...)
-	summary := ai.Message{
-		Role:    "system",
-		Content: fmt.Sprintf("Conversation memory summary: %s", summarizeMessages(older)),
+	summarize := m.compaction.Summarize
+	if summarize == nil {
+		summarize = defaultMemorySummary
+	}
+	summary := summarize(older)
+	if summary.Role == "" {
+		summary.Role = "system"
 	}
 	m.hist.Reset()
 	m.hist.Add(summary.Role, summary.Content)
 	for _, msg := range recent {
 		m.hist.Add(msg.Role, msg.Content)
+	}
+}
+
+func defaultMemorySummary(msgs []ai.Message) ai.Message {
+	return ai.Message{
+		Role:    "system",
+		Content: fmt.Sprintf("Conversation memory summary: %s", summarizeMessages(msgs)),
 	}
 }
 

--- a/agent/memory_test.go
+++ b/agent/memory_test.go
@@ -3,9 +3,11 @@ package agent
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
+	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/store"
 )
@@ -93,6 +95,36 @@ func TestCompactingMemoryArchivePersistsAndReloads(t *testing.T) {
 	if !ok {
 		t.Fatal("compacting memory should support recall")
 	}
+	recalled := recall.Recall("alpha budget", 1)
+	if len(recalled) != 1 {
+		t.Fatalf("recalled %d messages, want 1", len(recalled))
+	}
+	if got := recalled[0].Content.(string); !strings.Contains(got, "alpha budget is 42") {
+		t.Fatalf("reloaded recall = %q, want alpha budget", got)
+	}
+}
+
+func TestCompactingMemoryUsesCustomSummarizerAndReloadsRecall(t *testing.T) {
+	st := store.NewMemoryStore()
+	m := NewCompactingMemoryWithOptions(st, "agent/custom/history", MemoryCompaction{
+		MaxMessages: 3,
+		KeepRecent:  1,
+		Summarize: func(msgs []ai.Message) ai.Message {
+			return ai.Message{Role: "system", Content: "custom summary count=" + strconv.Itoa(len(msgs))}
+		},
+	})
+	m.Add("user", "alpha budget is 42")
+	m.Add("assistant", "noted")
+	m.Add("user", "beta budget is 7")
+	m.Add("assistant", "noted")
+
+	msgs := m.Messages()
+	if len(msgs) == 0 || msgs[0].Content != "custom summary count=3" {
+		t.Fatalf("summary = %#v, want custom summarizer output", msgs)
+	}
+
+	reloaded := NewCompactingMemoryWithOptions(st, "agent/custom/history", MemoryCompaction{MaxMessages: 3, KeepRecent: 1})
+	recall := reloaded.(MemoryRecall)
 	recalled := recall.Recall("alpha budget", 1)
 	if len(recalled) != 1 {
 		t.Fatalf("recalled %d messages, want 1", len(recalled))

--- a/agent/options.go
+++ b/agent/options.go
@@ -246,11 +246,20 @@ func WithMemory(m Memory) Option {
 // turns are injected into matching future asks.
 func CompactMemory(maxMessages, keepRecent int) Option {
 	return func(o *Options) {
-		o.MemoryCompaction = MemoryCompaction{MaxMessages: maxMessages, KeepRecent: keepRecent}
+		o.MemoryCompaction.MaxMessages = maxMessages
+		o.MemoryCompaction.KeepRecent = keepRecent
 		if o.MemoryRecallLimit == 0 {
 			o.MemoryRecallLimit = 5
 		}
 	}
+}
+
+// MemorySummarizer sets the deterministic summarization hook used by the
+// default compacting memory. It is optional; without it, compacted memory uses
+// a provider-neutral text summary. The hook receives the older messages being
+// removed from active context and returns the replacement summary message.
+func MemorySummarizer(fn MemorySummaryFunc) Option {
+	return func(o *Options) { o.MemoryCompaction.Summarize = fn }
 }
 
 // MemoryRecallLimit sets how many archived turns a memory backend may inject


### PR DESCRIPTION
Summary:
- Add an optional compacting-memory summarizer hook while preserving the default deterministic summary behavior.
- Thread compacting memory options through agent setup so agents can use custom summaries with store-backed compaction.
- Add deterministic coverage for custom summary output and archived recall after reload.

Testing:
- go build ./...
- go test ./... (fails in this sandbox because loopback gRPC tests are blocked by the environment: Loopback targets forbidden)
- golangci-lint run ./...

Closes #3473
Closes #3477