### PR TITLE
docs: surface runnable lifecycle examples

### DIFF
--- a/internal/website/docs/examples/index.md
+++ b/internal/website/docs/examples/index.md
@@ -4,14 +4,44 @@ layout: default
 
 # Learn by Example
 
-A collection of small, focused examples demonstrating common patterns with Go Micro.
+Runnable examples are the fastest way to move from reading the guides to changing
+one thing. Start with the path that matches where you are in the services →
+agents → workflows lifecycle.
 
-- [Hello Service](hello-service.md)
-- [RPC Client](rpc-client.md)
-- [Pub/Sub with NATS Broker](pubsub-nats.md)
-- [Service Discovery with Consul](registry-consul.md)
-- [State with Postgres Store](store-postgres.md)
-- [NATS Transport](transport-nats.md)
+## Start here
+
+| Goal | Runnable example | Why it is useful |
+| --- | --- | --- |
+| 0→1 service | [`examples/hello-world`](https://github.com/micro/go-micro/tree/master/examples/hello-world) | Smallest RPC service with a client call and health checks. |
+| First service-backed agent | [`examples/agent-demo`](https://github.com/micro/go-micro/tree/master/examples/agent-demo) | Multi-service project/task/team app with agent playground integration. |
+| 0→hero lifecycle | [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support) | No-secret support-desk story: typed services, an agent, an event-driven flow, and a guardrail. |
+| Planning and delegation | [`examples/agent-plan-delegate`](https://github.com/micro/go-micro/tree/master/examples/agent-plan-delegate) | Two agents collaborate through `plan` and `delegate` over normal Go Micro RPC. |
+| Durable workflows | [`examples/flow-durable`](https://github.com/micro/go-micro/tree/master/examples/flow-durable) | Ordered, checkpointed flow steps resume without duplicating completed side effects. |
+| AI-callable services | [`examples/mcp`](https://github.com/micro/go-micro/tree/master/examples/mcp) | MCP examples that expose service endpoints as model tools. |
+
+## Guide-to-example map
+
+- [Getting Started](../getting-started.html) → run
+  [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support)
+  to see the full lifecycle before generating your own service.
+- [Your First Agent](../guides/your-first-agent.html) → run
+  [`examples/agent-demo`](https://github.com/micro/go-micro/tree/master/examples/agent-demo)
+  or [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support)
+  when you want a complete service-backed agent to inspect.
+- [0→hero Reference](../guides/zero-to-hero.html) → run
+  [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support)
+  for the human-readable scenario, then `make harness` for the full CI contract.
+- [Plan & Delegate](../guides/plan-delegate.html) → run
+  [`examples/agent-plan-delegate`](https://github.com/micro/go-micro/tree/master/examples/agent-plan-delegate).
+- [Agents and Workflows](../guides/agents-and-workflows.html) → run
+  [`examples/flow-durable`](https://github.com/micro/go-micro/tree/master/examples/flow-durable)
+  and [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support).
+
+## Repository examples
+
+See the repository [examples index](https://github.com/micro/go-micro/tree/master/examples)
+for the complete runnable list, including deployment, auth, gRPC interop, MCP,
+agent, and flow examples.
 
 ## More
 

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -31,6 +31,16 @@ go install go-micro.dev/v6/cmd/micro@latest
 
 ## Quick Start: Generate from a Prompt
 
+Prefer to start from a runnable reference? Clone the repository and run the maintained support-desk lifecycle example first:
+
+```bash
+git clone https://github.com/micro/go-micro.git
+cd go-micro
+go run ./examples/support
+```
+
+That example is the no-secret 0→hero path: services expose ticket/customer/notification tools, an agent handles the work, and an event-driven flow triggers the agent. See [Learn by Example](examples/) when you want more runnable starting points.
+
 Describe what you need. The AI designs services, writes handlers, compiles, and starts them:
 
 ```bash
@@ -134,7 +144,7 @@ micro new gateway --template api
 
 ## Building Agents
 
-For a complete service-backed walkthrough, start with [Your First Agent](guides/your-first-agent.html).
+For a complete service-backed walkthrough, start with [Your First Agent](guides/your-first-agent.html). If you want to run before you write, use [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support) for the full services → agents → workflows lifecycle or [`examples/agent-plan-delegate`](https://github.com/micro/go-micro/tree/master/examples/agent-plan-delegate) for the smallest multi-agent planning/delegation path.
 
 An Agent is an intelligent layer that manages one or more services:
 
@@ -219,6 +229,8 @@ The flow discovers all services as tools and lets the LLM decide which RPCs to c
 
 ## Next Steps
 
+- [Learn by Example](examples/) — runnable examples mapped to services, agents, and workflows
+- [0→hero Reference](guides/zero-to-hero.html) — the maintained no-secret lifecycle contract
 - [AI Integration](ai-integration.html) — how services, agents, MCP, and LLMs fit together
 - [Agent Design](https://github.com/micro/go-micro/blob/master/internal/docs/AGENT_DESIGN.md) — the full agent interface specification
 - [MCP & AI Agents](mcp.html) — MCP gateway, tool discovery, and auth

--- a/internal/website/docs/guides/your-first-agent.md
+++ b/internal/website/docs/guides/your-first-agent.md
@@ -11,6 +11,16 @@ the services → agents → workflows lifecycle: build capability first, add
 intelligence on top, then keep a clear path toward flows when the work needs to
 run on events or schedules.
 
+## Runnable reference first
+
+If you want to run the lifecycle before copying code, start with the maintained support-desk example from the repository root:
+
+```sh
+go run ./examples/support
+```
+
+It uses a deterministic mock model by default, so it needs no provider key, and it exercises the same shape this guide teaches: services become tools, an agent uses them, and a flow can trigger the work. Use this guide when you are ready to build the smaller 0→1 version yourself.
+
 ## What you'll build
 
 A tiny task assistant:
@@ -201,6 +211,7 @@ agent for judgment, tool use, and handoffs when the path is not known up front.
 
 - Read the [0→hero reference path](zero-to-hero.html) for the CI-verified
   lifecycle contract.
+- Run [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support) for the no-secret 0→hero support-desk lifecycle.
 - Run [`examples/agent-plan-delegate`](https://github.com/micro/go-micro/tree/master/examples/agent-plan-delegate)
   to see planning and delegation across agents.
 - Read [Agents and Workflows](agents-and-workflows.html) when you are ready to

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -24,6 +24,16 @@ cloud credentials?"
 | Deploy | `micro deploy --dry-run` resolves deploy targets without touching remote infrastructure. | `go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1` |
 | Runtime | Real services, agents, durable flows, store-backed history, delegation, and A2A run with only the model mocked. | `./internal/harness/zero-to-hero-ci/run.sh` and `make provider-conformance-mock` |
 
+## Run the runnable example
+
+From the repository root, start with the support-desk example when you want to see the full lifecycle in one terminal:
+
+```sh
+go run ./examples/support
+```
+
+It starts typed services, a support agent, an event-driven intake flow, and an approval gate with a deterministic mock model. Change one service method, agent prompt, or guardrail decision and run it again to learn the system by modifying a working path.
+
 ## Run the whole no-secret path
 
 From the repository root:
@@ -61,6 +71,11 @@ make provider-conformance-mock
 
 ## Reference scenarios
 
+- [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support)
+  is the runnable support-desk story: customers, tickets, notify, a support
+  agent, an intake flow, and an approval gate in one no-secret example.
+- [`examples/agent-plan-delegate`](https://github.com/micro/go-micro/tree/master/examples/agent-plan-delegate)
+  is the smallest runnable planning/delegation example for multiple agents.
 - [`internal/harness/plan-delegate`](https://github.com/micro/go-micro/tree/master/internal/harness/plan-delegate)
   is the compact 0→hero scenario: real task and notify services, a conductor
   agent, a comms agent, plan persistence, delegation, and a workflow handoff.


### PR DESCRIPTION
## Summary
- Link getting-started and first-agent docs to runnable support and plan/delegate examples.
- Expand the docs examples index with a guide-to-example map for the services → agents → workflows lifecycle.
- Add the support-desk example to the 0→hero reference path as the run-before-read entry point.

## Testing
- go build ./...
- go test ./... (fails in this sandbox: loopback gRPC tests are blocked by the environment, and internal/harness/plan-delegate currently duplicates the flow dispatch)
- golangci-lint run ./... --timeout=10m

Closes #3562
Closes #3583