### PR TITLE
agent: dedupe plan/delegate side effects

### DIFF
--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -290,7 +290,11 @@ func (a *agentImpl) planWrap(next ai.ToolHandler) ai.ToolHandler {
 		if call.Name == toolPlan {
 			return a.handlePlan(call)
 		}
-		return next(ctx, call)
+		res := next(ctx, call)
+		if res.Refused == "" && toolErrorMessage(res) == "" {
+			a.completeNextPlanStep()
+		}
+		return res
 	}
 }
 
@@ -366,6 +370,36 @@ func (a *agentImpl) handlePlan(call ai.ToolCall) ai.ToolResult {
 	}
 	_ = a.stateStore().Write(&store.Record{Key: planKey, Value: data})
 	return ai.ToolResult{ID: call.ID, Value: call.Input, Content: string(data)}
+}
+
+func (a *agentImpl) completeNextPlanStep() {
+	plan := a.loadPlan()
+	if plan == "" {
+		return
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(plan), &data); err != nil {
+		return
+	}
+	steps, ok := data["steps"].([]any)
+	if !ok {
+		return
+	}
+	for _, raw := range steps {
+		step, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		status, _ := step["status"].(string)
+		if status == "" || status == "pending" || status == "in_progress" {
+			step["status"] = "done"
+			b, err := json.Marshal(data)
+			if err == nil {
+				_ = a.stateStore().Write(&store.Record{Key: planKey, Value: b})
+			}
+			return
+		}
+	}
 }
 
 // handleHumanInput records that the model needs operator input before it can continue.

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -102,6 +102,45 @@ func TestResumeFailedCheckpointDoesNotReplayCompletedTool(t *testing.T) {
 	}
 }
 
+func TestCheckpointSkipsDuplicateToolWithinAsk(t *testing.T) {
+	ctx := context.Background()
+	cp := flow.StoreCheckpoint(store.NewMemoryStore(), "tool-dedupe-agent")
+	toolRuns := 0
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if opts.ToolHandler == nil {
+			t.Fatal("missing tool handler")
+		}
+		opts.ToolHandler(ctx, ai.ToolCall{ID: "plan-1", Name: toolPlan, Input: map[string]any{
+			"steps": []any{
+				map[string]any{"task": "create Design task", "status": "pending"},
+			},
+		}})
+		for i := 0; i < 3; i++ {
+			res := opts.ToolHandler(ctx, ai.ToolCall{ID: "call-1", Name: "external.create", Input: map[string]any{"title": "Design"}})
+			if res.Content != "created Design" {
+				t.Fatalf("tool result %d = %q, want cached created Design", i, res.Content)
+			}
+		}
+		return &ai.Response{Reply: "done"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("tool-dedupe-agent"), WithCheckpoint(cp),
+		WithTool("external.create", "create once", nil, func(context.Context, map[string]any) (string, error) {
+			toolRuns++
+			return "created Design", nil
+		}))
+	if _, err := a.Ask(ctx, "create Design once"); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if toolRuns != 1 {
+		t.Fatalf("tool executions = %d, want duplicate calls within the run replayed from checkpoint", toolRuns)
+	}
+	if plan := a.loadPlan(); !strings.Contains(plan, `"status":"done"`) {
+		t.Fatalf("plan = %s, want completed action marked done", plan)
+	}
+}
+
 func TestResumeFailedCheckpointAfterFreshAgentRestart(t *testing.T) {
 	ctx := context.Background()
 	cp := flow.StoreCheckpoint(store.NewMemoryStore(), "restart-resume-agent")

--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -243,6 +243,8 @@ func runPlanDelegate(provider string) error {
 	cl := harnessutil.Client(provider, reg)
 	mem := store.NewMemoryStore()
 	liveAgentOpts := harnessutil.AgentOptions(provider)
+	commsCheckpoint := flow.StoreCheckpoint(mem, "agent-comms")
+	conductorCheckpoint := flow.StoreCheckpoint(mem, "agent-conductor")
 
 	// Real services.
 	taskSvc := new(TaskService)
@@ -267,6 +269,7 @@ func runPlanDelegate(provider string) error {
 		agent.Prompt("You handle outbound notifications. Use the notify service."),
 		agent.Provider(provider), agent.APIKey(apiKey),
 		agent.WithRegistry(reg), agent.WithClient(cl), agent.WithStore(mem),
+		agent.WithCheckpoint(commsCheckpoint),
 	}
 	commsOpts = append(commsOpts, liveAgentOpts...)
 	comms := agent.New(commsOpts...)
@@ -281,6 +284,7 @@ func runPlanDelegate(provider string) error {
 		agent.Prompt("You coordinate launch work. Plan first, create tasks, and delegate notifications to the \"comms\" agent."),
 		agent.Provider(provider), agent.APIKey(apiKey),
 		agent.WithRegistry(reg), agent.WithClient(cl), agent.WithStore(mem),
+		agent.WithCheckpoint(conductorCheckpoint),
 	}
 	conductorOpts = append(conductorOpts, liveAgentOpts...)
 	conductor := agent.New(conductorOpts...)


### PR DESCRIPTION
Summary:
- Replays duplicate in-run tool calls from the agent checkpoint instead of repeating side effects in the plan/delegate path.
- Advances persisted plan steps to done after successful actions so harness state reflects completed task creation and delegation.
- Enables checkpointing for the plan-delegate harness agents.

Testing:
- go test ./agent ./internal/harness/plan-delegate
- go build ./...
- go test ./... (environment warning: loopback gRPC tests fail under envoy loopback restrictions)
- golangci-lint run ./...
- go run ./internal/harness/provider-conformance -providers mock -harnesses plan-delegate -summary-json /tmp/provider-conformance-summary.json -summary-markdown /tmp/provider-conformance-summary.md -capabilities-markdown /tmp/provider-capabilities.md

Closes #3559
Closes #3615