### PR TITLE
ci: run the live provider-conformance harness hourly, not daily

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     branches: ["**"]
   schedule:
-    - cron: "17 6 * * *" # daily, so the world is exercised even without changes
+    - cron: "17 * * * *" # hourly, so real-model conformance keeps pace with the dev/loop velocity
   workflow_dispatch:
     inputs:
       providers:


### PR DESCRIPTION
Switches the live provider-conformance harness from **daily → hourly** (`cron: "17 * * * *"`), so real-model regressions and provider drift surface within the hour instead of up to 24h — matching the dev/loop velocity.

Unchanged: the mock harness still runs on every push/PR (the free per-change gate), and the live job stays non-blocking and only runs on schedule/dispatch. This only changes the live (credentialed) cadence. It now runs against `minimaxai/minimax-m3` per #3538.

Note: this increases Atlas Cloud credit usage (~1 live run/hour) — which is what the credits are for, and we'll watch where it goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_