### PR TITLE
community: add a prominent Discord link + fix the stale invite code

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -48,4 +48,4 @@ Add any other context about the problem here.
 - [Troubleshooting Guide](https://github.com/micro/go-micro/tree/master/internal/website/docs/getting-started.md)
 - [Examples](https://github.com/micro/go-micro/tree/master/examples)
 - [API Reference](https://pkg.go.dev/go-micro.dev/v5)
-- [Discord Community](https://discord.gg/WeMU5AGxD)
+- [Discord Community](https://discord.gg/G8Gk5j3uXr)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -39,4 +39,4 @@ Add any other context, code examples, or screenshots about the feature request h
 - [Roadmap](https://github.com/micro/go-micro/blob/master/ROADMAP.md)
 - [Contributing Guide](https://github.com/micro/go-micro/blob/master/CONTRIBUTING.md)
 - [Architecture Docs](https://github.com/micro/go-micro/tree/master/internal/website/docs/architecture.md)
-- [Discord Community](https://discord.gg/WeMU5AGxD)
+- [Discord Community](https://discord.gg/G8Gk5j3uXr)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Go Micro [![Go.Dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/go-micro.dev/v6?tab=doc) [![Go Report Card](https://goreportcard.com/badge/github.com/go-micro/go-micro)](https://goreportcard.com/report/github.com/go-micro/go-micro)
+# Go Micro [![Go.Dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/go-micro.dev/v6?tab=doc) [![Go Report Card](https://goreportcard.com/badge/github.com/go-micro/go-micro)](https://goreportcard.com/report/github.com/go-micro/go-micro) [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white&style=flat-square)](https://discord.gg/G8Gk5j3uXr)
 
 Go Micro is an **agent harness** and service framework for Go.
+
+**Community:** questions, ideas, or just want to build alongside us? [Join the Discord](https://discord.gg/G8Gk5j3uXr).
 
 A harness is the runtime around an agent: the tools it can call, the memory it keeps, the guardrails that bound it, the workflows that trigger it, the services it depends on, and the protocols other agents use to reach it. 
 
@@ -14,7 +16,7 @@ Go Micro gives you the harness as Go code. Build an agent and it gets a model, m
 &nbsp;&nbsp;
 <a href="https://go-micro.dev/blog/8"><img src="https://www.atlascloud.ai/logo.svg" height="26" /></a>
 
-**Want to support Go Micro and see your logo here?** [Become a sponsor](https://discord.gg/WeMU5AGxD) — reach out on Discord.
+**Want to support Go Micro and see your logo here?** [Become a sponsor](https://discord.gg/G8Gk5j3uXr) — reach out on Discord.
 
 ## Commercial Support
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ hosted service, enterprise tier, or venture funding. See
 ## Contributing & feedback
 
 Pick an item, open an issue to discuss the approach, and submit a PR. Or join the
-[Discord](https://discord.gg/WeMU5AGxD). Include tests, run `make test` and
+[Discord](https://discord.gg/G8Gk5j3uXr). Include tests, run `make test` and
 `make lint`.
 
 ## Version support

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -174,6 +174,6 @@ We currently do not offer a bug bounty program, but we greatly appreciate respon
 
 For security questions that are not vulnerabilities, please:
 - Open a discussion: https://github.com/micro/go-micro/discussions
-- Join Discord: https://discord.gg/WeMU5AGxD
+- Join Discord: https://discord.gg/G8Gk5j3uXr
 - Email: support@go-micro.dev
 

--- a/contrib/go-micro-llamaindex/README.md
+++ b/contrib/go-micro-llamaindex/README.md
@@ -324,4 +324,4 @@ Apache 2.0 - See [LICENSE](../../LICENSE) for details.
 ## Support
 
 - GitHub Discussions: https://github.com/micro/go-micro/discussions
-- Discord: https://discord.gg/WeMU5AGxD
+- Discord: https://discord.gg/G8Gk5j3uXr

--- a/contrib/langchain-go-micro/CONTRIBUTING.md
+++ b/contrib/langchain-go-micro/CONTRIBUTING.md
@@ -102,4 +102,4 @@ pytest tests/integration/ -v
 ## Questions?
 
 - GitHub Discussions: https://github.com/micro/go-micro/discussions
-- Discord: https://discord.gg/WeMU5AGxD
+- Discord: https://discord.gg/G8Gk5j3uXr

--- a/contrib/langchain-go-micro/README.md
+++ b/contrib/langchain-go-micro/README.md
@@ -370,4 +370,4 @@ Apache 2.0 - See [LICENSE](../../LICENSE) for details.
 ## Support
 
 - GitHub Discussions: https://github.com/micro/go-micro/discussions
-- Discord: https://discord.gg/WeMU5AGxD
+- Discord: https://discord.gg/G8Gk5j3uXr

--- a/internal/website/_includes/footer-links.html
+++ b/internal/website/_includes/footer-links.html
@@ -1,4 +1,5 @@
 <a href="/docs/">Docs</a> &middot;
 <a href="/blog/">Blog</a> &middot;
 <a href="https://github.com/micro/go-micro">GitHub</a> &middot;
+<a href="https://discord.gg/G8Gk5j3uXr">Discord</a> &middot;
 <a href="/support">Support</a>

--- a/internal/website/_includes/nav-links.html
+++ b/internal/website/_includes/nav-links.html
@@ -1,4 +1,5 @@
 <a href="/docs/">Docs</a>
 <a href="/blog/">Blog</a>
 <a href="/support"{% if page.nav_active == 'support' %} class="active"{% endif %}>Support</a>
+<a href="https://discord.gg/G8Gk5j3uXr">Discord</a>
 <a href="https://github.com/micro/go-micro">GitHub</a>

--- a/internal/website/blog/13.md
+++ b/internal/website/blog/13.md
@@ -177,4 +177,4 @@ The future of microservices isn't fewer services. It's making them so easy to cr
 
 ---
 
-*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/WeMU5AGxD), or read the [docs](https://go-micro.dev/docs).*
+*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/G8Gk5j3uXr), or read the [docs](https://go-micro.dev/docs).*

--- a/internal/website/blog/14.md
+++ b/internal/website/blog/14.md
@@ -102,4 +102,4 @@ micro chat --provider anthropic
 
 ---
 
-*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/WeMU5AGxD), or read the [docs](https://go-micro.dev/docs).*
+*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/G8Gk5j3uXr), or read the [docs](https://go-micro.dev/docs).*

--- a/internal/website/blog/15.md
+++ b/internal/website/blog/15.md
@@ -144,4 +144,4 @@ The agent for your services answers. Not because you wired it up. Because the sy
 
 ---
 
-*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/WeMU5AGxD), or read the [docs](https://go-micro.dev/docs).*
+*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/G8Gk5j3uXr), or read the [docs](https://go-micro.dev/docs).*

--- a/internal/website/blog/16.md
+++ b/internal/website/blog/16.md
@@ -180,4 +180,4 @@ The agent implementation lives under `go-micro.dev/v6/agent`; most users create 
 
 ---
 
-*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/WeMU5AGxD), or read the [docs](https://go-micro.dev/docs).*
+*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/G8Gk5j3uXr), or read the [docs](https://go-micro.dev/docs).*

--- a/internal/website/blog/17.md
+++ b/internal/website/blog/17.md
@@ -165,4 +165,4 @@ Read the [Plan & Delegate guide](/docs/guides/plan-delegate) for the full refere
 
 ---
 
-*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/WeMU5AGxD), or read the [docs](https://go-micro.dev/docs).*
+*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/G8Gk5j3uXr), or read the [docs](https://go-micro.dev/docs).*

--- a/internal/website/blog/18.md
+++ b/internal/website/blog/18.md
@@ -90,4 +90,4 @@ curl -fsSL https://go-micro.dev/install.sh | sh
 
 ---
 
-*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/WeMU5AGxD), or read the [docs](https://go-micro.dev/docs).*
+*Go Micro is open source. Star us on [GitHub](https://github.com/micro/go-micro), join the [Discord](https://discord.gg/G8Gk5j3uXr), or read the [docs](https://go-micro.dev/docs).*

--- a/internal/website/blog/25.md
+++ b/internal/website/blog/25.md
@@ -58,4 +58,4 @@ A small end-to-end harness now boots a real world (services, a durable flow that
 
 The upshot is that building an agent in Go Micro looks like building a service, because underneath it is one. The infrastructure for a system of agents is, for the most part, the infrastructure for a system of services, and that is the decade of work already in the framework. Services remain the foundation; agents are what we are building on top of them.
 
-Thanks to Anthropic for the sponsorship. Join us in a new [Discord](https://discord.gg/WeMU5AGxD) to discuss the future of the project. 
+Thanks to Anthropic for the sponsorship. Join us in a new [Discord](https://discord.gg/G8Gk5j3uXr) to discuss the future of the project. 

--- a/internal/website/blog/27.md
+++ b/internal/website/blog/27.md
@@ -49,4 +49,4 @@ V6 is the beginning of something real. It's secure by default, leads with agents
 
 Projects dont come back from the dead like this. AI brought it back from the dead. Agents made services more relevant. And Claude Code made it possible for me to ship code again.
 
-Thanks to Anthropic for the grant and the sponsorship. Join me in the [Discord](https://discord.gg/WeMU5AGxD) to discuss further.
+Thanks to Anthropic for the grant and the sponsorship. Join me in the [Discord](https://discord.gg/G8Gk5j3uXr) to discuss further.

--- a/internal/website/docs/guides/cli-gateway.md
+++ b/internal/website/docs/guides/cli-gateway.md
@@ -423,5 +423,5 @@ micro server --address :9000
 ## Need Help?
 
 - **Issues**: [github.com/micro/go-micro/issues](https://github.com/micro/go-micro/issues)
-- **Discord**: [discord.gg/WeMU5AGxD](https://discord.gg/WeMU5AGxD)
+- **Discord**: [discord.gg/G8Gk5j3uXr](https://discord.gg/G8Gk5j3uXr)
 - **Docs**: [go-micro.dev/docs](https://go-micro.dev/docs)

--- a/internal/website/docs/quickstart.md
+++ b/internal/website/docs/quickstart.md
@@ -95,7 +95,7 @@ publisher.Publish(ctx, &UserCreatedEvent{
 
 ## Get Help
 
-- **[Discord Community](https://discord.gg/WeMU5AGxD)** - Chat with other users
+- **[Discord Community](https://discord.gg/G8Gk5j3uXr)** - Chat with other users
 - **[GitHub Issues](https://github.com/micro/go-micro/issues)** - Report bugs or request features
 - **[Documentation](https://go-micro.dev/docs/)** - Complete docs
 

--- a/internal/website/docs/roadmap.md
+++ b/internal/website/docs/roadmap.md
@@ -58,4 +58,4 @@ The framework is the product. It's funded by **sponsorship** from the people and
 
 ## Feedback
 
-Open an issue or start a discussion on [GitHub](https://github.com/micro/go-micro), or join the [Discord](https://discord.gg/WeMU5AGxD).
+Open an issue or start a discussion on [GitHub](https://github.com/micro/go-micro), or join the [Discord](https://discord.gg/G8Gk5j3uXr).

--- a/internal/website/index.html
+++ b/internal/website/index.html
@@ -271,7 +271,7 @@
       </div>
       <p class="subtitle" style="margin-top: 2.25rem;">Want to support Go Micro and put your logo here? Or running it in production and need a hand?</p>
       <div class="hero-buttons">
-        <a href="https://discord.gg/WeMU5AGxD" class="btn btn-secondary">Become a sponsor</a>
+        <a href="https://discord.gg/G8Gk5j3uXr" class="btn btn-secondary">Become a sponsor</a>
         <a href="/support" class="btn btn-primary">Commercial support</a>
       </div>
     </section>
@@ -283,6 +283,7 @@
         <div class="hero-buttons">
           <a href="/docs/getting-started.html" class="btn btn-primary">Get Started</a>
           <a href="/docs/" class="btn btn-secondary">Read the Docs</a>
+          <a href="https://discord.gg/G8Gk5j3uXr" class="btn btn-secondary">Join Discord</a>
           <a href="/blog/" class="btn btn-secondary">Blog</a>
         </div>
       </div>


### PR DESCRIPTION
There was no working, prominent Discord link — the ones that existed used a **stale invite code (`WeMU5AGxD`)** and were buried (a sponsor line, mid-blog footers).

- **Updated the invite code everywhere** → `https://discord.gg/G8Gk5j3uXr` (README, docs, blog posts, landing, SECURITY, issue templates, contrib). No stale codes remain.
- **Added it prominently:**
  - Site **nav** and **footer** includes → shows on every landing / docs / blog page.
  - README: a **Discord badge** (top) + a **Community** line under the intro.
  - Landing: a **"Join Discord"** button in the community CTA row.

Community/docs only. Directly serves the adoption goal — a visible place for developers to land and get help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_