### PR TITLE
ci+docs: name loop workflows by role (planner/generator/evaluator)

### DIFF
--- a/.github/workflows/loop-architect.yml
+++ b/.github/workflows/loop-architect.yml
@@ -1,4 +1,4 @@
-name: Architecture Review
+name: "Loop: Architect (Planner)"
 
 # Continuous high-altitude oversight of the whole framework and harness — the
 # "founder lens" of the autonomous loop (internal/docs/CONTINUOUS_IMPROVEMENT.md).

--- a/.github/workflows/loop-builder.yml
+++ b/.github/workflows/loop-builder.yml
@@ -1,4 +1,4 @@
-name: Continuous Improvement
+name: "Loop: Builder (Generator)"
 
 # Durable backbone for the autonomous improvement loop
 # (see internal/docs/CONTINUOUS_IMPROVEMENT.md).

--- a/.github/workflows/loop-devrel.yml
+++ b/.github/workflows/loop-devrel.yml
@@ -1,4 +1,4 @@
-name: DevRel Review
+name: "Loop: DevRel"
 
 # Daily higher-altitude coherence pass over the PUBLIC surface — README,
 # website (landing + docs), and blog — part of the autonomous loop

--- a/.github/workflows/loop-triage.yml
+++ b/.github/workflows/loop-triage.yml
@@ -1,4 +1,4 @@
-name: Harness Failure Triage
+name: "Loop: Triage (Evaluator feedback)"
 
 # Closes the autonomous loop's feedback path: when the live provider-conformance
 # harness fails, dispatch Codex to TRIAGE the failing run and file scoped, deduped

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,17 @@ Thank you for your interest in contributing to Go Micro! This document provides 
 
 Be respectful, inclusive, and collaborative. We're all here to build great software together.
 
+## How Go Micro is built
+
+Go Micro is developed by an **autonomous improvement loop** — a planner, a
+generator, and a separate evaluator, running as scheduled GitHub Actions with a
+human setting direction. It's the framework's own thesis (an agent operating a
+system) pointed at itself: an agent harness, built by agents. The full process —
+the planner → generator → evaluator pipeline, the correctness-only merge gate, and
+the guardrails — is documented in
+[`internal/docs/CONTINUOUS_IMPROVEMENT.md`](internal/docs/CONTINUOUS_IMPROVEMENT.md).
+Human contributions follow the same gate: green CI, one concern per PR.
+
 ## Getting Started
 
 1. Fork the repository

--- a/internal/docs/CONTINUOUS_IMPROVEMENT.md
+++ b/internal/docs/CONTINUOUS_IMPROVEMENT.md
@@ -10,6 +10,25 @@ and can stop or revert anything at any time.
 > **services → agents → workflows**. Judge each change against it — work that
 > doesn't move toward that lifecycle isn't an improvement, however clean.
 
+## The pipeline (planner → generator → evaluator)
+
+The development process is an operational instance of the long-running-agent
+harness pattern ([Anthropic on harness design](https://www.anthropic.com/engineering/harness-design-long-running-apps)) —
+a planner, a generator, and a *separate* evaluator — distributed across GitHub
+Actions instead of subagents. Each role is a workflow:
+
+| Role | Workflow (action name) | What it does |
+|------|------------------------|--------------|
+| **Planner** | `loop-architect.yml` — *Loop: Architect (Planner)* | Tracks live state, prioritizes the roadmap + an internal scan, and maintains the ranked queue in [`PRIORITIES.md`](PRIORITIES.md). Decides *what*. |
+| **Generator** | `loop-builder.yml` — *Loop: Builder (Generator)* | Builds the top open queue item as a single-concern PR (via Codex) and self-merges on green CI. Does the work. |
+| **Evaluator** | `harness.yml` — *Harness (E2E)*, plus the CI gate (`tests.yaml`, `lint.yaml`) | Grades every change: the mock harness + unit/lint on each push/PR, and real-model conformance hourly. A *separate* grader — never the generator judging itself. |
+| **Evaluator → feedback** | `loop-triage.yml` — *Loop: Triage (Evaluator feedback)* | On harness failure, root-causes, dedupes, and files scoped fix issues back into the planner's queue. The hill-climbing feedback path. |
+| **Coherence** | `loop-devrel.yml` — *Loop: DevRel* | Keeps README/website/docs/blog aligned with the North Star. |
+
+Generation is separated from evaluation on purpose: an agent grading its own work
+reliably over-rates it, so **CI and the harness — not the builder — are the gate**.
+The human sets direction and owns the calls that need taste (see Guardrails).
+
 ## Autonomy
 
 Full autonomy, **no approval gates**. Each increment: Claude Code picks the work,
@@ -72,7 +91,7 @@ Grounded in real signal, never speculative rewrites. Each cycle draws from:
   tracking issue for each increment and dispatches Codex there. It needs a
   `CODEX_TRIGGER_TOKEN` repo secret from a user account Codex responds to;
   without that secret the workflow deliberately no-ops to avoid ignored bot
-  comments. See `.github/workflows/continuous-improvement.yml` and the mechanics
+  comments. See `.github/workflows/loop-builder.yml` and the mechanics
   below.
 
 ## How the durable loop works (mechanics)
@@ -127,13 +146,13 @@ The hourly loop ships increments; two periodic passes keep the *whole* heading i
 the right direction. Both use the same mechanism (fresh issue → `@codex` →
 output) but produce direction and coherence, not just code.
 
-- **DevRel — daily** (`.github/workflows/devrel-review.yml`). Audits the public
+- **DevRel — daily** (`.github/workflows/loop-devrel.yml`). Audits the public
   surface (README, website landing + docs, blog) for coherence with the North
   Star, README crispness, and blog-worthy material. **Autonomy boundary:** safe
   factual-alignment and crispness fixes auto-merge like any increment;
   brand/positioning copy and blog drafts are *surfaced in a report* for the
   human, never auto-merged.
-- **Architect — continuous (hourly)** (`.github/workflows/architecture-review.yml`).
+- **Architect — continuous (hourly)** (`.github/workflows/loop-architect.yml`).
   The *founder lens*, running alongside the builders. Each run it **tracks live
   state** (what just merged, what's in flight), **prioritizes the roadmap**
   (`ROADMAP.md`, Now → Next → Later) against an internal scan (lifecycle gaps, API
@@ -156,7 +175,7 @@ to redirect. Codex is serial, so these passes queue behind any in-flight increme
 
 ## Failure triage (the feedback loop)
 
-The loop also closes on its own failures. `.github/workflows/harness-triage.yml`
+The loop also closes on its own failures. `.github/workflows/loop-triage.yml`
 fires when the live provider-conformance harness finishes with `conclusion:
 failure` (scheduled/manual runs only), and dispatches Codex to **triage** the
 failing run: read the logs, root-cause each distinct failure, **dedupe** against


### PR DESCRIPTION
Names the autonomous-loop workflows by their **role** so the Actions list maps to the long-running-agent harness pattern (planner → generator → evaluator, per [Anthropic on harness design](https://www.anthropic.com/engineering/harness-design-long-running-apps)), and documents the development process.

**Renames** (files + action names):
| Before | After | Name | Role |
|---|---|---|---|
| `architecture-review.yml` | `loop-architect.yml` | *Loop: Architect (Planner)* | decides *what* → `PRIORITIES.md` |
| `continuous-improvement.yml` | `loop-builder.yml` | *Loop: Builder (Generator)* | builds the top item |
| `harness-triage.yml` | `loop-triage.yml` | *Loop: Triage (Evaluator feedback)* | failure → fix issues |
| `devrel-review.yml` | `loop-devrel.yml` | *Loop: DevRel* | coherence |

`harness.yml` stays the shared **Evaluator/CI gate** (kept its `name: Harness (E2E)` so the triage `workflow_run` trigger and the required checks are untouched).

**Docs:** `CONTINUOUS_IMPROVEMENT.md` gains a "The pipeline (planner → generator → evaluator)" section mapping each role to its workflow, and `CONTRIBUTING.md` now points to it under "How Go Micro is built" so the process is discoverable.

No behavior change — schedules, cron, gates, and required status checks are all unaffected (renames are file/`name:` only; job names and the harness name are preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_