### PR TITLE
ci: smoke test installer first-run CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -X $(GIT_IMPORT).BuildDate=$(BUILD_DATE) -X $(GIT_IMPORT).GitCommit=$(
 # GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser-cross:v1.25.7
 GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser:latest
 
-.PHONY: test test-race test-coverage harness provider-conformance-mock provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
+.PHONY: test test-race test-coverage harness install-smoke provider-conformance-mock provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
 
 # Default target
 help:
@@ -19,6 +19,7 @@ help:
 	@echo "  make test-coverage - Run tests with coverage"
 	@echo "  make lint          - Run linter"
 	@echo "  make harness       - Run deterministic getting-started and end-to-end harnesses"
+	@echo "  make install-smoke - Verify the local install.sh and first-run CLI smoke path"
 	@echo "  make provider-conformance-mock - Run cross-provider harness with deterministic mock provider"
 	@echo "  make provider-conformance - Run harnesses against configured live providers"
 	@echo "  make fmt           - Format code"
@@ -48,10 +49,16 @@ test-coverage:
 # This mirrors the default CI path so local dogfooding catches scaffold,
 # run/chat/inspect, and 0→hero regressions before a PR is opened.
 harness:
+	$(MAKE) install-smoke
 	go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
 	./internal/harness/zero-to-hero-ci/run.sh
 	go run ./internal/harness/agent-flow
 	$(MAKE) provider-conformance-mock
+
+# Verify the documented install script and first-run CLI command boundaries without
+# provider keys or network access.
+install-smoke:
+	./internal/harness/install-smoke/run.sh
 
 # Run the shared provider conformance contract with the deterministic mock
 # provider. This is the no-secret path used by CI and local dogfooding to keep

--- a/README.md
+++ b/README.md
@@ -66,8 +66,15 @@ curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call \
   -H 'Content-Type: application/json' -d '{"name":"World"}'
 ```
 
-This scaffold → run → call path is covered by the no-secret CI harness. To run
-the same local contract (including the [0→hero services → agents → workflows path](internal/website/docs/guides/zero-to-hero.md),
+This install → scaffold → run → call path is covered by no-secret CI harnesses. To
+verify just the local installer and first-run CLI boundaries without network
+access or provider keys, use:
+
+```bash
+make install-smoke
+```
+
+To run the broader local contract (including the [0→hero services → agents → workflows path](internal/website/docs/guides/zero-to-hero.md),
 chat/inspect CLI boundaries, and deploy dry-run), use:
 
 ```bash

--- a/internal/harness/install-smoke/run.sh
+++ b/internal/harness/install-smoke/run.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Smoke-test the documented install.sh path without network access.
+# It builds the local CLI, packages it like a release archive, installs it into a
+# temporary bin directory through internal/scripts/install.sh, then checks the
+# first-run command boundaries shown in the getting-started docs.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ARCHIVE_DIR="$TMP_DIR/archive"
+INSTALL_DIR="$TMP_DIR/install"
+ARCHIVE="$TMP_DIR/micro-local.tar.gz"
+mkdir -p "$ARCHIVE_DIR" "$INSTALL_DIR"
+
+CGO_ENABLED=0 go build -o "$ARCHIVE_DIR/micro" ./cmd/micro
+chmod +x "$ARCHIVE_DIR/micro"
+tar -C "$ARCHIVE_DIR" -czf "$ARCHIVE" micro
+
+MICRO_INSTALL_DIR="$INSTALL_DIR" \
+MICRO_INSTALL_ARCHIVE="$ARCHIVE" \
+MICRO_VERSION="local-smoke" \
+PATH="$INSTALL_DIR:$PATH" \
+  "$ROOT/internal/scripts/install.sh" > "$TMP_DIR/install.out"
+
+MICRO="$INSTALL_DIR/micro"
+if [[ ! -x "$MICRO" ]]; then
+  echo "installed micro binary not found at $MICRO" >&2
+  cat "$TMP_DIR/install.out" >&2
+  exit 1
+fi
+
+require_output() {
+  local description=$1
+  local expected=$2
+  shift 2
+  local output
+  if ! output=$("$MICRO" "$@" 2>&1); then
+    echo "micro $* failed while checking $description" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"$expected"* ]]; then
+    echo "micro $* missing expected text '$expected' for $description" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
+require_output "version" "micro version" --version
+require_output "root help" "COMMANDS" --help
+require_output "service scaffold" "micro new" new --help
+require_output "first-agent preflight" "preflight" agent preflight --help
+require_output "local runtime" "micro run" run --help
+require_output "agent chat" "micro chat" chat --help
+require_output "agent inspection" "micro inspect agent" inspect agent --help
+require_output "flow inspection" "micro inspect flow" inspect flow --help
+
+echo "✓ install smoke path verified"

--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -27,15 +27,17 @@ and A2A with only the LLM mocked.
 ## Local and CI entry points
 
 The default GitHub harness workflow runs this script on every push and pull
-request after the 0→1 scaffold contract. Developers can run the same no-secret
-contract locally with:
+request after the install smoke check and 0→1 scaffold contract. Developers can
+verify the installer seam alone with `make install-smoke`, or run the same
+no-secret contract locally with:
 
 ```sh
 make harness
 ```
 
-That target intentionally exercises both 0→1 scaffold variants, the 0→hero
-scenario, the event-driven agent-flow harness, and mock provider conformance, so
+That target intentionally exercises the install script smoke path, both 0→1
+scaffold variants, the 0→hero scenario, the event-driven agent-flow harness, and
+mock provider conformance, so
 the public scaffold → run/chat → inspect → deploy lifecycle stays executable
 outside CI as well. Live provider checks remain separate and gated by configured
 API keys (`make provider-conformance` or the scheduled/manual CI job).

--- a/internal/scripts/install.sh
+++ b/internal/scripts/install.sh
@@ -23,8 +23,12 @@ case $OS in
     *) echo "Unsupported OS: $OS"; exit 1 ;;
 esac
 
-# Determine install directory
-if [ "$EUID" -eq 0 ] || [ "$(id -u)" -eq 0 ]; then
+# Determine install directory. MICRO_INSTALL_DIR is intended for CI/local smoke
+# tests that verify the installer without writing to a real system directory.
+if [ -n "${MICRO_INSTALL_DIR:-}" ]; then
+    INSTALL_DIR="$MICRO_INSTALL_DIR"
+    mkdir -p "$INSTALL_DIR"
+elif [ "$EUID" -eq 0 ] || [ "$(id -u)" -eq 0 ]; then
     INSTALL_DIR="/usr/local/bin"
 else
     INSTALL_DIR="$HOME/.local/bin"
@@ -44,8 +48,11 @@ fi
 TMP_DIR=$(mktemp -d)
 TMP_FILE="${TMP_DIR}/micro.tar.gz"
 
-# Download
-if command -v curl &> /dev/null; then
+# Download, or use a local release archive supplied by the deterministic smoke
+# harness. The default path still fetches the documented GitHub release artifact.
+if [ -n "${MICRO_INSTALL_ARCHIVE:-}" ]; then
+    cp "$MICRO_INSTALL_ARCHIVE" "$TMP_FILE"
+elif command -v curl &> /dev/null; then
     curl -fsSL "$URL" -o "$TMP_FILE"
 elif command -v wget &> /dev/null; then
     wget -q "$URL" -O "$TMP_FILE"

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -54,6 +54,9 @@ SSH access, or remote service is required.
 Use the smaller checks when you are working on one seam:
 
 ```sh
+# Install script and first-run CLI boundary, with no network or provider keys.
+make install-smoke
+
 # Scaffold → run/call contract.
 go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
 

--- a/internal/website/install.sh
+++ b/internal/website/install.sh
@@ -23,8 +23,12 @@ case $OS in
     *) echo "Unsupported OS: $OS"; exit 1 ;;
 esac
 
-# Determine install directory
-if [ "$EUID" -eq 0 ] || [ "$(id -u)" -eq 0 ]; then
+# Determine install directory. MICRO_INSTALL_DIR is intended for CI/local smoke
+# tests that verify the installer without writing to a real system directory.
+if [ -n "${MICRO_INSTALL_DIR:-}" ]; then
+    INSTALL_DIR="$MICRO_INSTALL_DIR"
+    mkdir -p "$INSTALL_DIR"
+elif [ "$EUID" -eq 0 ] || [ "$(id -u)" -eq 0 ]; then
     INSTALL_DIR="/usr/local/bin"
 else
     INSTALL_DIR="$HOME/.local/bin"
@@ -44,8 +48,11 @@ fi
 TMP_DIR=$(mktemp -d)
 TMP_FILE="${TMP_DIR}/micro.tar.gz"
 
-# Download
-if command -v curl &> /dev/null; then
+# Download, or use a local release archive supplied by the deterministic smoke
+# harness. The default path still fetches the documented GitHub release artifact.
+if [ -n "${MICRO_INSTALL_ARCHIVE:-}" ]; then
+    cp "$MICRO_INSTALL_ARCHIVE" "$TMP_FILE"
+elif command -v curl &> /dev/null; then
     curl -fsSL "$URL" -o "$TMP_FILE"
 elif command -v wget &> /dev/null; then
     wget -q "$URL" -O "$TMP_FILE"


### PR DESCRIPTION
Summary:
- Add a deterministic install smoke harness that packages the locally built micro CLI, installs it through install.sh without network access, and verifies first-run command boundaries.
- Wire the smoke check into make harness and document make install-smoke for local reproduction.

Testing:
- make install-smoke
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in grpc tests)
- golangci-lint run ./...

Closes #3630
Closes #3634