### PR TITLE
Harden agent terminal failure statuses

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -298,12 +298,15 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		Backoff:     a.opts.ModelRetryBackoff,
 	})
 	if err != nil {
-		run.Status = "failed"
-		run.Steps[0].Status = "failed"
-		run.Steps[0].Error = err.Error()
+		run.Status = agentRunFailureStatus(err)
 		if a.currentRun != nil {
 			run.Steps = a.currentRun.Steps
 		}
+		if len(run.Steps) == 0 {
+			run.Steps = []flow.StepRecord{{Name: agentAskStep}}
+		}
+		run.Steps[0].Status = run.Status
+		run.Steps[0].Error = err.Error()
 		_ = a.saveRun(ctx, run)
 		return nil, err
 	}

--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -171,10 +171,23 @@ func (a *agentImpl) pending(ctx context.Context) ([]flow.Run, error) {
 
 func terminalAgentRunStatus(status string) bool {
 	switch status {
-	case "done", "canceled", "expired":
+	case "done", "canceled", "timeout", "rate_limited", "expired":
 		return true
 	default:
 		return false
+	}
+}
+
+func agentRunFailureStatus(err error) string {
+	switch ai.ClassifyError(err) {
+	case ai.ErrorKindCanceled:
+		return "canceled"
+	case ai.ErrorKindTimeout:
+		return "timeout"
+	case ai.ErrorKindRateLimited:
+		return "rate_limited"
+	default:
+		return "failed"
 	}
 }
 

--- a/agent/resilience_test.go
+++ b/agent/resilience_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/flow"
+	"go-micro.dev/v6/store"
 )
 
 func TestAskCancellationAbortsPromptly(t *testing.T) {
@@ -129,3 +131,56 @@ func TestToolCallTimeoutPropagatesDeadlineToCustomTool(t *testing.T) {
 		t.Fatalf("tool call took %s, want bounded timeout", elapsed)
 	}
 }
+
+func TestAskCheckpointRecordsTerminalOperationalFailureStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "canceled", err: context.Canceled, want: "canceled"},
+		{name: "timeout", err: context.DeadlineExceeded, want: "timeout"},
+		{name: "rate limited", err: testStatusError{code: 429}, want: "rate_limited"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp := flow.StoreCheckpoint(store.NewMemoryStore(), "terminal-"+strings.ReplaceAll(tt.name, " ", "-"))
+			fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+				return nil, tt.err
+			}
+			defer func() { fakeGen = nil }()
+
+			a := newTestAgent(Name("terminal-"+strings.ReplaceAll(tt.name, " ", "-")), WithCheckpoint(cp))
+			_, err := a.Ask(context.Background(), "fail safely")
+			if err == nil {
+				t.Fatal("Ask succeeded, want failure")
+			}
+
+			runs, err := cp.List(context.Background())
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if len(runs) != 1 {
+				t.Fatalf("checkpointed runs = %d, want 1", len(runs))
+			}
+			if runs[0].Status != tt.want {
+				t.Fatalf("run status = %q, want %q", runs[0].Status, tt.want)
+			}
+			if len(runs[0].Steps) == 0 || runs[0].Steps[0].Status != tt.want {
+				t.Fatalf("step status = %#v, want %q", runs[0].Steps, tt.want)
+			}
+			if pending, err := Pending(context.Background(), a); err != nil || len(pending) != 0 {
+				t.Fatalf("Pending = %#v, %v; want no terminal run", pending, err)
+			}
+		})
+	}
+}
+
+type testStatusError struct {
+	code int
+}
+
+func (e testStatusError) Error() string { return "provider status error" }
+
+func (e testStatusError) StatusCode() int { return e.code }


### PR DESCRIPTION
Summary:
- Classify checkpointed agent operational failures as terminal canceled, timeout, or rate_limited statuses instead of generic failed.
- Keep unknown/provider failures resumable as failed.
- Add resilience coverage for cancellation, timeout, and rate-limit checkpoint status and pending filtering.

Testing:
- go build ./...
- go test ./... (environment failures: loopback targets forbidden in grpc tests; sum.golang.org 502 during generated service tidy)
- golangci-lint run ./...

Closes #3492
Closes #3498