### PR TITLE
loop: have DevRel maintain CHANGELOG.md and draft a changelog blog post

### DIFF
--- a/.github/workflows/loop-devrel.yml
+++ b/.github/workflows/loop-devrel.yml
@@ -6,10 +6,16 @@ name: "Loop: DevRel"
 # code; this keeps the story coherent: docs/website aligned, README crisp, and
 # a steady supply of things worth blogging about.
 #
+# It also keeps the CHANGELOG living: each run reconciles the `[Unreleased]`
+# section of CHANGELOG.md against what actually merged (rolling it into a dated
+# version heading whenever a new tag was cut), and — when enough has shipped —
+# drafts a "what's new" changelog blog post narrating it.
+#
 # Like the increment loop it opens a fresh issue and dispatches Codex via
 # CODEX_TRIGGER_TOKEN (Codex ignores Actions-bot comments). Autonomy boundary:
-# SAFE factual-alignment and crispness fixes auto-merge; brand/positioning copy
-# and blog drafts are surfaced in the report for the human, never auto-merged.
+# SAFE factual-alignment and crispness fixes — including CHANGELOG.md upkeep —
+# auto-merge; brand/positioning copy and the changelog blog post are opened as a
+# PR but left for the human to review/merge (blog voice stays with the human).
 
 on:
   workflow_dispatch: {}
@@ -40,8 +46,16 @@ jobs:
           fi
           ISSUE_URL=$(gh issue create --repo "$REPO" \
             --title "DevRel coherence review #$RUN_NUMBER" \
-            --body "Daily DevRel / coherence pass over README, website (landing + docs), and the blog. North Star: internal/docs/THESIS.md.")
+            --body "Daily DevRel / coherence pass over README, website (landing + docs), and the blog, plus CHANGELOG.md upkeep and a changelog blog post. North Star: internal/docs/THESIS.md.")
           ISSUE_NUM="${ISSUE_URL##*/}"
           echo "Opened issue #$ISSUE_NUM — dispatching Codex (DevRel)."
           gh issue comment "$ISSUE_NUM" --repo "$REPO" --body \
-          "@codex Act as DevRel for go-micro. Audit the PUBLIC surface — \`README.md\`, \`internal/website/\` (landing \`index.html\` + \`docs/\`), and the blog under \`internal/website/blog/\` — for coherence with the North Star in internal/docs/THESIS.md (an agent harness and service framework; the services → agents → workflows lifecycle). Look for: (1) places where README / website / docs contradict each other, are stale, or describe behavior that has since changed (cross-check against the code and recent merged PRs / CHANGELOG.md); (2) whether the README is crisp and leads with the harness positioning; (3) one to three genuinely blog-worthy items from recently shipped work. Then do BOTH of these: (A) post a concise findings report as a comment on this issue (#$ISSUE_NUM) — what is aligned, what drifted, what you fixed, and the blog ideas; (B) for SAFE factual-alignment and crispness fixes only (NOT brand/marketing/positioning rewrites), open one PR: \`git switch -c codex/devrel-$ISSUE_NUM\`, \`git push -u origin codex/devrel-$ISSUE_NUM\`, \`gh pr create --base master --label codex --title \"<title>\" --body \"<summary, including 'Closes #$ISSUE_NUM'>\"\`, then \`gh pr merge --squash --auto --delete-branch\`. Leave brand/positioning copy and blog drafts for the human — describe them in the report, do NOT open auto-merging PRs for them. Do not use the make_pr tool (it is a no-op stub). If you touch code, verify go build/test/golangci-lint. Stay out of breaking public-API changes."
+          "@codex Act as DevRel for go-micro. Do FOUR things this run.
+
+          COHERENCE AUDIT. Audit the PUBLIC surface — \`README.md\`, \`internal/website/\` (landing \`index.html\` + \`docs/\`), and the blog under \`internal/website/blog/\` — for coherence with the North Star in internal/docs/THESIS.md (an agent harness and service framework; the services → agents → workflows lifecycle). Look for: (1) places where README / website / docs contradict each other, are stale, or describe behavior that has since changed (cross-check against the code and recent merged PRs); (2) whether the README is crisp and leads with the harness positioning; (3) one to three genuinely blog-worthy items from recently shipped work.
+
+          CHANGELOG UPKEEP (this is a SAFE factual task — it goes in the auto-merged PR). Keep CHANGELOG.md living, in [Keep a Changelog](https://keepachangelog.com/) format with the newest content at the top under \`## [Unreleased]\`. (a) Enumerate PRs merged to master since the last CHANGELOG update — \`gh pr list --repo $REPO --state merged --base master --limit 60 --json number,title,mergedAt,labels\` — and compare against what CHANGELOG.md already lists. (b) For each genuinely user-facing change not yet recorded (new capability, behavior/API change, notable fix — SKIP purely internal loop/CI/priorities-refresh churn), add a concise entry under the right \`### Added\` / \`### Changed\` / \`### Fixed\` / \`### Documentation\` subheading of \`## [Unreleased]\`, phrased for a user (what it does, which package), not a commit subject. (c) If a new \`v6.MINOR.PATCH\` tag has been cut since the last run (\`git fetch --tags --force\`; compare the newest \`v6.*\` tag to the versions already in CHANGELOG.md), RENAME the current \`## [Unreleased]\` heading to \`## [MINOR.PATCH] - <Month YYYY>\` for that tag and open a fresh empty \`## [Unreleased]\` above it. Keep it accurate — do not invent entries; if nothing user-facing merged, leave [Unreleased] as-is.
+
+          CHANGELOG BLOG POST (blog voice — open a PR but do NOT auto-merge; leave it for the human). If — and only if — enough user-facing work has accumulated since the last changelog post to be worth reading (a meaningful batch, roughly a week's worth; do NOT post an almost-empty update every day), draft a short 'What's new in Go Micro' post that narrates what shipped in plain language (grouped by theme, linking the docs/examples, closing with install/upgrade). Create it as the next-numbered file in \`internal/website/blog/\` (find the highest N, use N+1), mirroring the frontmatter (layout/title/permalink/description) and the post-nav 'previous post' link of the latest existing post, and add an entry at the TOP of \`internal/website/blog/index.html\`. Base it strictly on the CHANGELOG — no speculation.
+
+          THEN do all of these: (A) post a concise findings report as a comment on this issue (#$ISSUE_NUM) — what is aligned, what drifted, what you fixed, the CHANGELOG entries you added, whether you drafted a changelog post (and why / why not), and any other blog ideas. (B) Open ONE auto-merging PR for the SAFE factual work only — coherence/crispness fixes AND the CHANGELOG.md update (NOT brand/marketing/positioning rewrites, NOT the blog post): \`git switch -c codex/devrel-$ISSUE_NUM\`, \`git push -u origin codex/devrel-$ISSUE_NUM\`, \`gh pr create --base master --label codex --title \"<title>\" --body \"<summary, including 'Closes #$ISSUE_NUM'>\"\`, then \`gh pr merge --squash --auto --delete-branch\`. (C) If you drafted a changelog blog post, open it as a SEPARATE PR on its own branch (\`codex/devrel-blog-$ISSUE_NUM\`) with a title prefixed 'blog:' and do NOT enable auto-merge — leave it open for the human to review and merge. Do the same (separate, non-auto-merged PR or just a report note) for any brand/positioning copy. Do not use the make_pr tool (it is a no-op stub). If you touch code, verify go build/test/golangci-lint. Stay out of breaking public-API changes."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,33 @@
 
 All notable changes to Go Micro are documented here.
 
-Format follows [Keep a Changelog](https://keepachangelog.com/). Go Micro uses
-calendar-based versions (YYYY.MM) for the AI-native era.
+Format follows [Keep a Changelog](https://keepachangelog.com/) and versions
+follow [Semantic Versioning](https://semver.org/), matching the git tags and
+[GitHub releases](https://github.com/micro/go-micro/releases) (`v6.MINOR.PATCH`).
+Patch releases are cut automatically as the loop merges improvements; the
+`[Unreleased]` section below is kept current between tags and rolled into the
+next version when it ships.
+
+> Earlier `2026.0x` headings are historical calendar-style markers from before
+> v6 tagging; they are kept for continuity and not reused.
+
+---
+
+## [Unreleased]
+
+### Added
+- **Retrieval-backed agent memory** — agents can recall relevant prior turns by similarity, not just the recent window, with a summarizer hook that compacts older history so long conversations stay in budget. (`agent/`)
+- **Scheduled flows** — a flow can run an agent (or any step) on a cron-style schedule, with the dispatch traced end to end. (`flow/`)
+- **Flow verification/grader loop** — a workflow can grade its own step output against a rubric and retry until it passes, plus run-trace analysis to surface where a flow spends its time. (`flow/`)
+- **A2A streaming & continuity** — outbound agent streaming flows through the A2A binding (`message/stream`), with `tasks/resubscribe` and `input-required` handoffs for multi-turn interop. (`gateway/a2a/`)
+
+### Changed
+- **Agent tool-call resilience** — opt-in retries around agent tool calls, and a fallback that executes tool calls emitted as text by weaker models so they still make progress. (`agent/`)
+- **Hardened agent durability** — terminal failure statuses are classified and surfaced, and durable resume-after-restart is covered by tests. (`agent/`)
+
+### Documentation
+- **"Your first agent" walkthrough** and a canonical 0-to-hero reference path, lowering the on-ramp from install to a running agent. (`internal/website/docs/`)
+- **Discord** linked prominently across the README, website nav/footer, and docs. (`https://discord.gg/G8Gk5j3uXr`)
 
 ---
 

--- a/internal/docs/CONTINUOUS_IMPROVEMENT.md
+++ b/internal/docs/CONTINUOUS_IMPROVEMENT.md
@@ -23,7 +23,7 @@ Actions instead of subagents. Each role is a workflow:
 | **Generator** | `loop-builder.yml` — *Loop: Builder (Generator)* | Builds the top open queue item as a single-concern PR (via Codex) and self-merges on green CI. Does the work. |
 | **Evaluator** | `harness.yml` — *Harness (E2E)*, plus the CI gate (`tests.yaml`, `lint.yaml`) | Grades every change: the mock harness + unit/lint on each push/PR, and real-model conformance hourly. A *separate* grader — never the generator judging itself. |
 | **Evaluator → feedback** | `loop-triage.yml` — *Loop: Triage (Evaluator feedback)* | On harness failure, root-causes, dedupes, and files scoped fix issues back into the planner's queue. The hill-climbing feedback path. |
-| **Coherence** | `loop-devrel.yml` — *Loop: DevRel* | Keeps README/website/docs/blog aligned with the North Star. |
+| **Coherence** | `loop-devrel.yml` — *Loop: DevRel* | Keeps README/website/docs/blog aligned with the North Star, keeps `CHANGELOG.md` living (reconciling `[Unreleased]` against merged PRs and rolling it into version headings as tags cut), and drafts the changelog blog post. |
 | **Release** | `loop-release.yml` — *Loop: Release (daily patch)* | Cuts a daily patch tag when master has new commits, so the *installable* framework tracks the loop's improvements (triggers `release.yml`/goreleaser). Minor/major bumps stay with the human. |
 
 Generation is separated from evaluation on purpose: an agent grading its own work
@@ -149,10 +149,17 @@ output) but produce direction and coherence, not just code.
 
 - **DevRel — daily** (`.github/workflows/loop-devrel.yml`). Audits the public
   surface (README, website landing + docs, blog) for coherence with the North
-  Star, README crispness, and blog-worthy material. **Autonomy boundary:** safe
-  factual-alignment and crispness fixes auto-merge like any increment;
-  brand/positioning copy and blog drafts are *surfaced in a report* for the
-  human, never auto-merged.
+  Star, README crispness, and blog-worthy material. It also keeps `CHANGELOG.md`
+  living: each run reconciles the `[Unreleased]` section against the PRs that
+  actually merged (Keep-a-Changelog format, user-facing entries only — internal
+  loop/CI churn is skipped), and rolls `[Unreleased]` into a dated version
+  heading whenever a new `v6.MINOR.PATCH` tag has been cut (by `loop-release`).
+  When enough user-facing work has accumulated (roughly weekly, not a near-empty
+  post every day) it also drafts a "what's new" changelog blog post narrating it.
+  **Autonomy boundary:** safe factual-alignment and crispness fixes — *including
+  the `CHANGELOG.md` upkeep* — auto-merge like any increment; brand/positioning
+  copy and the changelog blog post are opened as a PR (or surfaced in the report)
+  and left for the human to review/merge — blog voice stays with the human.
 - **Architect — continuous (hourly)** (`.github/workflows/loop-architect.yml`).
   The *founder lens*, running alongside the builders. Each run it **tracks live
   state** (what just merged, what's in flight), **prioritizes the roadmap**


### PR DESCRIPTION
## What

Makes the daily DevRel loop keep `CHANGELOG.md` living and produce a changelog blog post, so the framework's shipped history stays current instead of drifting.

### DevRel loop (`loop-devrel.yml`)
The daily coherence pass now does two more things:
- **CHANGELOG upkeep (auto-merged).** Each run reconciles a Keep-a-Changelog `## [Unreleased]` section against the PRs that actually merged to master — user-facing entries only, internal loop/CI/priorities churn skipped — and rolls `[Unreleased]` into a dated `## [MINOR.PATCH]` heading whenever `loop-release` cuts a new `v6.*` tag. This is a safe factual change, so it rides the existing auto-merged DevRel PR.
- **Changelog blog post (drafted, not auto-merged).** When enough user-facing work has accumulated (roughly a week's worth — deliberately *not* a near-empty post every day), it drafts a "What's new in Go Micro" post as the next-numbered `blog/N.md` + index entry, and opens it as a **separate PR left for the human to merge**. Blog voice stays with the human, consistent with the existing autonomy boundary.

### CHANGELOG.md fixes
The preamble claimed calendar versions (`YYYY.MM`) while every tag is semver (`v6.MINOR.PATCH`), and the newest entry was `[6.0.0]` with 40+ merges since. Corrected the preamble to semver, seeded a real `## [Unreleased]` section from actual recent work (retrieval memory, scheduled flows, flow grader loop, A2A streaming/continuity, tool-call resilience, first-agent docs, Discord), and marked the old `2026.0x` headings as historical.

### Docs
Updated `internal/docs/CONTINUOUS_IMPROVEMENT.md` (pipeline table + DevRel overseer section) to describe the new CHANGELOG/blog responsibilities and reaffirm the autonomy boundary.

## Why
The changelog had gone stale and was factually wrong about its own versioning scheme. Tying its upkeep to the DevRel loop — which already audits the public surface daily — keeps it accurate automatically, and gives releases a human-readable narrative without adding a human chore.

## Notes
- No code changes; workflow + docs + changelog only. `loop-devrel.yml` YAML validated.
- Takes effect on the next DevRel run (07:00 UTC or manual dispatch); the seeded `[Unreleased]` section is live now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_