### PR TITLE
docs: lead v6 installs with latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Install the CLI:
 curl -fsSL https://go-micro.dev/install.sh | sh
 
 # Or with Go
-go install go-micro.dev/v6/cmd/micro@v6
+go install go-micro.dev/v6/cmd/micro@latest
 ```
 
 ### Fastest start — no API key

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -26,10 +26,8 @@ Go Micro has three core abstractions:
 curl -fsSL https://go-micro.dev/install.sh | sh
 
 # Or with Go
-go install go-micro.dev/v6/cmd/micro@v6
+go install go-micro.dev/v6/cmd/micro@latest
 ```
-
-> Use `@v6` (not `@latest`). It selects the newest `v6.x.x` release. Plain `@latest` can currently resolve to a stale pre-rename tag through the public module proxy and fail with a "version constraints conflict"; `@v6` avoids that. To pin an exact version use e.g. `@v6.2.0` (see [releases](https://github.com/micro/go-micro/releases)).
 
 ## Quick Start: Generate from a Prompt
 

--- a/internal/website/docs/guides/ai-native-services.md
+++ b/internal/website/docs/guides/ai-native-services.md
@@ -17,7 +17,7 @@ A **task management service** with full CRUD operations that:
 ## Prerequisites
 
 ```bash
-go install go-micro.dev/v6/cmd/micro@v6
+go install go-micro.dev/v6/cmd/micro@latest
 ```
 
 ## Step 1: Create the Service

--- a/internal/website/docs/guides/grpc-compatibility.md
+++ b/internal/website/docs/guides/grpc-compatibility.md
@@ -84,7 +84,7 @@ message Response {
 
 ```bash
 # Install protoc-gen-micro
-go install go-micro.dev/v6/cmd/protoc-gen-micro@v6
+go install go-micro.dev/v6/cmd/protoc-gen-micro@latest
 
 # Generate Go code
 protoc --proto_path=. \
@@ -92,8 +92,6 @@ protoc --proto_path=. \
     --micro_out=. --micro_opt=paths=source_relative \
     proto/helloworld.proto
 ```
-
-> **Note:** Use a specific version instead of `@latest` to avoid module path conflicts. See [releases](https://github.com/micro/go-micro/releases) for the latest version.
 
 ### Server Implementation
 

--- a/internal/website/docs/guides/migration/from-grpc.md
+++ b/internal/website/docs/guides/migration/from-grpc.md
@@ -90,7 +90,7 @@ Update your proto generation:
 
 ```bash
 # Install protoc-gen-micro
-go install go-micro.dev/v6/cmd/protoc-gen-micro@v6
+go install go-micro.dev/v6/cmd/protoc-gen-micro@latest
 
 # Generate both gRPC and Go Micro code
 protoc --proto_path=. \
@@ -100,7 +100,6 @@ protoc --proto_path=. \
   proto/hello.proto
 ```
 
-> **Note:** Use a specific version instead of `@latest` to avoid module path conflicts. See [releases](https://github.com/micro/go-micro/releases) for the latest version.
 
 This generates:
 - `hello.pb.go` - Protocol Buffers types

--- a/internal/website/docs/guides/migration/v5-to-v6.md
+++ b/internal/website/docs/guides/migration/v5-to-v6.md
@@ -32,7 +32,7 @@ go mod tidy
 Update the CLI too:
 
 ```bash
-go install go-micro.dev/v6/cmd/micro@v6
+go install go-micro.dev/v6/cmd/micro@latest
 ```
 
 ## 2. TLS is verified by default

--- a/internal/website/docs/quickstart.md
+++ b/internal/website/docs/quickstart.md
@@ -13,10 +13,8 @@ curl -fsSL https://go-micro.dev/install.sh | sh
 Or, if you have Go and prefer to build from source:
 
 ```bash
-go install go-micro.dev/v6/cmd/micro@v6
+go install go-micro.dev/v6/cmd/micro@latest
 ```
-
-> **Note:** Use `@v6` (not `@latest`) — it resolves to the newest `v6.x.x` release. Plain `@latest` can currently resolve to a stale pre-rename tag through the public module proxy and fail with a "version constraints conflict"; `@v6` avoids that. To pin an exact version use e.g. `@v6.2.0` (see [releases](https://github.com/micro/go-micro/releases)).
 
 ## Create Your First Service
 

--- a/internal/website/docs/server.md
+++ b/internal/website/docs/server.md
@@ -28,10 +28,8 @@ For local development, use [`micro run`](guides/micro-run.html) instead.
 Install the CLI which includes the server command:
 
 ```bash
-go install go-micro.dev/v6/cmd/micro@v6
+go install go-micro.dev/v6/cmd/micro@latest
 ```
-
-> **Note:** Use a specific version instead of `@latest` to avoid module path conflicts. See [releases](https://github.com/micro/go-micro/releases) for the latest version.
 
 ## Run
 


### PR DESCRIPTION
## Summary
- Update README and website docs to lead Go-based v6 CLI installs with `@latest`.
- Remove stale warnings that told users to avoid `@latest` because the phantom-module retraction now lets the install resolve cleanly.
- Align protoc-gen-micro install examples with the same `@latest` guidance.

## Verification
- `GOBIN=$(mktemp -d) go install go-micro.dev/v6/cmd/micro@latest`
- `go build ./...`
- `go test ./...` (fails in this environment because loopback gRPC dials are blocked by envoy: "Loopback targets forbidden")
- `golangci-lint run ./...`

Closes #3565
Closes #3578