### PR TITLE
Add scheduled flow agent harness

### DIFF
--- a/flow/dispatch_test.go
+++ b/flow/dispatch_test.go
@@ -7,6 +7,7 @@ import (
 
 	"go-micro.dev/v6/client"
 	codecbytes "go-micro.dev/v6/codec/bytes"
+	"go-micro.dev/v6/store"
 )
 
 // fakeClient embeds the default client (so NewRequest works) and
@@ -63,5 +64,67 @@ func TestExecuteDispatchesToAgent(t *testing.T) {
 	}
 	if results[0].Prompt != "welcome bob" {
 		t.Errorf("rendered prompt = %q, want %q", results[0].Prompt, "welcome bob")
+	}
+}
+
+// A caller-owned schedule can trigger an agent workflow without a human chat
+// prompt and still leave the normal flow run metadata behind for inspection.
+func TestScheduledAgentRunHarnessContract(t *testing.T) {
+	ctx := context.Background()
+	cp := StoreCheckpoint(store.NewMemoryStore(), "scheduled-contract")
+	f := New("scheduled-contract",
+		Trigger("schedule.daily"),
+		WithCheckpoint(cp),
+		Steps(Step{Name: "summarize", Run: Dispatch("ops-agent")}),
+	)
+
+	var parentID string
+	f.client = &fakeClient{
+		Client: client.DefaultClient,
+		callFn: func(req client.Request, rsp interface{}) error {
+			if req.Service() != "ops-agent" || req.Endpoint() != "Agent.Chat" {
+				t.Fatalf("dispatched to %s.%s, want ops-agent.Agent.Chat", req.Service(), req.Endpoint())
+			}
+			reqFrame := req.Body().(*codecbytes.Frame)
+			var body map[string]string
+			if err := json.Unmarshal(reqFrame.Data, &body); err != nil {
+				t.Fatalf("request body: %v", err)
+			}
+			parentID = body["parent_id"]
+			if body["message"] != "run unattended daily ops review" {
+				t.Fatalf("message = %q, want scheduled payload", body["message"])
+			}
+			frame := rsp.(*codecbytes.Frame)
+			frame.Data = []byte(`{"reply":"review queued","agent":"ops-agent","parent_id":"` + parentID + `"}`)
+			return nil
+		},
+	}
+
+	if err := Scheduled(f, "run unattended daily ops review").Tick(ctx); err != nil {
+		t.Fatalf("scheduled tick: %v", err)
+	}
+	if parentID == "" {
+		t.Fatal("dispatch did not receive the scheduled flow run id as parent_id")
+	}
+
+	runs, err := cp.List(ctx)
+	if err != nil {
+		t.Fatalf("list scheduled runs: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("got %d runs, want 1", len(runs))
+	}
+	run := runs[0]
+	if run.ID != parentID {
+		t.Fatalf("run ID = %q, parent_id = %q", run.ID, parentID)
+	}
+	if run.Flow != "scheduled-contract" || run.Status != "done" {
+		t.Fatalf("run = %+v, want scheduled-contract done", run)
+	}
+	if got := run.State.String(); got != "review queued" {
+		t.Fatalf("run result = %q, want agent reply", got)
+	}
+	if len(run.Steps) != 1 || run.Steps[0].Name != "summarize" || run.Steps[0].Status != "done" {
+		t.Fatalf("steps = %+v, want summarize done", run.Steps)
 	}
 }

--- a/flow/schedule.go
+++ b/flow/schedule.go
@@ -1,0 +1,47 @@
+package flow
+
+import (
+	"context"
+	"time"
+)
+
+// Schedule binds a flow to a recurring work item without introducing a
+// scheduler service. It is a small harness contract: callers own the clock,
+// Go Micro owns turning each tick into the same inspectable flow run used for
+// broker events and direct Execute calls.
+type Schedule struct {
+	flow *Flow
+	data string
+}
+
+// Scheduled returns a deterministic scheduled-run harness for this flow.
+// Tests and event loops can call Tick directly; production processes can wire
+// the same contract to time.Ticker through RunEvery. Each tick calls Execute, so
+// checkpointed run history, parent/run metadata, cancellation, and inspection
+// stay on the normal flow surfaces.
+func Scheduled(f *Flow, data string) Schedule {
+	return Schedule{flow: f, data: data}
+}
+
+// Tick starts one scheduled run immediately and returns when that run finishes.
+func (s Schedule) Tick(ctx context.Context) error {
+	return s.flow.Execute(ctx, s.data)
+}
+
+// RunEvery drives scheduled runs from a ticker until ctx is canceled. It does
+// not persist schedule definitions or host a scheduler; it only adapts a caller
+// owned cadence to Tick.
+func (s Schedule) RunEvery(ctx context.Context, interval time.Duration) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := s.Tick(ctx); err != nil {
+				return err
+			}
+		}
+	}
+}


### PR DESCRIPTION
Summary:
- Add a lightweight flow scheduling contract that lets caller-owned clocks trigger inspectable flow runs without introducing a hosted scheduler.
- Add a no-secret conformance test for a scheduled flow dispatching to an agent RPC boundary and persisting run metadata.

Testing:
- go build ./...
- go test ./... (environment warning: loopback gRPC targets blocked by envoy in client/grpc and transport/grpc tests)
- golangci-lint run ./...

Closes #3486
Closes #3504