### PR TITLE
docs: connect quickstart to first agent path

### DIFF
--- a/internal/website/docs/quickstart.md
+++ b/internal/website/docs/quickstart.md
@@ -37,8 +37,16 @@ curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call \
 
 ## Next Steps
 
+You now have the service half of the services → agents → workflows lifecycle running locally. Keep the on-ramp going in this order:
+
+1. **[Your First Agent](guides/your-first-agent.html)** - turn this service into an agent-callable tool, chat with it, and learn the `micro agent preflight` → `micro run` → `micro chat` loop.
+2. **[Debugging your agent](guides/debugging-agents.html)** - inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent does something surprising.
+3. **[0→hero Reference](guides/zero-to-hero.html)** - walk the maintained scaffold → run → chat → inspect → deploy dry-run path that proves services, agents, and workflows together.
+
+After that first-agent path, branch out to:
+
 - **[Full Tutorial](getting-started.html)** - In-depth guide
-- **[Examples](examples/)** - Learn by example
+- **[Examples](examples/)** - Runnable examples mapped to services, agents, and workflows
 - **[API Reference](https://pkg.go.dev/go-micro.dev/v6)** - Complete API docs
 - **[Deployment](deployment.html)** - Deploy to production
 


### PR DESCRIPTION
Summary:
- Updates the standalone website quickstart next steps to hand off from the first service smoke test to Your First Agent, Debugging your agent, and the 0→hero reference path.
- Keeps broader tutorial/examples/API/deployment links after the first-agent on-ramp.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback targets are forbidden for grpc client/transport tests)
- golangci-lint run ./...
- go test ./internal/website/docs/guides

Closes #3648
Closes #3654