### PR TITLE
agent: execute text tool call fallbacks

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -329,6 +329,19 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		return nil, fmt.Errorf("agent run %s paused for approval: %s", run.ID, a.pause.Message)
 	}
 
+	if len(resp.ToolCalls) == 0 {
+		if calls, answer, ok := a.executeTextToolCalls(ctx, resp.Reply, toolList); ok {
+			resp.ToolCalls = calls
+			if resp.Answer == "" {
+				resp.Answer = answer
+			}
+			trimmedReply := strings.TrimSpace(resp.Reply)
+			if strings.HasPrefix(trimmedReply, "{") || strings.HasPrefix(trimmedReply, "[") || strings.HasPrefix(trimmedReply, "```") {
+				resp.Reply = ""
+			}
+		}
+	}
+
 	if resp.Reply != "" {
 		a.mem.Add("assistant", resp.Reply)
 	}

--- a/agent/conformance_test.go
+++ b/agent/conformance_test.go
@@ -171,3 +171,50 @@ func TestAgentProviderConformanceFakeError(t *testing.T) {
 		t.Fatalf("Ask error = %v, want conformance provider failure", err)
 	}
 }
+
+func TestAgentExecutesProviderTextToolCallFallback(t *testing.T) {
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if opts.ToolHandler == nil {
+			return nil, errors.New("missing tool handler")
+		}
+		return &ai.Response{
+			Reply: `{"name":"conformance_echo","input":{"value":"agent-conformance"}}`,
+		}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	var sawTool bool
+	a := New(
+		Name("conformance-text-tool"),
+		Provider("fake"),
+		WithRegistry(registry.NewMemoryRegistry()),
+		WithStore(store.NewMemoryStore()),
+		WithMemory(NewInMemory(4)),
+		WithTool("conformance_echo", "Echo a conformance value.", map[string]any{
+			"value": map[string]any{"type": "string"},
+		}, func(ctx context.Context, input map[string]any) (string, error) {
+			sawTool = true
+			if input["value"] != "agent-conformance" {
+				return "", fmt.Errorf("unexpected value %v", input["value"])
+			}
+			return `{"marker":"agent-conformance-ok"}`, nil
+		}),
+	)
+
+	resp, err := a.Ask(context.Background(), "Run the text tool call fallback.")
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !sawTool {
+		t.Fatal("text tool call fallback did not execute the tool")
+	}
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].Name != "conformance_echo" {
+		t.Fatalf("ToolCalls = %+v, want conformance_echo", resp.ToolCalls)
+	}
+	if !strings.Contains(resp.Reply, "agent-conformance-ok") {
+		t.Fatalf("Reply = %q, want tool result marker", resp.Reply)
+	}
+	if strings.Contains(resp.Reply, `"name":"conformance_echo"`) {
+		t.Fatalf("Reply = %q, want tool result instead of raw JSON", resp.Reply)
+	}
+}

--- a/agent/text_tool_calls.go
+++ b/agent/text_tool_calls.go
@@ -1,0 +1,141 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go-micro.dev/v6/ai"
+)
+
+var fencedJSONBlock = regexp.MustCompile("(?s)```(?:json)?\\s*(.*?)\\s*```")
+
+type textToolCall struct {
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Tool      string         `json:"tool"`
+	Input     map[string]any `json:"input"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+// executeTextToolCalls is a compatibility fallback for providers that return a
+// tool call as text JSON instead of a structured tool_calls field. It only runs
+// calls whose names match the tools offered to the model, so ordinary JSON
+// answers are left untouched.
+func (a *agentImpl) executeTextToolCalls(ctx context.Context, reply string, tools []ai.Tool) ([]ai.ToolCall, string, bool) {
+	calls := parseTextToolCalls(reply, tools)
+	if len(calls) == 0 {
+		return nil, "", false
+	}
+
+	handler := a.toolHandler()
+	results := make([]string, 0, len(calls))
+	for i := range calls {
+		result := handler(ctx, calls[i])
+		calls[i].Result = result.Content
+		if result.Refused != "" {
+			calls[i].Error = result.Refused
+		}
+		if result.Content != "" {
+			results = append(results, result.Content)
+		}
+	}
+	return calls, strings.Join(results, "\n"), true
+}
+
+func parseTextToolCalls(text string, tools []ai.Tool) []ai.ToolCall {
+	allowed := map[string]bool{}
+	for _, tool := range tools {
+		allowed[tool.Name] = true
+		if tool.OriginalName != "" {
+			allowed[tool.OriginalName] = true
+		}
+	}
+	if len(allowed) == 0 {
+		return nil
+	}
+
+	for _, candidate := range jsonCandidates(text) {
+		if calls := decodeTextToolCalls(candidate, allowed); len(calls) > 0 {
+			return calls
+		}
+	}
+	return nil
+}
+
+func jsonCandidates(text string) []string {
+	trimmed := strings.TrimSpace(text)
+	var out []string
+	if trimmed != "" {
+		out = append(out, trimmed)
+	}
+	for _, match := range fencedJSONBlock.FindAllStringSubmatch(text, -1) {
+		if len(match) > 1 {
+			out = append(out, strings.TrimSpace(match[1]))
+		}
+	}
+	if start, end := strings.IndexAny(text, "[{"), strings.LastIndexAny(text, "]}"); start >= 0 && end > start {
+		out = append(out, strings.TrimSpace(text[start:end+1]))
+	}
+	return out
+}
+
+func decodeTextToolCalls(candidate string, allowed map[string]bool) []ai.ToolCall {
+	var root any
+	if err := json.Unmarshal([]byte(candidate), &root); err != nil {
+		return nil
+	}
+	return collectTextToolCalls(root, allowed)
+}
+
+func collectTextToolCalls(v any, allowed map[string]bool) []ai.ToolCall {
+	switch x := v.(type) {
+	case []any:
+		var out []ai.ToolCall
+		for _, item := range x {
+			out = append(out, collectTextToolCalls(item, allowed)...)
+		}
+		return out
+	case map[string]any:
+		if nested, ok := firstNestedToolCalls(x); ok {
+			return collectTextToolCalls(nested, allowed)
+		}
+		call := mapToTextToolCall(x)
+		name := call.Name
+		if name == "" {
+			name = call.Tool
+		}
+		input := call.Input
+		if input == nil {
+			input = call.Arguments
+		}
+		if name == "" || !allowed[name] || input == nil {
+			return nil
+		}
+		id := call.ID
+		if id == "" {
+			id = fmt.Sprintf("text-call-%s", strings.ReplaceAll(name, ".", "_"))
+		}
+		return []ai.ToolCall{{ID: id, Name: name, Input: input}}
+	default:
+		return nil
+	}
+}
+
+func firstNestedToolCalls(m map[string]any) (any, bool) {
+	for _, key := range []string{"tool_calls", "toolCalls", "calls"} {
+		if v, ok := m[key]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func mapToTextToolCall(m map[string]any) textToolCall {
+	b, _ := json.Marshal(m)
+	var call textToolCall
+	_ = json.Unmarshal(b, &call)
+	return call
+}


### PR DESCRIPTION
## Summary
- Execute provider-emitted text JSON tool calls through the agent's normal tool path when structured tool_calls are absent.
- Only run text calls that match tools offered to the model, and surface tool results instead of raw JSON.
- Add conformance coverage for a fake provider returning a text tool call.

Closes #3546
Closes #3553

## Testing
- go build ./...
- go test ./agent -run TestAgentExecutesProviderTextToolCallFallback -count=1
- go test ./... (fails in client/grpc because loopback targets are forbidden in this environment)
- golangci-lint run ./...