### PR TITLE
docs: roll changelog for v6.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ next version when it ships.
 
 ## [Unreleased]
 
+---
+
+## [6.3.12] - July 2026
+
 ### Added
 - **Ollama provider** — run agents against open-weight models locally (`/api/chat`, NDJSON streaming) or via Ollama Cloud (OpenAI-compatible `/v1/chat/completions`, SSE), auto-detected from the base URL, with tool calling in both modes. Point any agent at a non-default endpoint with the new `agent.BaseURL` / `micro.AgentBaseURL` option. (`ai/ollama/`, `examples/agent-ollama/`)
 - **Retrieval-backed agent memory** — agents can recall relevant prior turns by similarity, not just the recent window, with a summarizer hook that compacts older history so long conversations stay in budget. (`agent/`)


### PR DESCRIPTION
Summary:
- Roll the accumulated Unreleased changelog entries into the newly cut v6.3.12 section.
- Leave a fresh empty Unreleased section for future changes.

DevRel audit:
- README and website/docs are aligned around the agent harness and services → agents → workflows lifecycle after the recent first-agent documentation work.
- No safe factual copy drift requiring changes was found in this pass.
- A changelog blog post was not drafted: the accumulated public changes are meaningful, but the latest blog cadence is still primarily thesis/positioning and no prior changelog-post pattern exists to mirror safely without human taste review.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback targets are forbidden by envoy for grpc tests)
- golangci-lint run ./...

Closes #3645