### PR TITLE
docs: surface first agent on-ramp

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Running Go Micro in production, or building on it and want help? Paid **support,
 ## Contents
 
 - [Quick Start](#quick-start)
+  - [First agent on-ramp](#first-agent-on-ramp)
 - [Why an Agent Harness](#why-an-agent-harness)
 - [Writing Services](#writing-services)
 - [Building Agents](#building-agents) — [Plan & Delegate](#plan--delegate), [Pluggable](#batteries-included-pluggable), [Paid tools (x402)](#paid-tools-x402), [A2A](#reachable-by-other-agents-a2a)
@@ -80,6 +81,20 @@ chat/inspect CLI boundaries, and deploy dry-run), use:
 ```bash
 make harness
 ```
+
+### First agent on-ramp
+
+After install and the first `micro new`/`micro run` smoke check, take the
+walkable agent path in this order:
+
+1. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
+   service-backed agent and talk to it with `micro chat`.
+2. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
+   `micro agent inspect`, run history, memory, and provider checks when the first
+   conversation does something unexpected.
+3. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
+   services → agents → workflows loop with scaffold, run, chat, inspect, flow
+   history, and deploy dry-run commands that match the maintained harness.
 
 ### Generate from a prompt — with an LLM key
 

--- a/internal/website/_data/navigation.yml
+++ b/internal/website/_data/navigation.yml
@@ -5,6 +5,10 @@ core:
     url: /docs/getting-started.html
   - title: AI Integration
     url: /docs/ai-integration.html
+  - title: Your First Agent
+    url: /docs/guides/your-first-agent.html
+  - title: 0→hero Reference
+    url: /docs/guides/zero-to-hero.html
   - title: MCP & AI Agents
     url: /docs/mcp.html
   - title: Deployment
@@ -32,12 +36,8 @@ examples:
   - title: Real-World Examples
     url: /docs/examples/realworld/
 guides:
-  - title: Your First Agent
-    url: /docs/guides/your-first-agent.html
   - title: Debugging your agent
     url: /docs/guides/debugging-agents.html
-  - title: 0→hero Reference
-    url: /docs/guides/zero-to-hero.html
   - title: Plan & Delegate
     url: /docs/guides/plan-delegate.html
   - title: Agent Guardrails
@@ -78,6 +78,7 @@ project:
   - title: Server (optional)
     url: /docs/server.html
 search_order:
+  - /docs/guides/your-first-agent.html
   - /docs/guides/zero-to-hero.html
   - /docs/guides/debugging-agents.html
   - /docs/getting-started.html

--- a/internal/website/docs/index.md
+++ b/internal/website/docs/index.md
@@ -16,7 +16,7 @@ It's built on a pluggable architecture of Go interfaces: service discovery, clie
 
 ## Learn More
 
-Start with [Getting Started](getting-started.html) for install and the first local service. If you want the full services → agents → workflows on-ramp in one walkable sequence, use the [0→hero reference path](guides/zero-to-hero.html): it links the exact scaffold, run, chat, inspect, and deploy dry-run commands covered by CI.
+Start with [Getting Started](getting-started.html) for install and the first local service. Then follow the first-agent on-ramp: [Your First Agent](guides/your-first-agent.html) to build and chat with a service-backed agent, [Debugging your agent](guides/debugging-agents.html) to inspect runs and memory, and the [0→hero reference path](guides/zero-to-hero.html) to walk the full scaffold → run → chat → inspect → deploy dry-run lifecycle covered by CI.
 
 Otherwise continue to read the docs for more information about the framework.
 


### PR DESCRIPTION
## Summary
- Add a README first-agent on-ramp after the install/scaffold smoke path.
- Promote Your First Agent and 0→hero in website docs navigation and search ordering.
- Align the docs index with the walkable services → agents → workflows path.

## Testing
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3640
Closes #3643