### PR TITLE
ci: auto-triage harness failures into fix issues (hill-climbing loop)

### DIFF
--- a/.github/workflows/harness-triage.yml
+++ b/.github/workflows/harness-triage.yml
@@ -1,0 +1,59 @@
+name: Harness Failure Triage
+
+# Closes the autonomous loop's feedback path: when the live provider-conformance
+# harness fails, dispatch Codex to TRIAGE the failing run and file scoped, deduped
+# issues that the hourly increment loop then fixes — no human in the middle. It
+# only triages the scheduled/manual live run (not every push/PR mock run), dedupes
+# against open issues so hourly repeats don't spam, ignores transient flakes, and
+# ESCALATES anything needing a breaking/architectural change as needs-human rather
+# than auto-building it.
+#
+# Gated on CODEX_TRIGGER_TOKEN like the rest of the loop (Codex ignores comments
+# authored by the github-actions bot).
+#
+# Note: Codex is serial, so this competes with the hourly increment + architect
+# dispatches for the single task slot. If it saturates, lower the harness cadence
+# or gate this to a slower schedule.
+
+on:
+  workflow_run:
+    workflows: ["Harness (E2E)"]
+    types: [completed]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: harness-triage
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    # Only when the harness actually failed, and only for the scheduled or manual
+    # live run — never the per-push/PR mock run.
+    if: github.event.workflow_run.conclusion == 'failure' && (github.event.workflow_run.event == 'schedule' || github.event.workflow_run.event == 'workflow_dispatch')
+    steps:
+      - name: Open a triage issue and dispatch Codex
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_TRIGGER_TOKEN || github.token }}
+          HAS_TRIGGER_TOKEN: ${{ secrets.CODEX_TRIGGER_TOKEN != '' }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          if [ "$HAS_TRIGGER_TOKEN" != "true" ]; then
+            echo "CODEX_TRIGGER_TOKEN is not set — skipping (Codex ignores Actions-bot comments)."
+            exit 0
+          fi
+          # Ensure the escalation label exists (idempotent).
+          gh label create needs-human --repo "$REPO" --color FBCA04 \
+            --description "Requires a human/architect decision (breaking or architectural)" --force || true
+
+          ISSUE_URL=$(gh issue create --repo "$REPO" \
+            --title "Harness failure triage: run $RUN_ID" \
+            --body "Automated triage of a failed live provider-conformance harness run: $RUN_URL")
+          ISSUE_NUM="${ISSUE_URL##*/}"
+          echo "Opened triage issue #$ISSUE_NUM — dispatching Codex."
+          gh issue comment "$ISSUE_NUM" --repo "$REPO" --body \
+          "@codex Act as failure triage for the autonomous loop. The live provider-conformance harness failed: $RUN_URL (run id $RUN_ID). Do this, and do NOT change code or open a PR — triage only: (1) Read the failing logs (\`gh run view $RUN_ID --repo $REPO --log-failed\`) and the provider-conformance artifact/summary. (2) Root-cause each DISTINCT failure. (3) DEDUPE against existing work — list open issues (\`gh issue list --repo $REPO --label codex --state open --limit 100\`); if a matching issue already exists for a failure, add a one-line 'recurred in $RUN_URL' comment to it and do NOT open a duplicate. (4) For each genuine, self-contained, CI-verifiable defect that is NOT already tracked, open a scoped issue: \`gh issue create --repo $REPO --label codex --label enhancement --title \"<scoped task>\" --body \"<root cause, scope, acceptance criteria, and the failing run link>\"\` — the hourly increment loop will build it. (5) If a failure is transient/flaky and not a code defect (e.g. a live-model latency timeout or provider outage), note it in a comment and file NOTHING. (6) If a real fix would require a breaking public-API change or an architectural change, do NOT file it as an auto-buildable task — open an issue labeled \`needs-human\` describing it for the architect/human. When finished, close this triage issue (\`gh issue close $ISSUE_NUM\`)."

--- a/internal/docs/CONTINUOUS_IMPROVEMENT.md
+++ b/internal/docs/CONTINUOUS_IMPROVEMENT.md
@@ -154,6 +154,20 @@ roadmap-driven by default, not a fresh guess every hour. Cadence is tunable in e
 workflow's `cron`; the human can reorder `PRIORITIES.md` or its issues at any time
 to redirect. Codex is serial, so these passes queue behind any in-flight increment.
 
+## Failure triage (the feedback loop)
+
+The loop also closes on its own failures. `.github/workflows/harness-triage.yml`
+fires when the live provider-conformance harness finishes with `conclusion:
+failure` (scheduled/manual runs only), and dispatches Codex to **triage** the
+failing run: read the logs, root-cause each distinct failure, **dedupe** against
+open issues (comment "recurred" rather than filing a duplicate), and file a scoped
+`codex`/`enhancement` issue for each genuine, self-contained defect — which the
+increment loop then builds and the next harness run verifies. Transient flakes
+(live-model latency, provider outages) are ignored; anything needing a breaking or
+architectural change is escalated as `needs-human` instead of auto-built. This is
+the hill-climbing layer: CI/harness failures become fixes with no human in the
+middle, short of a decision that's genuinely the human's.
+
 ## Stop / redirect
 
 - In-session: `CronDelete <id>` (or end the session).


### PR DESCRIPTION
Closes the autonomous loop's feedback path — the "hill-climbing" layer where **CI/harness failures become fixes with no human in the middle.**

**`harness-triage.yml`** fires when the **Harness (E2E)** workflow finishes with `conclusion: failure` (scheduled/manual live runs only — not per-push mock runs), and dispatches Codex to *triage* the failing run:
1. Read the failing logs + conformance artifact,
2. Root-cause each distinct failure,
3. **Dedupe** against open issues (comment "recurred" instead of filing a duplicate — so hourly repeats don't spam),
4. File a scoped `codex`/`enhancement` issue for each genuine, self-contained defect → the increment loop builds it, the next harness run verifies,
5. Ignore transient flakes (live-model latency, provider outages),
6. **Escalate** anything needing a breaking/architectural change as `needs-human` — not auto-built.

This is exactly the manual triage I did for #3546/#3547, automated. Gated on `CODEX_TRIGGER_TOKEN` like the rest of the loop. Documented in `CONTINUOUS_IMPROVEMENT.md`.

**One honest tradeoff:** Codex is serial, so this competes with the hourly increment + architect dispatches for the single task slot; the dedupe keeps repeat-triage cheap, but if it saturates, lower the harness cadence or gate triage to a slower schedule (noted in the workflow header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_