### PR TITLE
Add first-agent walkthrough smoke coverage

### DIFF
--- a/cmd/micro/first_agent_walkthrough_test.go
+++ b/cmd/micro/first_agent_walkthrough_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+	microcmd "go-micro.dev/v6/cmd"
+)
+
+func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
+	commands := map[string]bool{}
+	subcommands := map[string]map[string]bool{}
+	for _, command := range microcmd.DefaultCmd.App().Commands {
+		commands[command.Name] = true
+		for _, subcommand := range command.Subcommands {
+			if subcommands[command.Name] == nil {
+				subcommands[command.Name] = map[string]bool{}
+			}
+			subcommands[command.Name][subcommand.Name] = true
+		}
+	}
+
+	for _, want := range []string{"new", "run", "chat", "inspect", "agent"} {
+		if !commands[want] {
+			t.Fatalf("first-agent walkthrough missing %q command", want)
+		}
+	}
+	if !subcommands["agent"]["preflight"] {
+		t.Fatal("first-agent walkthrough missing preflight boundary: agent preflight")
+	}
+	if !subcommands["inspect"]["agent"] {
+		t.Fatal("first-agent walkthrough missing inspect boundary: inspect agent")
+	}
+
+	chat := commandByName(t, "chat")
+	if !strings.Contains(chat.Description, "services") || !strings.Contains(chat.Description, "agent") {
+		t.Fatalf("micro chat should describe the service-to-agent walkthrough boundary; description was %q", chat.Description)
+	}
+}
+
+func commandByName(t *testing.T, name string) *cli.Command {
+	t.Helper()
+	for _, command := range microcmd.DefaultCmd.App().Commands {
+		if command.Name == name {
+			return command
+		}
+	}
+	t.Fatalf("missing command %q", name)
+	return nil
+}

--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -4,14 +4,17 @@ This directory owns the no-secret reference scenario for the Go Micro
 services → agents → workflows lifecycle. It is intentionally small and
 scripted so CI can run it on every push without external services or model keys.
 
-`run.sh` verifies four boundaries together:
+`run.sh` verifies five boundaries together:
 
-1. **Run** — `micro run` remains available as the local development entry point.
-2. **Chat** — `micro chat` remains available as the interactive agent entry point.
-3. **Inspect** — `micro inspect agent <name>` and `micro inspect flow <name>`
+1. **First agent** — `micro new`, `micro agent preflight`, `micro run`,
+   `micro chat`, and `micro inspect agent <name>` remain available as the
+   documented first-agent walkthrough path.
+2. **Run** — `micro run` remains available as the local development entry point.
+3. **Chat** — `micro chat` remains available as the interactive agent entry point.
+4. **Inspect** — `micro inspect agent <name>` and `micro inspect flow <name>`
    remain available as the local run-history inspection step, with `micro flow
    runs` preserving durable workflow history inspection.
-4. **Deploy** — `micro deploy --dry-run <target>` remains available as the
+5. **Deploy** — `micro deploy --dry-run <target>` remains available as the
    deployment-boundary checkpoint. The dry run resolves configured deploy targets
    and services and prints the remote build/copy/systemd/health plan without
    building binaries, opening SSH connections, running `rsync`, or touching

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -14,6 +14,7 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 	for _, want := range []string{
 		"make harness",
 		"go test ./cmd/micro/cli/new -run TestZeroToOne -count=1",
+		"go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1",
 		"go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1",
 		"go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1",
 		"./internal/harness/zero-to-hero-ci/run.sh",

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -6,7 +6,7 @@ cd "$ROOT"
 
 # Keep the developer inner-loop boundaries executable and discoverable in CI
 # without secrets or long-running daemons.
-go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1
+go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestZeroToHeroCLIBoundaries' -count=1
 go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
 
 # Deterministic no-secret reference scenarios. These use the real Go Micro

--- a/internal/website/docs/guides/your-first-agent.md
+++ b/internal/website/docs/guides/your-first-agent.md
@@ -47,7 +47,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 Plain service calls work without a model key; the key is only needed when the
 agent reasons over tools.
 
-Run the read-only first-agent preflight before starting the walkthrough:
+Run the read-only first-agent preflight before starting the walkthrough. The same CLI boundary is covered by CI with `go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1`, so the documented scaffold → run → chat → inspect path stays visible in the local harness:
 
 ```sh
 micro agent preflight

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -18,6 +18,7 @@ cloud credentials?"
 | Boundary | Contract | CI check |
 | --- | --- | --- |
 | Scaffold | `micro new` generates a runnable service with and without MCP support. | `go test ./cmd/micro/cli/new -run TestZeroToOne -count=1` |
+| First agent | `micro new`, `micro agent preflight`, `micro run`, `micro chat`, and `micro inspect agent` stay available for the documented first-agent walkthrough. | `go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1` |
 | Run | `micro run` remains the local development entry point. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
 | Chat | `micro chat` remains the interactive agent entry point. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
 | Inspect | `micro inspect agent`, `micro inspect flow`, and `micro flow runs` remain discoverable for run history. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
@@ -54,6 +55,9 @@ Use the smaller checks when you are working on one seam:
 ```sh
 # Scaffold → run/call contract.
 go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
+
+# First-agent walkthrough boundary: scaffold, preflight, run, chat, inspect.
+go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1
 
 # CLI inner-loop commands: run, chat, inspect, flow runs, deploy --dry-run.
 go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1


### PR DESCRIPTION
Summary:
- Add a CI-visible first-agent CLI boundary smoke test for scaffold, preflight, run, chat, and inspect.
- Include the new smoke check in the zero-to-hero harness script and docs so the local no-secret path exercises it.

Testing:
- go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1
- go test ./internal/harness/zero-to-hero-ci -count=1
- go build ./...
- go test ./... (fails in this environment because the sandbox forbids loopback targets used by grpc tests)
- golangci-lint run ./...

Closes #3618
Closes #3620