### PR TITLE
cli: add first-agent preflight diagnostics

### DIFF
--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -37,6 +37,14 @@ func init() {
 		Usage: "Manage AI agents",
 		Subcommands: []*cli.Command{
 			{
+				Name:    "preflight",
+				Aliases: []string{"doctor"},
+				Usage:   "Check local prerequisites before the first provider-backed agent",
+				Action: func(c *cli.Context) error {
+					return runAgentPreflight(os.Stdout, defaultPreflightDeps())
+				},
+			},
+			{
 				Name:  "list",
 				Usage: "List registered agents",
 				Action: func(c *cli.Context) error {

--- a/cmd/micro/cli/agent/preflight.go
+++ b/cmd/micro/cli/agent/preflight.go
@@ -1,0 +1,140 @@
+package agent
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+
+	"go-micro.dev/v6/cmd"
+)
+
+type preflightCheck struct {
+	Name   string
+	OK     bool
+	Detail string
+	Fix    string
+}
+
+type preflightDeps struct {
+	lookPath      func(string) (string, error)
+	commandOutput func(string, ...string) ([]byte, error)
+	executable    func() (string, error)
+	version       func() string
+	getenv        func(string) string
+	listen        func(string, string) (net.Listener, error)
+}
+
+func defaultPreflightDeps() preflightDeps {
+	return preflightDeps{
+		lookPath:      exec.LookPath,
+		commandOutput: func(name string, args ...string) ([]byte, error) { return exec.Command(name, args...).CombinedOutput() },
+		executable:    os.Executable,
+		version:       func() string { return cmd.App().Version },
+		getenv:        os.Getenv,
+		listen:        net.Listen,
+	}
+}
+
+func runAgentPreflight(w io.Writer, deps preflightDeps) error {
+	checks := agentPreflightChecks(deps)
+	failures := 0
+	fmt.Fprintln(w, "First-agent preflight")
+	for _, check := range checks {
+		mark := "✓"
+		if !check.OK {
+			mark = "✗"
+			failures++
+		}
+		fmt.Fprintf(w, "  %s %s — %s\n", mark, check.Name, check.Detail)
+		if !check.OK && check.Fix != "" {
+			fmt.Fprintf(w, "    Fix: %s\n", check.Fix)
+		}
+	}
+	if failures > 0 {
+		return fmt.Errorf("first-agent preflight failed: %d check(s) need attention", failures)
+	}
+	fmt.Fprintln(w, "\nReady for the first-agent walkthrough: micro run, then open http://localhost:8080/agent or use micro chat.")
+	return nil
+}
+
+func agentPreflightChecks(deps preflightDeps) []preflightCheck {
+	if deps.lookPath == nil {
+		deps.lookPath = exec.LookPath
+	}
+	if deps.commandOutput == nil {
+		deps.commandOutput = func(name string, args ...string) ([]byte, error) { return exec.Command(name, args...).CombinedOutput() }
+	}
+	if deps.executable == nil {
+		deps.executable = os.Executable
+	}
+	if deps.version == nil {
+		deps.version = func() string { return cmd.App().Version }
+	}
+	if deps.getenv == nil {
+		deps.getenv = os.Getenv
+	}
+	if deps.listen == nil {
+		deps.listen = net.Listen
+	}
+
+	checks := []preflightCheck{checkGoToolchain(deps), checkMicroBinary(deps), checkProviderKey(deps), checkPortAvailable(deps, ":8080", "micro run gateway and /agent playground")}
+	return checks
+}
+
+func checkGoToolchain(deps preflightDeps) preflightCheck {
+	path, err := deps.lookPath("go")
+	if err != nil {
+		return preflightCheck{Name: "Go toolchain", Fix: "Install Go 1.24 or newer and ensure go is on PATH."}
+	}
+	out, err := deps.commandOutput("go", "version")
+	if err != nil {
+		return preflightCheck{Name: "Go toolchain", Detail: strings.TrimSpace(string(out)), Fix: "Ensure the go command runs successfully."}
+	}
+	return preflightCheck{Name: "Go toolchain", OK: true, Detail: fmt.Sprintf("%s (%s)", firstLine(out), path)}
+}
+
+func checkMicroBinary(deps preflightDeps) preflightCheck {
+	exe, err := deps.executable()
+	if err != nil || exe == "" {
+		return preflightCheck{Name: "micro binary", Fix: "Install the micro CLI or run this check through go run ./cmd/micro agent preflight."}
+	}
+	version := deps.version()
+	if version == "" {
+		version = "version unavailable"
+	}
+	return preflightCheck{Name: "micro binary", OK: true, Detail: fmt.Sprintf("%s (%s)", version, exe)}
+}
+
+func checkProviderKey(deps preflightDeps) preflightCheck {
+	keys := []string{"MICRO_AI_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY", "TOGETHER_API_KEY", "ATLASCLOUD_API_KEY"}
+	var found []string
+	for _, k := range keys {
+		if deps.getenv(k) != "" {
+			found = append(found, k)
+		}
+	}
+	if len(found) == 0 {
+		return preflightCheck{Name: "provider API key", Detail: "no supported provider key found", Fix: "Export MICRO_AI_API_KEY or a provider key such as ANTHROPIC_API_KEY before running provider-backed agents."}
+	}
+	return preflightCheck{Name: "provider API key", OK: true, Detail: "found " + strings.Join(found, ", ")}
+}
+
+func checkPortAvailable(deps preflightDeps, addr, use string) preflightCheck {
+	ln, err := deps.listen("tcp", addr)
+	if err != nil {
+		return preflightCheck{Name: "local port " + addr, Detail: "busy or unavailable for " + use, Fix: "Stop the process using " + addr + " or run micro run --address with a free port."}
+	}
+	_ = ln.Close()
+	return preflightCheck{Name: "local port " + addr, OK: true, Detail: "available for " + use}
+}
+
+func firstLine(b []byte) string {
+	s := strings.TrimSpace(string(b))
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/cmd/micro/cli/agent/preflight_test.go
+++ b/cmd/micro/cli/agent/preflight_test.go
@@ -1,0 +1,78 @@
+package agent
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+type stubListener struct{}
+
+func (stubListener) Accept() (net.Conn, error) { return nil, errors.New("closed") }
+func (stubListener) Close() error              { return nil }
+func (stubListener) Addr() net.Addr            { return stubAddr(":8080") }
+
+type stubAddr string
+
+func (a stubAddr) Network() string { return "tcp" }
+func (a stubAddr) String() string  { return string(a) }
+
+func TestRunAgentPreflightPassesWithKeyAndFreePort(t *testing.T) {
+	deps := preflightDeps{
+		lookPath: func(name string) (string, error) { return "/usr/bin/" + name, nil },
+		commandOutput: func(name string, args ...string) ([]byte, error) {
+			return []byte("go version go1.24.0 linux/amd64\n"), nil
+		},
+		executable: func() (string, error) { return "/usr/local/bin/micro", nil },
+		getenv: func(key string) string {
+			if key == "ANTHROPIC_API_KEY" {
+				return "set"
+			}
+			return ""
+		},
+		listen: func(network, address string) (net.Listener, error) { return stubListener{}, nil },
+	}
+
+	var out bytes.Buffer
+	if err := runAgentPreflight(&out, deps); err != nil {
+		t.Fatalf("runAgentPreflight() error = %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"First-agent preflight", "✓ Go toolchain", "✓ micro binary", "✓ provider API key", "✓ local port :8080", "Ready for the first-agent walkthrough"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunAgentPreflightReportsActionableFailures(t *testing.T) {
+	deps := preflightDeps{
+		lookPath:   func(name string) (string, error) { return "", errors.New("not found") },
+		executable: func() (string, error) { return "", errors.New("unknown") },
+		getenv:     func(key string) string { return "" },
+		listen:     func(network, address string) (net.Listener, error) { return nil, errors.New("in use") },
+	}
+
+	var out bytes.Buffer
+	err := runAgentPreflight(&out, deps)
+	if err == nil {
+		t.Fatal("runAgentPreflight() error = nil")
+	}
+	got := out.String()
+	for _, want := range []string{"✗ Go toolchain", "Install Go 1.24", "✗ micro binary", "✗ provider API key", "ANTHROPIC_API_KEY", "✗ local port :8080", "micro run --address"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFirstLine(t *testing.T) {
+	if got := firstLine([]byte("one\ntwo")); got != "one" {
+		t.Fatalf("firstLine() = %q", got)
+	}
+	if got := firstLine([]byte(" single ")); got != "single" {
+		t.Fatalf("firstLine() = %q", got)
+	}
+}

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -19,6 +19,14 @@ Go Micro has three core abstractions:
 - **Go 1.24+** for development. The `curl` install below gives you the `micro` binary without Go, but `micro run` compiles your services, so you'll want Go installed to build them.
 - An **LLM provider key** (Anthropic, OpenAI, Gemini, …) *only* for the AI features — `micro run --prompt`, `micro chat`, and agents. Plain services need no key. Set it before running, e.g. `export ANTHROPIC_API_KEY=sk-ant-...`.
 
+Before your first provider-backed agent run, check the local path with:
+
+```bash
+micro agent preflight
+```
+
+The preflight is read-only: it verifies Go, the `micro` binary, provider-key setup, and whether the default `micro run` gateway port is free, without calling an LLM provider.
+
 ## Install
 
 ```bash

--- a/internal/website/docs/guides/your-first-agent.md
+++ b/internal/website/docs/guides/your-first-agent.md
@@ -47,6 +47,14 @@ export ANTHROPIC_API_KEY=sk-ant-...
 Plain service calls work without a model key; the key is only needed when the
 agent reasons over tools.
 
+Run the read-only first-agent preflight before starting the walkthrough:
+
+```sh
+micro agent preflight
+```
+
+It checks Go, the `micro` binary, provider-key setup, and the default local gateway port without contacting a provider.
+
 ## 1. Create a workspace
 
 ```sh


### PR DESCRIPTION
## Summary
- add `micro agent preflight` (alias `doctor`) to check Go, the micro binary/version, provider-key setup, and the default local gateway port before the first provider-backed agent run
- cover pass and actionable-failure output with unit tests using injected dependencies
- link the read-only preflight from Getting Started and Your First Agent docs

Closes #3604
Closes #3607

## Testing
- go build ./...
- go test ./cmd/micro/cli/agent
- go test ./... (fails in this environment because grpc loopback tests are blocked by envoy: Loopback targets forbidden)
- golangci-lint run ./...