### PR TITLE
docs: lead guides nav with hands-on path

### DIFF
--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -38,6 +38,39 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 	}
 }
 
+func TestGuidesNavigationLeadsWithDoing(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	nav := readFile(t, filepath.Join(root, "internal", "website", "_data", "navigation.yml"))
+
+	orderedGuides := []string{
+		"/docs/guides/your-first-agent.html",
+		"/docs/guides/zero-to-hero.html",
+		"/docs/guides/plan-delegate.html",
+		"/docs/guides/agent-guardrails.html",
+		"/docs/guides/agents-and-workflows.html",
+		"/docs/guides/agent-patterns.html",
+		"/docs/guides/agent-harness.html",
+		"/docs/guides/agent-loops.html",
+	}
+
+	last := -1
+	for _, guide := range orderedGuides {
+		idx := strings.Index(nav, guide)
+		if idx == -1 {
+			t.Fatalf("website navigation does not expose %s", guide)
+		}
+		if idx < last {
+			t.Fatalf("website navigation should lead with hands-on guides; %s appeared out of order", guide)
+		}
+		last = idx
+
+		doc := strings.TrimPrefix(strings.TrimSuffix(guide, ".html"), "/docs/") + ".md"
+		if _, err := os.Stat(filepath.Join(root, "internal", "website", "docs", doc)); err != nil {
+			t.Fatalf("navigation links to missing guide %s: %v", guide, err)
+		}
+	}
+}
+
 func readFile(t *testing.T, name string) string {
 	t.Helper()
 	data, err := os.ReadFile(name)

--- a/internal/website/_data/navigation.yml
+++ b/internal/website/_data/navigation.yml
@@ -32,28 +32,32 @@ examples:
   - title: Real-World Examples
     url: /docs/examples/realworld/
 guides:
+  - title: Your First Agent
+    url: /docs/guides/your-first-agent.html
   - title: 0→hero Reference
     url: /docs/guides/zero-to-hero.html
-  - title: The Agent Harness
-    url: /docs/guides/agent-harness.html
-  - title: Agents and Workflows
-    url: /docs/guides/agents-and-workflows.html
-  - title: Agent Loops
-    url: /docs/guides/agent-loops.html
   - title: Plan & Delegate
     url: /docs/guides/plan-delegate.html
   - title: Agent Guardrails
     url: /docs/guides/agent-guardrails.html
-  - title: Payments (x402)
-    url: /docs/guides/x402-payments.html
+  - title: Agents and Workflows
+    url: /docs/guides/agents-and-workflows.html
+  - title: Agent Integration Patterns
+    url: /docs/guides/agent-patterns.html
+  - title: The Agent Harness
+    url: /docs/guides/agent-harness.html
+  - title: Agent Loops
+    url: /docs/guides/agent-loops.html
   - title: Agent2Agent (A2A)
     url: /docs/guides/a2a-protocol.html
-  - title: Atlas Cloud Integration
-    url: /docs/guides/atlascloud-integration.html
   - title: AI Provider Guide
     url: /docs/guides/ai-provider-guide.html
   - title: Provider Conformance
     url: /docs/guides/provider-conformance.html
+  - title: Atlas Cloud Integration
+    url: /docs/guides/atlascloud-integration.html
+  - title: Payments (x402)
+    url: /docs/guides/x402-payments.html
   - title: Comparison
     url: /docs/guides/comparison.html
   - title: Migration Guides


### PR DESCRIPTION
## Summary
- Reordered the guides navigation so hands-on agent-building docs lead before conceptual docs.
- Added the existing Agent Integration Patterns guide to the guides navigation.
- Added a regression test that verifies the build-first guide order and linked guide files.

## Testing
- `go build ./...` ✅
- `go test ./...` ⚠️ failed in sandbox on pre-existing/environment-sensitive tests: cache expiration timing plus loopback targets forbidden in gRPC client/transport tests; the changed docs test package passed as part of the run.
- `golangci-lint run ./...` ✅

Closes #3563
Closes #3590
