### PR TITLE
Add A2A resubscribe client support

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -180,6 +180,8 @@ type Provider struct {
 type Capabilities struct {
 	Streaming         bool `json:"streaming"`
 	PushNotifications bool `json:"pushNotifications"`
+	TaskResubscribe   bool `json:"taskResubscribe"`
+	InputRequired     bool `json:"inputRequired"`
 }
 
 // Skill is a capability advertised on the Agent Card.
@@ -349,7 +351,7 @@ func Card(name, url, description string, services []string) AgentCard {
 		URL:                url,
 		Version:            "1.0.0",
 		ProtocolVersion:    protocolVersion,
-		Capabilities:       Capabilities{Streaming: true, PushNotifications: true},
+		Capabilities:       Capabilities{Streaming: true, PushNotifications: true, TaskResubscribe: true, InputRequired: true},
 		DefaultInputModes:  []string{"text/plain"},
 		DefaultOutputModes: []string{"text/plain"},
 		Skills:             skills,

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -91,6 +91,9 @@ func TestAgentCardFromRegistry(t *testing.T) {
 	if card.ProtocolVersion == "" {
 		t.Errorf("card missing protocolVersion: %+v", card)
 	}
+	if !card.Capabilities.TaskResubscribe || !card.Capabilities.InputRequired {
+		t.Errorf("card capabilities = %+v, want task resubscribe and input-required advertised", card.Capabilities)
+	}
 	if got := skillIDs(card.Skills); strings.Join(got, ",") != "task,project" {
 		t.Errorf("skill IDs = %v, want [task project]", got)
 	}

--- a/gateway/a2a/client.go
+++ b/gateway/a2a/client.go
@@ -1,11 +1,13 @@
 package a2a
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -135,6 +137,77 @@ func (c *Client) SendMessage(ctx context.Context, message Message) (*Task, error
 	return &task, nil
 }
 
+// Resubscribe reconnects to a retained or active task stream and returns task
+// snapshots as the remote agent emits updates. The returned channel is closed
+// when the task reaches a terminal state or ctx is canceled.
+func (c *Client) Resubscribe(ctx context.Context, taskID string) (<-chan Task, <-chan error) {
+	tasks := make(chan Task, 8)
+	errs := make(chan error, 1)
+	go func() {
+		defer close(tasks)
+		defer close(errs)
+		body, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      uuid.New().String(),
+			"method":  "tasks/resubscribe",
+			"params":  getParams{ID: taskID},
+		})
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(body))
+		if err != nil {
+			errs <- err
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "text/event-stream")
+		resp, err := c.http.Do(req)
+		if err != nil {
+			errs <- err
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			errs <- fmt.Errorf("tasks/resubscribe: status %d", resp.StatusCode)
+			return
+		}
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data:") {
+				continue
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if payload == "" {
+				continue
+			}
+			var out struct {
+				Result Task      `json:"result"`
+				Error  *rpcError `json:"error"`
+			}
+			if err := json.Unmarshal([]byte(payload), &out); err != nil {
+				errs <- err
+				return
+			}
+			if out.Error != nil {
+				errs <- fmt.Errorf("a2a tasks/resubscribe: %s (%d)", out.Error.Message, out.Error.Code)
+				return
+			}
+			select {
+			case <-ctx.Done():
+				errs <- ctx.Err()
+				return
+			case tasks <- out.Result:
+			}
+			if terminal(out.Result.Status.State) {
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			errs <- err
+		}
+	}()
+	return tasks, errs
+}
+
 // SetPushNotificationConfig asks the remote agent to POST updates for taskID to cfg.URL.
 func (c *Client) SetPushNotificationConfig(ctx context.Context, taskID string, cfg PushNotificationConfig) error {
 	_, err := c.call(ctx, "tasks/pushNotificationConfig/set", pushConfigParams{
@@ -193,7 +266,7 @@ func (c *Client) call(ctx context.Context, method string, params any) (json.RawM
 
 func terminal(state string) bool {
 	switch state {
-	case "completed", "failed", "canceled", "rejected":
+	case "completed", "failed", "canceled", "rejected", "input-required":
 		return true
 	}
 	return false

--- a/gateway/a2a/client_test.go
+++ b/gateway/a2a/client_test.go
@@ -3,8 +3,10 @@ package a2a
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -108,5 +110,59 @@ func TestClientContinuesTaskAndConfiguresPush(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for push update")
+	}
+}
+
+func TestClientResubscribeStreamsRetainedAndLiveTask(t *testing.T) {
+	d := newDispatcher()
+	initial := &Task{ID: "task-1", ContextID: "ctx-1", Kind: "task", Status: TaskStatus{State: stateWorking, Timestamp: time.Now().UTC().Format(time.RFC3339)}}
+	d.store(initial)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		d.serve(w, r, func(context.Context, string) (string, error) { return "", nil })
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	tasks, errs := NewClient(ts.URL).Resubscribe(ctx, initial.ID)
+
+	first := <-tasks
+	if first.ID != initial.ID || first.Status.State != stateWorking {
+		t.Fatalf("first resubscribe task = %+v, want retained working task", first)
+	}
+	final := &Task{ID: initial.ID, ContextID: initial.ContextID, Kind: "task", Status: TaskStatus{State: stateCompleted, Timestamp: time.Now().UTC().Format(time.RFC3339)}, Artifacts: []Artifact{textArtifact("done")}}
+	d.store(final)
+	second := <-tasks
+	if second.ID != final.ID || second.Status.State != stateCompleted || textOf(second.Artifacts[0].Parts) != "done" {
+		t.Fatalf("second resubscribe task = %+v, want live completed task", second)
+	}
+	if _, ok := <-tasks; ok {
+		t.Fatal("resubscribe task channel stayed open after terminal update")
+	}
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Fatalf("resubscribe error = %v", err)
+		}
+	default:
+	}
+}
+
+func TestClientSendMessageReturnsInputRequiredTask(t *testing.T) {
+	card := Card("solo", "http://localhost:4000", "", []string{"task"})
+	h := NewAgentHandler(card, func(context.Context, string) (string, error) {
+		return "", errors.New("input-required: provide approval code")
+	})
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	task, err := NewClient(ts.URL).SendMessage(ctx, Message{Parts: []Part{{Kind: "text", Text: "approve?"}}})
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if task.Status.State != stateInputRequired || !strings.Contains(textOf(task.Artifacts[0].Parts), "provide approval code") {
+		t.Fatalf("task = %+v, want input-required handoff", task)
 	}
 }


### PR DESCRIPTION
Summary:
- Advertise A2A task resubscribe and input-required support in agent cards.
- Add an outbound client Resubscribe helper for retained/live task streams.
- Treat input-required as terminal for outbound A2A clients and cover handoff behavior with tests.

Testing:
- go build ./...
- go test ./gateway/a2a
- golangci-lint run ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy in client/grpc and transport/grpc tests)

Closes #3474
Closes #3483