### PR TITLE
Document the 0-to-hero reference path

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call \
 ```
 
 This scaffold → run → call path is covered by the no-secret CI harness. To run
-the same local contract (including the 0→hero services → agents → workflows path,
+the same local contract (including the [0→hero services → agents → workflows path](internal/website/docs/guides/zero-to-hero.md),
 chat/inspect CLI boundaries, and deploy dry-run), use:
 
 ```bash
@@ -423,6 +423,7 @@ See [all examples](examples/README.md).
 
 - [Getting Started](internal/website/docs/getting-started.md)
 - [AI Integration](internal/website/docs/ai-integration.md)
+- [0→hero Reference](internal/website/docs/guides/zero-to-hero.md)
 - [Agents and Workflows](internal/website/docs/guides/agents-and-workflows.md)
 - [Agent Design](internal/docs/AGENT_DESIGN.md)
 - [Plan & Delegate](internal/website/docs/guides/plan-delegate.md)

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -1,0 +1,48 @@
+package zerotoheroci
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestZeroToHeroReferenceDocs(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+
+	guide := readFile(t, filepath.Join(root, "internal", "website", "docs", "guides", "zero-to-hero.md"))
+	for _, want := range []string{
+		"make harness",
+		"go test ./cmd/micro/cli/new -run TestZeroToOne -count=1",
+		"go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1",
+		"go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1",
+		"./internal/harness/zero-to-hero-ci/run.sh",
+		"go run ./internal/harness/agent-flow",
+		"make provider-conformance-mock",
+		"internal/harness/plan-delegate",
+		"internal/harness/universe",
+	} {
+		if !strings.Contains(guide, want) {
+			t.Fatalf("0→hero guide missing %q", want)
+		}
+	}
+
+	readme := readFile(t, filepath.Join(root, "README.md"))
+	if !strings.Contains(readme, "internal/website/docs/guides/zero-to-hero.md") {
+		t.Fatal("README does not point to the canonical 0→hero guide")
+	}
+
+	nav := readFile(t, filepath.Join(root, "internal", "website", "_data", "navigation.yml"))
+	if !strings.Contains(nav, "0→hero Reference") || !strings.Contains(nav, "/docs/guides/zero-to-hero.html") {
+		t.Fatal("website navigation does not expose the canonical 0→hero guide")
+	}
+}
+
+func readFile(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(data)
+}

--- a/internal/website/_data/navigation.yml
+++ b/internal/website/_data/navigation.yml
@@ -32,6 +32,8 @@ examples:
   - title: Real-World Examples
     url: /docs/examples/realworld/
 guides:
+  - title: 0→hero Reference
+    url: /docs/guides/zero-to-hero.html
   - title: The Agent Harness
     url: /docs/guides/agent-harness.html
   - title: Agents and Workflows
@@ -70,6 +72,7 @@ project:
   - title: Server (optional)
     url: /docs/server.html
 search_order:
+  - /docs/guides/zero-to-hero.html
   - /docs/getting-started.html
   - /docs/mcp.html
   - /docs/architecture.html

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -1,0 +1,84 @@
+---
+layout: default
+---
+
+# 0→hero reference path
+
+The 0→hero path is the maintained, no-secret reference for the Go Micro
+services → agents → workflows lifecycle. It ties the CLI inner loop and the
+runtime harness together so a contributor can prove the framework still works as
+one system, not as separate demos.
+
+Use it when you want to answer: "Can I scaffold a service, run it locally, talk
+to an agent, inspect durable work, and reach the deployment boundary without
+cloud credentials?"
+
+## What the contract covers
+
+| Boundary | Contract | CI check |
+| --- | --- | --- |
+| Scaffold | `micro new` generates a runnable service with and without MCP support. | `go test ./cmd/micro/cli/new -run TestZeroToOne -count=1` |
+| Run | `micro run` remains the local development entry point. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
+| Chat | `micro chat` remains the interactive agent entry point. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
+| Inspect | `micro inspect agent`, `micro inspect flow`, and `micro flow runs` remain discoverable for run history. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
+| Deploy | `micro deploy --dry-run` resolves deploy targets without touching remote infrastructure. | `go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1` |
+| Runtime | Real services, agents, durable flows, store-backed history, delegation, and A2A run with only the model mocked. | `./internal/harness/zero-to-hero-ci/run.sh` and `make provider-conformance-mock` |
+
+## Run the whole no-secret path
+
+From the repository root:
+
+```sh
+make harness
+```
+
+That target runs the scaffold contract, the CLI boundary smoke tests, the
+0→hero runtime harnesses, the event-driven agent-flow harness, and mock provider
+conformance. It is intentionally deterministic: no provider key, cloud account,
+SSH access, or remote service is required.
+
+## Run focused checks while iterating
+
+Use the smaller checks when you are working on one seam:
+
+```sh
+# Scaffold → run/call contract.
+go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
+
+# CLI inner-loop commands: run, chat, inspect, flow runs, deploy --dry-run.
+go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1
+go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
+
+# Durable services → agents → workflows reference scenarios.
+./internal/harness/zero-to-hero-ci/run.sh
+
+# Event-as-prompt agent flow.
+go run ./internal/harness/agent-flow
+
+# Cross-provider semantics with the deterministic mock provider.
+make provider-conformance-mock
+```
+
+## Reference scenarios
+
+- [`internal/harness/plan-delegate`](https://github.com/micro/go-micro/tree/master/internal/harness/plan-delegate)
+  is the compact 0→hero scenario: real task and notify services, a conductor
+  agent, a comms agent, plan persistence, delegation, and a workflow handoff.
+- [`internal/harness/universe`](https://github.com/micro/go-micro/tree/master/internal/harness/universe)
+  boots a larger mini-world: inventory, payment, order confirmation, a concierge
+  agent, durable checkpoint/resume, agent run history, flow run history, and A2A
+  reachability.
+- [`internal/harness/agent-flow`](https://github.com/micro/go-micro/tree/master/internal/harness/agent-flow)
+  shows the event-driven path where a `user.created` event prompts an agent to
+  call services and complete onboarding.
+
+Together these scenarios keep the North Star executable: services expose typed
+capabilities, agents use those capabilities with memory and guardrails, and
+workflows compose the work over time.
+
+## Keeping the guide honest
+
+If you change the CLI inner loop, durable flow APIs, agent run history, or the
+provider/tool semantics, update this guide and the harness in the same PR. The
+point of 0→hero is not a polished sample app that drifts from reality; it is a
+CI-verifiable contract that the documented lifecycle still works.


### PR DESCRIPTION
Summary:
- Add a canonical 0→hero reference guide for the no-secret services → agents → workflows path.
- Link the guide from README and website navigation.
- Add a docs contract test so the guide, README, and nav stay wired together.

Testing:
- go test ./internal/harness/zero-to-hero-ci -count=1
- go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
- ./internal/harness/zero-to-hero-ci/run.sh
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in grpc tests)
- golangci-lint run ./...
- go run ./internal/harness/agent-flow
- make provider-conformance-mock

Closes #3515
Closes #3521