### PR TITLE
docs: complete Ollama provider surface (capability matrix, README, example fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ next version when it ships.
 ## [Unreleased]
 
 ### Added
+- **Ollama provider** — run agents against open-weight models locally (`/api/chat`, NDJSON streaming) or via Ollama Cloud (OpenAI-compatible `/v1/chat/completions`, SSE), auto-detected from the base URL, with tool calling in both modes. Point any agent at a non-default endpoint with the new `agent.BaseURL` / `micro.AgentBaseURL` option. (`ai/ollama/`, `examples/agent-ollama/`)
 - **Retrieval-backed agent memory** — agents can recall relevant prior turns by similarity, not just the recent window, with a summarizer hook that compacts older history so long conversations stay in budget. (`agent/`)
 - **Scheduled flows** — a flow can run an agent (or any step) on a cron-style schedule, with the dispatch traced end to end. (`flow/`)
 - **Flow verification/grader loop** — a workflow can grade its own step output against a rubric and retry until it passes, plus run-trace analysis to surface where a flow spends its time. (`flow/`)

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ MCP exposes your services as tools; A2A exposes your agents as agents. See the [
 | MCP gateway | Every endpoint is an AI tool automatically |
 | A2A gateway | Every agent is reachable over the Agent2Agent protocol; cards generated from the registry (`micro a2a`) |
 | Payments (x402) | Opt-in per-call payments for tools via the x402 standard; pluggable facilitator (Base, Solana, …) |
-| 7 LLM providers | Anthropic, OpenAI, Gemini, Groq, Mistral, Together, Atlas Cloud |
+| 8 LLM providers | Anthropic, OpenAI, Gemini, Groq, Mistral, Together, Atlas Cloud, Ollama (local + cloud) |
 | Interactive console | `micro run` includes a chat console for talking to services |
 | Service generation | `micro run --prompt` — describe a system, get running services |
 
@@ -412,6 +412,7 @@ Swap providers with a single import — same interface everywhere:
 | Mistral | `mistral-large-latest` |
 | Together AI | `meta-llama/Llama-3.3-70B-Instruct-Turbo` |
 | Atlas Cloud | `deepseek-ai/DeepSeek-V3-0324` |
+| Ollama | `llama3.2` (local) |
 
 ```go
 m := ai.New("anthropic", ai.WithAPIKey(key))

--- a/ai/ollama/ollama.go
+++ b/ai/ollama/ollama.go
@@ -23,7 +23,7 @@
 //	m := ai.New("ollama",
 //	    ai.WithBaseURL("https://ollama.com/v1"),
 //	    ai.WithAPIKey("your-key"),
-//	    ai.WithModel("gemma4:31b-cloud"),
+//	    ai.WithModel("gpt-oss:120b"),
 //	)
 package ollama
 

--- a/examples/agent-ollama/main.go
+++ b/examples/agent-ollama/main.go
@@ -2,7 +2,7 @@
 //
 // This example demonstrates the full harness loop — service tools, custom
 // tools, agent memory, guardrails, and streaming — using the Ollama
-// provider with gemma4:31b-cloud on Ollama Cloud.
+// provider with gpt-oss:120b on Ollama Cloud.
 //
 // It creates a "knowledge" service with two endpoints (Add, Search) that
 // the agent discovers as tools, plus a custom "current_time" tool. The
@@ -114,7 +114,7 @@ func main() {
 	}
 	model := os.Getenv("OLLAMA_MODEL")
 	if model == "" {
-		model = "gemma4:31b-cloud"
+		model = "gpt-oss:120b"
 	}
 	apiKey := os.Getenv("OLLAMA_API_KEY")
 

--- a/internal/website/docs/guides/ai-provider-guide.md
+++ b/internal/website/docs/guides/ai-provider-guide.md
@@ -43,6 +43,7 @@ The built-in providers currently register these capability interfaces:
 | `gemini` | Yes | No | No | No |
 | `groq` | Yes | No | No | Yes |
 | `mistral` | Yes | No | No | Yes |
+| `ollama` | Yes | No | No | Yes |
 | `openai` | Yes | Yes | No | Yes |
 | `together` | Yes | No | No | Yes |
 

--- a/internal/website/docs/guides/provider_capabilities_test.go
+++ b/internal/website/docs/guides/provider_capabilities_test.go
@@ -14,6 +14,7 @@ import (
 	_ "go-micro.dev/v6/ai/gemini"
 	_ "go-micro.dev/v6/ai/groq"
 	_ "go-micro.dev/v6/ai/mistral"
+	_ "go-micro.dev/v6/ai/ollama"
 	_ "go-micro.dev/v6/ai/openai"
 	_ "go-micro.dev/v6/ai/together"
 )


### PR DESCRIPTION
Follow-up cleanup after merging the Ollama provider (#3636).

## What
- **Capability matrix enforced.** Add the `ollama` row to the provider-guide capability matrix, and blank-import `ai/ollama` in `provider_capabilities_test.go`. The provider registers a stream but wasn't imported in that test, so its row went unchecked and the docs matrix silently omitted it — this makes the registry↔docs check cover it going forward.
- **README.** "7 LLM providers" → **8**, listing Ollama (local + cloud); added its default model (`llama3.2`) to the model table.
- **Fixed a fictional model name** shipped in the example and package doc: `gemma4:31b-cloud` → `gpt-oss:120b`. `gemma4` doesn't exist, and the `-cloud` suffix is for cloud models proxied through a *local* Ollama, not the direct `ollama.com/v1` endpoint the example targets — so the old default would have failed at runtime.
- **CHANGELOG.** Recorded the provider and the new `agent.BaseURL` / `micro.AgentBaseURL` option under `[Unreleased]`.

## Why
The merged PR was technically sound but its public surface was incomplete: the docs capability matrix (which is registry-verified by a test) didn't include Ollama, the README undercounted providers, and the example's default model was invented. This closes those gaps.

## Testing
- `go build ./...` — clean
- `go test ./internal/website/docs/guides/...` — passes (the matrix test now enforces the ollama row)
- `gofmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_