### PR TITLE
Add mock provider conformance target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -X $(GIT_IMPORT).BuildDate=$(BUILD_DATE) -X $(GIT_IMPORT).GitCommit=$(
 # GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser-cross:v1.25.7
 GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser:latest
 
-.PHONY: test test-race test-coverage harness provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
+.PHONY: test test-race test-coverage harness provider-conformance-mock provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
 
 # Default target
 help:
@@ -19,6 +19,7 @@ help:
 	@echo "  make test-coverage - Run tests with coverage"
 	@echo "  make lint          - Run linter"
 	@echo "  make harness       - Run deterministic getting-started and end-to-end harnesses"
+	@echo "  make provider-conformance-mock - Run cross-provider harness with deterministic mock provider"
 	@echo "  make provider-conformance - Run harnesses against configured live providers"
 	@echo "  make fmt           - Format code"
 	@echo "  make install-tools - Install development tools"
@@ -50,6 +51,12 @@ harness:
 	go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
 	./internal/harness/zero-to-hero-ci/run.sh
 	go run ./internal/harness/agent-flow
+	$(MAKE) provider-conformance-mock
+
+# Run the shared provider conformance contract with the deterministic mock
+# provider. This is the no-secret path used by CI and local dogfooding to keep
+# provider-facing agent/tool semantics covered on every machine.
+provider-conformance-mock:
 	go run ./internal/harness/provider-conformance -providers mock
 
 # Run the same harnesses against every configured live provider. Providers

--- a/internal/docs/AGENT_CONFORMANCE.md
+++ b/internal/docs/AGENT_CONFORMANCE.md
@@ -29,6 +29,18 @@ consistent across providers.
 The companion `TestAgentProviderConformanceFakeError` keeps provider error
 propagation covered locally without relying on external credentials.
 
+## Local no-secret conformance
+
+Use `make provider-conformance-mock` to run the same provider conformance harness
+through the deterministic mock provider. That target requires no API keys and is
+what `make harness` delegates to after the 0→1 and 0→hero scenarios, so every PR
+continues to exercise the provider-facing agent/tool contract without spending
+live model credits.
+
+Use `make provider-conformance` when you want the live-provider sweep: providers
+without keys are skipped, and configured providers must satisfy the same harness
+contract.
+
 ## Scheduled CI
 
 The daily/manual `Harness (E2E)` workflow runs the same matrix with


### PR DESCRIPTION
## Summary
- Add a dedicated make provider-conformance-mock target for the deterministic no-secret provider conformance path.
- Keep make harness delegated to that target so local dogfooding and CI exercise the shared services → agents → workflows provider contract without live keys.
- Document when to use the mock target versus the live provider sweep.

## Testing
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...
- make provider-conformance-mock

Closes #3491
Closes #3494