### PR TITLE
docs: expose the 0-to-hero on-ramp

### DIFF
--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -80,6 +80,8 @@ The console discovers services from the registry and orchestrates across them vi
 
 If the agent surprises you while iterating, use the [Debugging your agent](guides/debugging-agents.html) guide to inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs.
 
+When you are ready to prove the whole path end to end, follow the [0→hero reference path](guides/zero-to-hero.html). It is the canonical handoff from this quick start: scaffold a service, run it locally, chat with an agent, inspect durable agent/flow history, and finish with `micro deploy --dry-run` using the same commands exercised by `make harness`.
+
 ## Quick Start: Write a Service
 
 Create and run a service manually:

--- a/internal/website/docs/index.md
+++ b/internal/website/docs/index.md
@@ -16,13 +16,14 @@ It's built on a pluggable architecture of Go interfaces: service discovery, clie
 
 ## Learn More
 
-To get started follow the getting started guide. 
-Otherwise continue to read the docs for more information 
-about the framework.
+Start with [Getting Started](getting-started.html) for install and the first local service. If you want the full services → agents → workflows on-ramp in one walkable sequence, use the [0→hero reference path](guides/zero-to-hero.html): it links the exact scaffold, run, chat, inspect, and deploy dry-run commands covered by CI.
+
+Otherwise continue to read the docs for more information about the framework.
 
 ## Contents
 
 - [Getting Started](getting-started.html)
+- [0→hero Reference](guides/zero-to-hero.html) - Walk scaffold → run → chat → inspect → deploy dry-run with CI-backed commands
 - [Your First Agent](guides/your-first-agent.html) - Build a service-backed agent end to end
 - [MCP & AI Agents](mcp.html) - Turn services into AI-callable tools with the Model Context Protocol
 - [CLI & Gateway Guide](guides/cli-gateway.html) - Development vs Production modes
@@ -45,6 +46,7 @@ about the framework.
 
 ## AI & Agents
 
+- [0→hero Reference](guides/zero-to-hero.html) - Walk scaffold → run → chat → inspect → deploy dry-run with CI-backed commands
 - [Your First Agent](guides/your-first-agent.html) - Build a service-backed agent end to end
 - [Building AI-Native Services](guides/ai-native-services.html) - End-to-end tutorial for MCP-enabled services
 - [MCP Security Guide](guides/mcp-security.html) - Auth, scopes, rate limiting, and audit logging


### PR DESCRIPTION
Summary:
- Link the docs landing page directly to the 0→hero reference path so the scaffold → run → chat → inspect → deploy dry-run flow is discoverable.
- Add a Getting Started handoff to the canonical CI-backed 0→hero guide after the first runnable agent path.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback gRPC tests are blocked by the sandbox/proxy: "Loopback targets forbidden")
- golangci-lint run ./...
- go test ./internal/harness/zero-to-hero-ci ./internal/website/docs/guides

Closes #3598
Closes #3601