### PR TITLE
Align public AI harness docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,8 +401,8 @@ Swap providers with a single import — same interface everywhere:
 | Google Gemini | `gemini-2.5-flash` |
 | Groq | `llama-3.3-70b-versatile` |
 | Mistral | `mistral-large-latest` |
-| Together AI | `Llama-3.3-70B-Instruct-Turbo` |
-| Atlas Cloud | `llama-3.3-70b` |
+| Together AI | `meta-llama/Llama-3.3-70B-Instruct-Turbo` |
+| Atlas Cloud | `deepseek-ai/DeepSeek-V3-0324` |
 
 ```go
 m := ai.New("anthropic", ai.WithAPIKey(key))

--- a/internal/website/blog/16.md
+++ b/internal/website/blog/16.md
@@ -135,8 +135,8 @@ The store backend determines durability — file-backed by default, Postgres or 
 | **What** | Capability | Intelligence | Event orchestration |
 | **Does** | Handles requests | Manages services | Reacts to events |
 | **Knows** | Its endpoints | Its services' endpoints | Its trigger topic |
-| **State** | Store | Store (memory) | Stateless per event |
-| **Create** | `micro.NewService()` | `micro.NewAgent()` | `micro.NewFlow()` |
+| **State** | Store | Store-backed memory | Checkpointed run history |
+| **Create** | `micro.NewService("name")` | `micro.NewAgent("name")` | `micro.NewFlow("name")` |
 | **Package** | `service/` | `agent/` | `flow/` |
 
 They compose:
@@ -164,7 +164,7 @@ Or build an agent in Go:
 ```go
 package main
 
-import "go-micro.dev/v5"
+import "go-micro.dev/v6"
 
 func main() {
     agent := micro.NewAgent("task-mgr",
@@ -176,7 +176,7 @@ func main() {
 }
 ```
 
-The agent package is at `go-micro.dev/v5/agent`. The full interface design is documented in [AGENT_DESIGN.md](https://github.com/micro/go-micro/blob/master/internal/docs/AGENT_DESIGN.md).
+The agent implementation lives under `go-micro.dev/v6/agent`; most users create agents through the top-level `go-micro.dev/v6` API. The full interface design is documented in [AGENT_DESIGN.md](https://github.com/micro/go-micro/blob/master/internal/docs/AGENT_DESIGN.md).
 
 ---
 

--- a/internal/website/docs/guides/agent-harness.md
+++ b/internal/website/docs/guides/agent-harness.md
@@ -31,7 +31,7 @@ your stack — the harness *is* the stack.
 | Tools | Every service endpoint is an MCP-callable tool from registry metadata — no extra code | Shipped |
 | Memory | Store-backed agent memory (`AgentMemory`), durable across restarts | Shipped |
 | Guardrails | `MaxSteps`, `LoopLimit`, `ApproveTool`, tool wrappers — enforced at the call site | Shipped |
-| Workflows | Durable flows; `flow.Loop` for run-until-done | Shipped |
+| Workflows | Durable flows; `micro.FlowLoop` for run-until-done | Shipped |
 | Planning / delegation | Built-in `plan` and `delegate` tools on every agent | Shipped |
 | Discovery & RPC | Registry + client; agents and services find and call each other | Shipped |
 | Interop | MCP (tools), A2A (agents), x402 (paid tools) | Shipped |

--- a/internal/website/docs/guides/agent-loops.md
+++ b/internal/website/docs/guides/agent-loops.md
@@ -18,11 +18,11 @@ you're done") has no natural ceiling. So a usable loop needs two things:
 1. a **stop condition** — how it decides it's done, and
 2. a **hard cap** — a guardrail that guarantees it always terminates.
 
-Go Micro gives you both as a flow step: `flow.Loop`.
+Go Micro gives you both as a flow step: `micro.FlowLoop`.
 
 ## The shape
 
-`flow.Loop` is a `StepFunc`, so it drops into a flow's ordered, checkpointed
+`micro.FlowLoop` is a `StepFunc`, so it drops into a flow's ordered, checkpointed
 step list like any other step. It runs a **body** step repeatedly, carrying the
 flow `State` from one pass to the next, until a stop condition fires or the
 iteration cap is hit — whichever comes first.


### PR DESCRIPTION
Summary:
- Update README provider defaults to match the current Together AI and Atlas Cloud provider implementations.
- Refresh stale blog/API references from v5 and nameless constructors to v6 named constructors.
- Use the exported micro.FlowLoop name in public loop/harness docs.

Testing:
- go build ./...
- go test ./... (environment warning: loopback targets forbidden in grpc tests)
- golangci-lint run ./...

Closes #3530