### PR TITLE
Add flow step verification loop

### DIFF
--- a/ai/model.go
+++ b/ai/model.go
@@ -121,13 +121,14 @@ const (
 // tell which provider attempt produced the call and whether it is part of a
 // retry budget. They are zero when no model-attempt context is known.
 type RunInfo struct {
-	RunID       string // correlation id for this agent or flow run
-	ParentID    string // the run that delegated to this one, if any
-	Agent       string // the agent's name
-	Flow        string // the flow's name, when the call is part of a workflow
-	Step        string // the flow step currently executing, when known
-	Attempt     int    // current model Generate attempt, starting at 1 when known
-	MaxAttempts int    // configured model Generate attempt budget when known
+	RunID                string // correlation id for this agent or flow run
+	ParentID             string // the run that delegated to this one, if any
+	Agent                string // the agent's name
+	Flow                 string // the flow's name, when the call is part of a workflow
+	Step                 string // the flow step currently executing, when known
+	Attempt              int    // current model Generate attempt, starting at 1 when known
+	MaxAttempts          int    // configured model Generate attempt budget when known
+	VerificationFeedback string // feedback from the previous failed verifier attempt, when retrying a flow step
 }
 
 type runInfoKey struct{}

--- a/flow/otel.go
+++ b/flow/otel.go
@@ -16,14 +16,16 @@ const (
 	spanNameFlowRun  = "flow.run"
 	spanNameFlowStep = "flow.step"
 
-	AttrFlowRunID     = "flow.run.id"
-	AttrFlowParentID  = "flow.run.parent_id"
-	AttrFlowName      = "flow.name"
-	AttrFlowStepName  = "flow.step.name"
-	AttrFlowStatus    = "flow.status"
-	AttrFlowAttempts  = "flow.step.attempts"
-	AttrFlowLatencyMS = "flow.latency_ms"
-	AttrFlowErrorKind = "flow.error.kind"
+	AttrFlowRunID              = "flow.run.id"
+	AttrFlowParentID           = "flow.run.parent_id"
+	AttrFlowName               = "flow.name"
+	AttrFlowStepName           = "flow.step.name"
+	AttrFlowStatus             = "flow.status"
+	AttrFlowAttempts           = "flow.step.attempts"
+	AttrFlowLatencyMS          = "flow.latency_ms"
+	AttrFlowErrorKind          = "flow.error.kind"
+	AttrFlowVerificationStatus = "flow.verification.status"
+	AttrFlowVerificationNote   = "flow.verification.note"
 )
 
 func (f *Flow) tracer() trace.Tracer {
@@ -57,7 +59,7 @@ func (f *Flow) startRunSpan(ctx context.Context, run Run) (context.Context, func
 	}
 }
 
-func (f *Flow) runStepSpan(ctx context.Context, step Step, in State) (State, int, error) {
+func (f *Flow) runStepSpan(ctx context.Context, step Step, in State) (State, int, Verification, error) {
 	if f.opts.TraceProvider == nil {
 		return f.runStep(ctx, step, in)
 	}
@@ -69,11 +71,20 @@ func (f *Flow) runStepSpan(ctx context.Context, step Step, in State) (State, int
 		attribute.String(AttrFlowStepName, step.Name),
 	))
 	start := time.Now()
-	out, attempts, err := f.runStep(ctx, step, in)
+	out, attempts, verification, err := f.runStep(ctx, step, in)
 	span.SetAttributes(
 		attribute.Int(AttrFlowAttempts, attempts),
 		attribute.Int64(AttrFlowLatencyMS, time.Since(start).Milliseconds()),
 	)
+	if verification.Passed {
+		span.SetAttributes(attribute.String(AttrFlowVerificationStatus, "passed"))
+	}
+	if verification.Feedback != "" {
+		span.SetAttributes(attribute.String(AttrFlowVerificationNote, verification.Feedback))
+		if !verification.Passed {
+			span.SetAttributes(attribute.String(AttrFlowVerificationStatus, "failed"))
+		}
+	}
 	if err != nil {
 		span.RecordError(err)
 		span.SetAttributes(attribute.String(AttrFlowErrorKind, string(ai.ClassifyError(err))))
@@ -82,5 +93,5 @@ func (f *Flow) runStepSpan(ctx context.Context, step Step, in State) (State, int
 		span.SetStatus(codes.Ok, "")
 	}
 	span.End()
-	return out, attempts, err
+	return out, attempts, verification, err
 }

--- a/flow/steps.go
+++ b/flow/steps.go
@@ -52,23 +52,53 @@ func (s State) String() string { return string(s.Data) }
 // returns the next state.
 type StepFunc func(ctx context.Context, in State) (State, error)
 
-// Step is one unit of a flow — a named action with an optional retry
-// override. There is one Step kind; the action is the Run func, and the
-// Call/LLM/Agent helpers produce the common ones.
+// Verifier grades a step output before the flow advances. Returning
+// Passed=false converts the grade into a retryable VerificationError, so
+// the existing step retry/supervision path can feed Feedback into the next
+// attempt through ai.RunInfo.VerificationFeedback.
+type Verifier func(ctx context.Context, out State) (Verification, error)
+
+// Verification is the verifier's deterministic grade for one step attempt.
+type Verification struct {
+	Passed   bool
+	Feedback string
+}
+
+// VerificationError reports a failed grade. It is returned from runStep so
+// existing retry, checkpoint, and trace paths handle verifier failures the
+// same way they handle step execution failures.
+type VerificationError struct {
+	Step     string
+	Feedback string
+}
+
+func (e *VerificationError) Error() string {
+	if e.Feedback == "" {
+		return fmt.Sprintf("flow: verification failed for step %q", e.Step)
+	}
+	return fmt.Sprintf("flow: verification failed for step %q: %s", e.Step, e.Feedback)
+}
+
+// Step is one unit of a flow — a named action with optional retry and
+// verification hooks. There is one Step kind; the action is the Run func,
+// and the Call/LLM/Agent helpers produce the common ones.
 type Step struct {
-	Name  string
-	Run   StepFunc
-	Retry int // per-step override of the flow's retry (0 = use the flow default)
+	Name   string
+	Run    StepFunc
+	Retry  int      // per-step override of the flow's retry (0 = use the flow default)
+	Verify Verifier // optional grade; failed grades retry the step with feedback in RunInfo
 }
 
 // StepRecord is the recorded outcome of one step within a run.
 type StepRecord struct {
-	Name      string `json:"name"`
-	Status    string `json:"status"` // pending | in_progress | done | failed
-	Attempts  int    `json:"attempts"`
-	Result    string `json:"result,omitempty"`
-	Error     string `json:"error,omitempty"`
-	ErrorKind string `json:"error_kind,omitempty"`
+	Name               string `json:"name"`
+	Status             string `json:"status"` // pending | in_progress | done | failed
+	Attempts           int    `json:"attempts"`
+	Result             string `json:"result,omitempty"`
+	Error              string `json:"error,omitempty"`
+	ErrorKind          string `json:"error_kind,omitempty"`
+	VerificationStatus string `json:"verification_status,omitempty"` // passed | failed
+	VerificationNote   string `json:"verification_note,omitempty"`
 }
 
 // Run is the persisted record of one flow execution — what a Checkpoint
@@ -426,8 +456,9 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 			return run, err
 		}
 
-		out, attempts, err := f.runStepSpan(ctx, step, run.State)
+		out, attempts, verification, err := f.runStepSpan(ctx, step, run.State)
 		run.Steps[i].Attempts = attempts
+		applyVerificationRecord(&run.Steps[i], verification)
 		if err != nil {
 			spanErr = err
 			run.Steps[i].Status = "failed"
@@ -476,40 +507,65 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 // runStep runs one step, retrying on error up to the resolved retry count.
 // A step with no Run function is a configuration error, and a canceled run
 // stops retrying immediately rather than burning the rest of its budget.
-func (f *Flow) runStep(ctx context.Context, step Step, in State) (State, int, error) {
+func (f *Flow) runStep(ctx context.Context, step Step, in State) (State, int, Verification, error) {
 	if step.Run == nil {
-		return in, 0, fmt.Errorf("flow: step %q has no Run function", step.Name)
+		return in, 0, Verification{}, fmt.Errorf("flow: step %q has no Run function", step.Name)
 	}
 	retries := f.opts.Retry
 	if step.Retry > 0 {
 		retries = step.Retry
 	}
 	var lastErr error
+	var lastVerification Verification
+	var feedback string
 	for attempt := 1; attempt <= retries+1; attempt++ {
 		// Stop the moment the run's context is canceled or its deadline
 		// passes — a canceled run shouldn't keep retrying, and the context
 		// error is surfaced so callers can detect cancellation upstream.
 		if err := ctx.Err(); err != nil {
-			return in, attempt - 1, err
+			return in, attempt - 1, lastVerification, err
 		}
+		attemptCtx := ctx
 		if info, ok := ai.RunInfoFrom(ctx); ok {
 			info.Step = step.Name
-			ctx = ai.WithRunInfo(ctx, info)
+			info.VerificationFeedback = feedback
+			attemptCtx = ai.WithRunInfo(ctx, info)
 		}
-		out, err := step.Run(ctx, in)
+		out, err := step.Run(attemptCtx, in)
+		if err == nil && step.Verify != nil {
+			lastVerification, err = step.Verify(attemptCtx, out)
+			if err == nil && !lastVerification.Passed {
+				err = &VerificationError{Step: step.Name, Feedback: lastVerification.Feedback}
+			}
+		}
 		if err == nil {
-			return out, attempt, nil
+			return out, attempt, lastVerification, nil
 		}
 		lastErr = err
+		if verr, ok := err.(*VerificationError); ok {
+			feedback = verr.Feedback
+		}
 		if attempt <= retries && f.opts.RetryBackoff > 0 {
 			select {
 			case <-time.After(f.opts.RetryBackoff):
 			case <-ctx.Done():
-				return in, attempt, ctx.Err()
+				return in, attempt, lastVerification, ctx.Err()
 			}
 		}
 	}
-	return in, retries + 1, lastErr
+	return in, retries + 1, lastVerification, lastErr
+}
+
+func applyVerificationRecord(record *StepRecord, verification Verification) {
+	if verification.Passed {
+		record.VerificationStatus = "passed"
+	}
+	if verification.Feedback != "" {
+		record.VerificationNote = truncate(verification.Feedback, 200)
+		if !verification.Passed {
+			record.VerificationStatus = "failed"
+		}
+	}
 }
 
 func (f *Flow) save(ctx context.Context, run Run) error {

--- a/flow/verification_test.go
+++ b/flow/verification_test.go
@@ -1,0 +1,100 @@
+package flow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/store"
+)
+
+func TestFlowStepVerificationRetriesWithFeedback(t *testing.T) {
+	var attempts int
+	var feedback []string
+	step := Step{
+		Name:  "draft",
+		Retry: 1,
+		Run: func(ctx context.Context, in State) (State, error) {
+			attempts++
+			info, ok := ai.RunInfoFrom(ctx)
+			if !ok {
+				t.Fatal("RunInfo missing from verified step")
+			}
+			feedback = append(feedback, info.VerificationFeedback)
+			if info.VerificationFeedback == "add evidence" {
+				in.Data = []byte("answer with evidence")
+			} else {
+				in.Data = []byte("answer")
+			}
+			return in, nil
+		},
+		Verify: func(ctx context.Context, out State) (Verification, error) {
+			if out.String() == "answer with evidence" {
+				return Verification{Passed: true, Feedback: "meets rubric"}, nil
+			}
+			return Verification{Feedback: "add evidence"}, nil
+		},
+	}
+
+	cp := StoreCheckpoint(store.NewMemoryStore(), "verified")
+	f := New("verified", WithCheckpoint(cp), Steps(step))
+	if err := f.Execute(context.Background(), "question"); err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if len(feedback) != 2 || feedback[0] != "" || feedback[1] != "add evidence" {
+		t.Fatalf("feedback = %#v, want empty then verifier feedback", feedback)
+	}
+	runs, err := cp.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(runs))
+	}
+	stepRecord := runs[0].Steps[0]
+	if stepRecord.Status != "done" || stepRecord.Attempts != 2 || stepRecord.VerificationStatus != "passed" || stepRecord.VerificationNote != "meets rubric" {
+		t.Fatalf("step record = %#v", stepRecord)
+	}
+}
+
+func TestFlowStepVerificationFailureIsCheckpointed(t *testing.T) {
+	step := Step{
+		Name: "grade",
+		Run: func(ctx context.Context, in State) (State, error) {
+			in.Data = []byte("bad")
+			return in, nil
+		},
+		Verify: func(ctx context.Context, out State) (Verification, error) {
+			return Verification{Feedback: "missing citation"}, nil
+		},
+	}
+
+	cp := StoreCheckpoint(store.NewMemoryStore(), "verified-fail")
+	f := New("verified-fail", WithCheckpoint(cp), Steps(step))
+	err := f.Execute(context.Background(), "question")
+	if err == nil {
+		t.Fatal("Execute succeeded, want verification failure")
+	}
+	var verr *VerificationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("error = %T %v, want VerificationError", err, err)
+	}
+	if verr.Feedback != "missing citation" {
+		t.Fatalf("feedback = %q, want missing citation", verr.Feedback)
+	}
+	runs, listErr := cp.List(context.Background())
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(runs))
+	}
+	stepRecord := runs[0].Steps[0]
+	if runs[0].Status != "failed" || stepRecord.VerificationStatus != "failed" || stepRecord.VerificationNote != "missing citation" {
+		t.Fatalf("run = %#v step = %#v", runs[0], stepRecord)
+	}
+}


### PR DESCRIPTION
## Summary
- Add optional flow step verifiers that grade step output before advancing.
- Route failed verification feedback through existing retry attempts via RunInfo.
- Persist verification status/notes and emit verification trace attributes.
- Add deterministic tests for failed-grade retry feedback and checkpointed verifier failures.

Closes #3481
Closes #3488

## Testing
- go build ./...
- go test ./flow
- go test ./... (fails in this sandbox because loopback gRPC targets are forbidden for existing grpc tests)
- golangci-lint run ./...