### PR TITLE
Verify zero-to-hero reference app in harness

### DIFF
--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -17,6 +17,7 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 		"go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1",
 		"go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1",
 		"go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1",
+		"go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1",
 		"./internal/harness/zero-to-hero-ci/run.sh",
 		"go run ./internal/harness/agent-flow",
 		"make provider-conformance-mock",

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -10,5 +10,8 @@ go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestZeroToHeroC
 go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
 
 # Deterministic no-secret reference scenarios. These use the real Go Micro
-# runtime and mock only the LLM provider.
+# runtime and mock only the LLM provider. The support example is the maintained
+# runnable 0→hero app; keep it in this CI path so its documented run/chat/inspect
+# journey cannot drift from the framework.
+go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1
 go test ./internal/harness/universe ./internal/harness/plan-delegate -run 'Test.*Harness|TestPlanDelegateEndToEnd|TestPlanDelegateFlowHandoff' -count=1

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -23,7 +23,8 @@ cloud credentials?"
 | Chat | `micro chat` remains the interactive agent entry point. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
 | Inspect | `micro inspect agent`, `micro inspect flow`, and `micro flow runs` remain discoverable for run history. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
 | Deploy | `micro deploy --dry-run` resolves deploy targets without touching remote infrastructure. | `go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1` |
-| Runtime | Real services, agents, durable flows, store-backed history, delegation, and A2A run with only the model mocked. | `./internal/harness/zero-to-hero-ci/run.sh` and `make provider-conformance-mock` |
+| Runtime reference app | `examples/support` runs typed services, an agent using those services as tools, an event-driven flow handoff, and an approval gate with only the model mocked. | `go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1` |
+| Runtime harnesses | Real services, agents, durable flows, store-backed history, delegation, and A2A run with only the model mocked. | `./internal/harness/zero-to-hero-ci/run.sh` and `make provider-conformance-mock` |
 
 ## Run the runnable example
 
@@ -62,6 +63,9 @@ go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1
 # CLI inner-loop commands: run, chat, inspect, flow runs, deploy --dry-run.
 go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1
 go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
+
+# Maintained 0→hero support-desk reference app.
+go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1
 
 # Durable services → agents → workflows reference scenarios.
 ./internal/harness/zero-to-hero-ci/run.sh


### PR DESCRIPTION
## Summary
- add the support-desk 0→hero reference app to the deterministic zero-to-hero harness script
- document the focused no-secret support example check in the 0→hero guide
- make the docs drift test require the new support example check

Closes #3623
Closes #3627

## Testing
- go build ./...
- go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1 -timeout 60s\n- go test ./internal/harness/zero-to-hero-ci -run TestZeroToHeroReferenceDocs -count=1 -timeout 30s\n- go test ./... (fails in this sandbox because loopback gRPC targets are blocked by Envoy)\n- golangci-lint run ./...