### PR TITLE
Broaden AI stream provider conformance

### DIFF
--- a/ai/stream_conformance_test.go
+++ b/ai/stream_conformance_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -145,6 +146,109 @@ func TestStreamProvidersCloseCancelsInFlightRequest(t *testing.T) {
 			case <-released:
 			case <-time.After(time.Second):
 				t.Fatal("server did not observe canceled stream request")
+			}
+		})
+	}
+}
+
+func TestStreamProvidersPropagateProviderErrors(t *testing.T) {
+	for _, provider := range conformingStreamProviders(t) {
+		provider := provider
+		t.Run(provider, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "upstream quota exhausted", http.StatusTooManyRequests)
+			}))
+			defer ts.Close()
+
+			stream, err := ai.New(provider, ai.WithAPIKey("test-key"), ai.WithBaseURL(ts.URL)).Stream(context.Background(), &ai.Request{Prompt: "Hello"})
+			if err == nil {
+				_ = stream.Close()
+				t.Fatal("Stream returned nil error for provider failure")
+			}
+			if !strings.Contains(err.Error(), "429") || !strings.Contains(err.Error(), "upstream quota exhausted") {
+				t.Fatalf("Stream error = %v, want provider status and body", err)
+			}
+			if strings.Contains(err.Error(), "test-key") {
+				t.Fatal("provider error leaked API key")
+			}
+		})
+	}
+}
+
+func TestStreamProvidersHonorCanceledContextBeforeRequest(t *testing.T) {
+	for _, provider := range conformingStreamProviders(t) {
+		provider := provider
+		t.Run(provider, func(t *testing.T) {
+			var sawRequest bool
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				sawRequest = true
+				http.Error(w, "unexpected request", http.StatusInternalServerError)
+			}))
+			defer ts.Close()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			stream, err := ai.New(provider, ai.WithAPIKey("test-key"), ai.WithBaseURL(ts.URL)).Stream(ctx, &ai.Request{Prompt: "Hello"})
+			if err == nil {
+				_ = stream.Close()
+				t.Fatal("Stream returned nil error for canceled context")
+			}
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("Stream error = %v, want context.Canceled", err)
+			}
+			if sawRequest {
+				t.Fatal("provider sent request after context was already canceled")
+			}
+		})
+	}
+}
+
+func TestConfiguredProviderStreamsSkipWithoutCredentials(t *testing.T) {
+	for _, tc := range []struct {
+		provider string
+		keyEnv   string
+		modelEnv string
+	}{
+		{provider: "openai", keyEnv: "OPENAI_API_KEY", modelEnv: "OPENAI_MODEL"},
+		{provider: "groq", keyEnv: "GROQ_API_KEY", modelEnv: "GROQ_MODEL"},
+		{provider: "mistral", keyEnv: "MISTRAL_API_KEY", modelEnv: "MISTRAL_MODEL"},
+		{provider: "together", keyEnv: "TOGETHER_API_KEY", modelEnv: "TOGETHER_MODEL"},
+		{provider: "atlascloud", keyEnv: "ATLASCLOUD_API_KEY", modelEnv: "ATLASCLOUD_MODEL"},
+	} {
+		tc := tc
+		t.Run(tc.provider, func(t *testing.T) {
+			key := os.Getenv(tc.keyEnv)
+			if key == "" {
+				t.Skipf("%s not set; skipping configured provider stream check", tc.keyEnv)
+			}
+
+			opts := []ai.Option{ai.WithAPIKey(key)}
+			if model := os.Getenv(tc.modelEnv); model != "" {
+				opts = append(opts, ai.WithModel(model))
+			}
+			stream, err := ai.New(tc.provider, opts...).Stream(context.Background(), &ai.Request{Prompt: "Reply with exactly: ok"})
+			if err != nil {
+				t.Fatalf("Stream returned error: %v", err)
+			}
+			defer stream.Close()
+
+			deadline := time.After(30 * time.Second)
+			for {
+				select {
+				case <-deadline:
+					t.Fatal("timed out waiting for provider stream chunk")
+				default:
+				}
+				chunk, err := stream.Recv()
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						t.Fatal("provider stream ended without content")
+					}
+					t.Fatalf("Recv returned error: %v", err)
+				}
+				if chunk.Reply != "" {
+					return
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Add mock stream conformance coverage for provider HTTP errors and pre-canceled contexts across registered OpenAI-compatible stream providers.
- Add provider-gated stream smoke checks that skip unless provider API key environment variables are configured.

## Testing
- go test ./ai
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by Envoy)
- golangci-lint run ./...

Closes #3502
Closes #3511