### PR TITLE
harness: extend live provider deadlines

### DIFF
--- a/internal/harness/a2a-stream-fallback/main.go
+++ b/internal/harness/a2a-stream-fallback/main.go
@@ -24,6 +24,7 @@ import (
 	"go-micro.dev/v6/agent"
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/gateway/a2a"
+	"go-micro.dev/v6/internal/harness/harnessutil"
 	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/store"
 )
@@ -95,7 +96,7 @@ func main() {
 	reg := registry.NewMemoryRegistry()
 	st := store.NewMemoryStore()
 	var sawTool, sawRunInfo bool
-	ag := agent.New(
+	agentOpts := []agent.Option{
 		agent.Name("a2a-fallback"),
 		agent.Provider(*provider),
 		agent.APIKey(apiKey),
@@ -103,7 +104,7 @@ func main() {
 		agent.WithRegistry(reg),
 		agent.WithStore(st),
 		agent.WithMemory(agent.NewInMemory(8)),
-		agent.ModelCallTimeout(45*time.Second),
+		agent.ModelCallTimeout(45 * time.Second),
 		agent.WithTool("fallback_echo", "Echo the A2A fallback marker.", map[string]any{
 			"value": map[string]any{"type": "string", "description": "value to echo"},
 		}, func(ctx context.Context, input map[string]any) (string, error) {
@@ -118,7 +119,9 @@ func main() {
 			}
 			return `{"marker":"a2a-fallback-ok"}`, nil
 		}),
-	)
+	}
+	agentOpts = append(agentOpts, harnessutil.AgentOptions(*provider)...)
+	ag := agent.New(agentOpts...)
 
 	card := a2a.Card("a2a-fallback", "http://example.invalid/a2a-fallback", "", nil)
 	handler := a2a.NewAgentStreamHandler(card, func(ctx context.Context, text string) (string, error) {

--- a/internal/harness/agent-flow/main.go
+++ b/internal/harness/agent-flow/main.go
@@ -25,10 +25,9 @@ import (
 	"go-micro.dev/v6/agent"
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/broker"
-	"go-micro.dev/v6/client"
 	"go-micro.dev/v6/flow"
+	"go-micro.dev/v6/internal/harness/harnessutil"
 	"go-micro.dev/v6/registry"
-	"go-micro.dev/v6/selector"
 	"go-micro.dev/v6/service"
 	"go-micro.dev/v6/store"
 )
@@ -203,8 +202,9 @@ func main() {
 		fmt.Println("broker connect:", err)
 		os.Exit(1)
 	}
-	cl := client.NewClient(client.Registry(reg), client.Selector(selector.NewSelector(selector.Registry(reg))))
+	cl := harnessutil.Client(*provider, reg)
 	mem := store.NewMemoryStore()
+	liveAgentOpts := harnessutil.AgentOptions(*provider)
 
 	wsSvc := new(WorkspaceService)
 	ws := service.New(service.Name("workspace"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
@@ -217,7 +217,7 @@ func main() {
 	go nt.Run()
 
 	// The onboarder agent, registered so the flow can reach it over RPC.
-	onboarder := agent.New(
+	onboarderOpts := []agent.Option{
 		agent.Name("onboarder"),
 		agent.Address("127.0.0.1:0"),
 		agent.Services("workspace", "notify"),
@@ -225,7 +225,9 @@ func main() {
 		agent.Provider(*provider),
 		agent.APIKey(apiKey),
 		agent.WithRegistry(reg), agent.WithClient(cl), agent.WithStore(mem),
-	)
+	}
+	onboarderOpts = append(onboarderOpts, liveAgentOpts...)
+	onboarder := agent.New(onboarderOpts...)
 	go onboarder.Run()
 	defer onboarder.Stop()
 
@@ -238,6 +240,7 @@ func main() {
 		flow.Trigger("events.user.created"),
 		flow.Agent("onboarder"),
 		flow.Prompt("A new user signed up: {{.Data}}. Get them set up."),
+		flow.Timeout(harnessutil.LiveTimeout(*provider)),
 	)
 	if err := f.Register(reg, br, cl); err != nil {
 		fmt.Println("flow register:", err)

--- a/internal/harness/harnessutil/harnessutil.go
+++ b/internal/harness/harnessutil/harnessutil.go
@@ -1,0 +1,61 @@
+package harnessutil
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"go-micro.dev/v6/agent"
+	"go-micro.dev/v6/client"
+	"go-micro.dev/v6/registry"
+	"go-micro.dev/v6/selector"
+)
+
+const (
+	// LiveTimeoutEnv overrides the per-call deadline used by live-provider
+	// harness runs. It intentionally does not affect deterministic mock runs.
+	LiveTimeoutEnv = "GO_MICRO_HARNESS_LIVE_TIMEOUT"
+	// DefaultLiveTimeout is generous enough for slow but correct hosted models
+	// while still bounding genuinely stuck live conformance runs.
+	DefaultLiveTimeout = 5 * time.Minute
+)
+
+// LiveTimeout returns the harness per-call timeout for live providers. Mock runs
+// keep their historical fast defaults by returning zero.
+func LiveTimeout(provider string) time.Duration {
+	if provider == "mock" {
+		return 0
+	}
+	if raw := os.Getenv(LiveTimeoutEnv); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid %s=%q; using %s\n", LiveTimeoutEnv, raw, DefaultLiveTimeout)
+			return DefaultLiveTimeout
+		}
+		return d
+	}
+	return DefaultLiveTimeout
+}
+
+// Client returns an in-memory-registry client. Live provider harnesses get a
+// larger request timeout so an otherwise correct agent run is not cut off by the
+// default 30-second RPC deadline; mock runs are unchanged.
+func Client(provider string, reg registry.Registry) client.Client {
+	opts := []client.Option{
+		client.Registry(reg),
+		client.Selector(selector.NewSelector(selector.Registry(reg))),
+	}
+	if d := LiveTimeout(provider); d > 0 {
+		opts = append(opts, client.RequestTimeout(d))
+	}
+	return client.NewClient(opts...)
+}
+
+// AgentOptions applies the same live-provider timeout to model and tool calls.
+// The empty result for mock runs preserves their deterministic timing.
+func AgentOptions(provider string) []agent.Option {
+	if d := LiveTimeout(provider); d > 0 {
+		return []agent.Option{agent.ModelCallTimeout(d), agent.ToolCallTimeout(d)}
+	}
+	return nil
+}

--- a/internal/harness/harnessutil/harnessutil_test.go
+++ b/internal/harness/harnessutil/harnessutil_test.go
@@ -1,0 +1,33 @@
+package harnessutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLiveTimeoutLeavesMockUnchanged(t *testing.T) {
+	t.Setenv(LiveTimeoutEnv, "2m")
+	if got := LiveTimeout("mock"); got != 0 {
+		t.Fatalf("LiveTimeout(mock) = %s, want 0", got)
+	}
+	if opts := AgentOptions("mock"); len(opts) != 0 {
+		t.Fatalf("AgentOptions(mock) length = %d, want 0", len(opts))
+	}
+}
+
+func TestLiveTimeoutUsesDefaultForLiveProviders(t *testing.T) {
+	t.Setenv(LiveTimeoutEnv, "")
+	if got := LiveTimeout("atlascloud"); got != DefaultLiveTimeout {
+		t.Fatalf("LiveTimeout(live) = %s, want %s", got, DefaultLiveTimeout)
+	}
+	if opts := AgentOptions("atlascloud"); len(opts) != 2 {
+		t.Fatalf("AgentOptions(live) length = %d, want 2", len(opts))
+	}
+}
+
+func TestLiveTimeoutCanBeOverridden(t *testing.T) {
+	t.Setenv(LiveTimeoutEnv, "90s")
+	if got := LiveTimeout("anthropic"); got != 90*time.Second {
+		t.Fatalf("LiveTimeout override = %s, want 90s", got)
+	}
+}

--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -26,10 +26,9 @@ import (
 	"go-micro.dev/v6/agent"
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/broker"
-	"go-micro.dev/v6/client"
 	"go-micro.dev/v6/flow"
+	"go-micro.dev/v6/internal/harness/harnessutil"
 	"go-micro.dev/v6/registry"
-	"go-micro.dev/v6/selector"
 	"go-micro.dev/v6/service"
 	"go-micro.dev/v6/store"
 )
@@ -241,8 +240,9 @@ func runPlanDelegate(provider string) error {
 	fmt.Print("Real services, registry, RPC, agent loop, store, delegation.\n\n")
 
 	reg := registry.NewMemoryRegistry()
-	cl := client.NewClient(client.Registry(reg), client.Selector(selector.NewSelector(selector.Registry(reg))))
+	cl := harnessutil.Client(provider, reg)
 	mem := store.NewMemoryStore()
+	liveAgentOpts := harnessutil.AgentOptions(provider)
 
 	// Real services.
 	taskSvc := new(TaskService)
@@ -260,26 +260,30 @@ func runPlanDelegate(provider string) error {
 	go notify.Run()
 
 	// Real comms agent (owns notify), registered so delegate reaches it over RPC.
-	comms := agent.New(
+	commsOpts := []agent.Option{
 		agent.Name("comms"),
 		agent.Address("127.0.0.1:0"),
 		agent.Services("notify"),
 		agent.Prompt("You handle outbound notifications. Use the notify service."),
 		agent.Provider(provider), agent.APIKey(apiKey),
 		agent.WithRegistry(reg), agent.WithClient(cl), agent.WithStore(mem),
-	)
+	}
+	commsOpts = append(commsOpts, liveAgentOpts...)
+	comms := agent.New(commsOpts...)
 	go comms.Run()
 	defer comms.Stop()
 
 	// Real conductor agent (owns task), registered so the flow can reach it over RPC.
-	conductor := agent.New(
+	conductorOpts := []agent.Option{
 		agent.Name("conductor"),
 		agent.Address("127.0.0.1:0"),
 		agent.Services("task"),
 		agent.Prompt("You coordinate launch work. Plan first, create tasks, and delegate notifications to the \"comms\" agent."),
 		agent.Provider(provider), agent.APIKey(apiKey),
 		agent.WithRegistry(reg), agent.WithClient(cl), agent.WithStore(mem),
-	)
+	}
+	conductorOpts = append(conductorOpts, liveAgentOpts...)
+	conductor := agent.New(conductorOpts...)
 	go conductor.Run()
 	defer conductor.Stop()
 
@@ -303,6 +307,7 @@ func runPlanDelegate(provider string) error {
 	f := flow.New("zero-to-hero",
 		flow.Agent("conductor"),
 		flow.Prompt("Create three launch tasks (Design, Build, Ship), then make sure owner@acme.com is notified: {{.Data}}"),
+		flow.Timeout(harnessutil.LiveTimeout(provider)),
 	)
 	if err := f.Register(reg, broker.DefaultBroker, cl); err != nil {
 		return fmt.Errorf("flow register: %w", err)

--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -38,11 +38,10 @@ import (
 	"go-micro.dev/v6/agent"
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/broker"
-	"go-micro.dev/v6/client"
 	"go-micro.dev/v6/flow"
 	"go-micro.dev/v6/gateway/a2a"
+	"go-micro.dev/v6/internal/harness/harnessutil"
 	"go-micro.dev/v6/registry"
-	"go-micro.dev/v6/selector"
 	"go-micro.dev/v6/service"
 	"go-micro.dev/v6/store"
 )
@@ -229,8 +228,9 @@ func runUniverse(provider string) int {
 		fmt.Println("broker connect:", err)
 		return 2
 	}
-	cl := client.NewClient(client.Registry(reg), client.Selector(selector.NewSelector(selector.Registry(reg))))
+	cl := harnessutil.Client(provider, reg)
 	st := store.NewMemoryStore()
+	liveAgentOpts := harnessutil.AgentOptions(provider)
 
 	// Services.
 	inv, pay, ord, ntf := new(Inventory), new(Payment), new(Orders), new(Notify)
@@ -243,7 +243,7 @@ func runUniverse(provider string) int {
 	// The concierge agent: guardrails on, plus a tool-execution wrapper
 	// that counts calls — to prove the wrapper seam runs end-to-end.
 	var wrapped int64
-	concierge := agent.New(
+	conciergeOpts := []agent.Option{
 		agent.Name("concierge"),
 		agent.Services("notify"),
 		agent.Prompt("You notify buyers when their order is confirmed."),
@@ -257,7 +257,9 @@ func runUniverse(provider string) int {
 			}
 		}),
 		agent.WithRegistry(reg), agent.WithClient(cl), agent.WithStore(st),
-	)
+	}
+	conciergeOpts = append(conciergeOpts, liveAgentOpts...)
+	concierge := agent.New(conciergeOpts...)
 	go concierge.Run()
 	defer concierge.Stop()
 
@@ -268,6 +270,7 @@ func runUniverse(provider string) int {
 	checkout := flow.New("checkout",
 		flow.Trigger("events.order.placed"),
 		flow.WithCheckpoint(flow.StoreCheckpoint(st, "checkout")),
+		flow.Timeout(harnessutil.LiveTimeout(provider)),
 		flow.Steps(
 			flow.Step{Name: "reserve", Run: flow.Call("inventory", "Inventory.Reserve")},
 			flow.Step{Name: "charge", Run: flow.Call("payment", "Payment.Charge")},


### PR DESCRIPTION
## Summary
- Add shared harness timeout helpers for live-provider runs while leaving mock harness runs on their existing defaults.
- Apply the live timeout to internal harness RPC clients, flow execution deadlines, and agent model/tool calls for plan-delegate, agent-flow, universe, and A2A stream fallback.
- Add unit coverage for mock/default/override timeout behavior.

Closes #3547
Closes #3568

## Testing
- go build ./...
- go test ./... (fails in this sandbox because Envoy forbids loopback gRPC targets in existing grpc tests)
- go test ./internal/harness/harnessutil ./internal/harness/plan-delegate ./internal/harness/agent-flow ./internal/harness/universe ./internal/harness/a2a-stream-fallback
- golangci-lint run ./...