### PR TITLE
loop-release: fix 403 on tag push (checkout token clobbered the PAT)

### DIFF
--- a/.github/workflows/loop-release.yml
+++ b/.github/workflows/loop-release.yml
@@ -29,6 +29,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # need full history + all tags
+          # Do NOT persist the default GITHUB_TOKEN as a git credential.
+          # actions/checkout otherwise sets an http.extraheader Authorization
+          # for github.com that is sent on ALL pushes — including our manual
+          # PAT push below — and overrides the PAT, so the tag push
+          # authenticates as github-actions[bot] and 403s (the job only has
+          # contents: read). With this off, the PAT embedded in the push URL
+          # is the only credential. (Fixes run 28554612450.)
+          persist-credentials: false
       - name: Cut the next patch release if there are new commits
         env:
           RELEASE_TOKEN: ${{ secrets.CODEX_TRIGGER_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ next version when it ships.
 ## [Unreleased]
 
 ### Added
+- **Ollama provider** — run agents against open-weight models locally (`/api/chat`, NDJSON streaming) or via Ollama Cloud (OpenAI-compatible `/v1/chat/completions`, SSE), auto-detected from the base URL, with tool calling in both modes. Point any agent at a non-default endpoint with the new `agent.BaseURL` / `micro.AgentBaseURL` option. (`ai/ollama/`, `examples/agent-ollama/`)
 - **Retrieval-backed agent memory** — agents can recall relevant prior turns by similarity, not just the recent window, with a summarizer hook that compacts older history so long conversations stay in budget. (`agent/`)
 - **Scheduled flows** — a flow can run an agent (or any step) on a cron-style schedule, with the dispatch traced end to end. (`flow/`)
 - **Flow verification/grader loop** — a workflow can grade its own step output against a rubric and retry until it passes, plus run-trace analysis to surface where a flow spends its time. (`flow/`)

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ MCP exposes your services as tools; A2A exposes your agents as agents. See the [
 | MCP gateway | Every endpoint is an AI tool automatically |
 | A2A gateway | Every agent is reachable over the Agent2Agent protocol; cards generated from the registry (`micro a2a`) |
 | Payments (x402) | Opt-in per-call payments for tools via the x402 standard; pluggable facilitator (Base, Solana, …) |
-| 7 LLM providers | Anthropic, OpenAI, Gemini, Groq, Mistral, Together, Atlas Cloud |
+| 8 LLM providers | Anthropic, OpenAI, Gemini, Groq, Mistral, Together, Atlas Cloud, Ollama (local + cloud) |
 | Interactive console | `micro run` includes a chat console for talking to services |
 | Service generation | `micro run --prompt` — describe a system, get running services |
 
@@ -412,6 +412,7 @@ Swap providers with a single import — same interface everywhere:
 | Mistral | `mistral-large-latest` |
 | Together AI | `meta-llama/Llama-3.3-70B-Instruct-Turbo` |
 | Atlas Cloud | `deepseek-ai/DeepSeek-V3-0324` |
+| Ollama | `llama3.2` (local) |
 
 ```go
 m := ai.New("anthropic", ai.WithAPIKey(key))

--- a/ai/ollama/ollama.go
+++ b/ai/ollama/ollama.go
@@ -23,7 +23,7 @@
 //	m := ai.New("ollama",
 //	    ai.WithBaseURL("https://ollama.com/v1"),
 //	    ai.WithAPIKey("your-key"),
-//	    ai.WithModel("gemma4:31b-cloud"),
+//	    ai.WithModel("gpt-oss:120b"),
 //	)
 package ollama
 

--- a/examples/agent-ollama/main.go
+++ b/examples/agent-ollama/main.go
@@ -2,7 +2,7 @@
 //
 // This example demonstrates the full harness loop — service tools, custom
 // tools, agent memory, guardrails, and streaming — using the Ollama
-// provider with gemma4:31b-cloud on Ollama Cloud.
+// provider with gpt-oss:120b on Ollama Cloud.
 //
 // It creates a "knowledge" service with two endpoints (Add, Search) that
 // the agent discovers as tools, plus a custom "current_time" tool. The
@@ -114,7 +114,7 @@ func main() {
 	}
 	model := os.Getenv("OLLAMA_MODEL")
 	if model == "" {
-		model = "gemma4:31b-cloud"
+		model = "gpt-oss:120b"
 	}
 	apiKey := os.Getenv("OLLAMA_API_KEY")
 

--- a/internal/website/docs/guides/ai-provider-guide.md
+++ b/internal/website/docs/guides/ai-provider-guide.md
@@ -43,6 +43,7 @@ The built-in providers currently register these capability interfaces:
 | `gemini` | Yes | No | No | No |
 | `groq` | Yes | No | No | Yes |
 | `mistral` | Yes | No | No | Yes |
+| `ollama` | Yes | No | No | Yes |
 | `openai` | Yes | Yes | No | Yes |
 | `together` | Yes | No | No | Yes |
 

--- a/internal/website/docs/guides/provider_capabilities_test.go
+++ b/internal/website/docs/guides/provider_capabilities_test.go
@@ -14,6 +14,7 @@ import (
 	_ "go-micro.dev/v6/ai/gemini"
 	_ "go-micro.dev/v6/ai/groq"
 	_ "go-micro.dev/v6/ai/mistral"
+	_ "go-micro.dev/v6/ai/ollama"
 	_ "go-micro.dev/v6/ai/openai"
 	_ "go-micro.dev/v6/ai/together"
 )


### PR DESCRIPTION
## Problem

The daily release job ([run 28554612450](https://github.com/micro/go-micro/actions/runs/28554612450/job/84659241164)) computed the next tag correctly but failed to push it:

```
latest release tag: v6.3.11
commits on HEAD since v6.3.11: 18
cutting: v6.3.12 (18 commits since v6.3.11)
remote: Permission to micro/go-micro.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

## Root cause

Not a token problem — the PAT (`CODEX_TRIGGER_TOKEN`) is set and the job got past the guard. `actions/checkout` persists the default `GITHUB_TOKEN` as a git credential via `http.https://github.com/.extraheader` (an `Authorization` header). Git sends that header on **every** request to github.com, including the workflow's manual `git push https://x-access-token:${PAT}@github.com/...`. The persisted header overrides the PAT embedded in the URL, so the push authenticates as `github-actions[bot]` — which can't push tags (the job only grants `contents: read`) — and 403s.

## Fix

Set `persist-credentials: false` on the checkout so no `extraheader` is written and the PAT in the push URL is the only credential. One line.

## Follow-up

Once merged, `v6.3.12` hasn't been cut yet (18 commits are waiting, including the Ollama provider). The next scheduled run will cut it, or it can be triggered manually via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_