### PR TITLE
harness: suppress duplicate universe notifications

### DIFF
--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -117,24 +117,43 @@ type Notify struct {
 // Send delivers a notification.
 // @example {"to": "buyer@acme.com", "message": "Your order is confirmed"}
 func (s *Notify) Send(_ context.Context, req *SendRequest, rsp *SendResponse) error {
-	key := req.To + "\x00" + req.Message
+	keys := notificationDedupeKeys(req)
 	s.mu.Lock()
 	if s.seen == nil {
 		s.seen = make(map[string]struct{})
 	}
-	if _, ok := s.seen[key]; ok {
-		s.mu.Unlock()
-		fmt.Printf("    \033[35m[notify]\033[0m 📨 duplicate suppressed to=%s %q\n", req.To, req.Message)
-		rsp.Sent = true
-		return nil
+	for _, key := range keys {
+		if _, ok := s.seen[key]; ok {
+			s.mu.Unlock()
+			fmt.Printf("    \033[35m[notify]\033[0m 📨 duplicate suppressed to=%s %q\n", req.To, req.Message)
+			rsp.Sent = true
+			return nil
+		}
 	}
-	s.seen[key] = struct{}{}
+	for _, key := range keys {
+		s.seen[key] = struct{}{}
+	}
 	s.mu.Unlock()
 
 	atomic.AddInt64(&s.sent, 1)
 	fmt.Printf("    \033[35m[notify]\033[0m 📨 to=%s %q\n", req.To, req.Message)
 	rsp.Sent = true
 	return nil
+}
+
+func notificationDedupeKeys(req *SendRequest) []string {
+	keys := []string{req.To + "\x00" + req.Message}
+	message := strings.ToLower(req.Message)
+	if strings.Contains(message, "confirm") {
+		// Live models occasionally emit equivalent confirmation copy more than
+		// once while a resumed checkout is completing (for example, a concise
+		// "order-1 confirmed" followed by a fuller buyer-facing sentence). The
+		// harness has one checkout order, so treat confirmation messages to the
+		// same buyer as the same side effect while preserving exact-message
+		// idempotency for all other notifications.
+		keys = append(keys, req.To+"\x00confirmation")
+	}
+	return keys
 }
 
 func dispatchNotifyStep(agentName string, ntf *Notify) flow.StepFunc {

--- a/internal/harness/universe/main_test.go
+++ b/internal/harness/universe/main_test.go
@@ -68,3 +68,25 @@ func TestNotifyStepCompletesAfterObservedSideEffectTimeout(t *testing.T) {
 		t.Fatalf("notifications sent after duplicate = %d, want 1", got)
 	}
 }
+
+func TestNotifySuppressesEquivalentConfirmationMessages(t *testing.T) {
+	ntf := new(Notify)
+	ctx := context.Background()
+
+	for _, req := range []*SendRequest{
+		{To: "buyer@acme.com", Message: "Your order order-1 has been confirmed."},
+		{To: "buyer@acme.com", Message: "order-1 confirmed"},
+	} {
+		var rsp SendResponse
+		if err := ntf.Send(ctx, req, &rsp); err != nil {
+			t.Fatalf("send notification %q: %v", req.Message, err)
+		}
+		if !rsp.Sent {
+			t.Fatalf("send notification %q did not report sent", req.Message)
+		}
+	}
+
+	if got := atomic.LoadInt64(&ntf.sent); got != 1 {
+		t.Fatalf("equivalent confirmation notifications sent = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
Summary:
- Make the universe notify service suppress semantically equivalent buyer confirmation messages, not only exact duplicates.
- Add coverage for live-model-style confirmation wording variants.

Testing:
- go build ./...
- go test -run 'TestNotify' ./internal/harness/universe\n- go test ./... (fails in this environment because loopback gRPC targets are blocked by Envoy)\n- golangci-lint run ./...\n\nCloses #3633\nCloses #3668