### PR TITLE
wrapper/x402: fix misspell lint failure on master (honour → honor)

### DIFF
--- a/wrapper/x402/x402_settle_test.go
+++ b/wrapper/x402/x402_settle_test.go
@@ -73,7 +73,7 @@ func TestSettlementFailureChallenges(t *testing.T) {
 	}
 }
 
-// TestPaymentSignatureHeaderAccepted checks the v2 request header is honoured.
+// TestPaymentSignatureHeaderAccepted checks the v2 request header is honored.
 func TestPaymentSignatureHeaderAccepted(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"isValid": true, "success": true, "transaction": "0x1"})
@@ -86,7 +86,7 @@ func TestPaymentSignatureHeaderAccepted(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	if !cfg.Require(rec, r, "10000", "chat") {
-		t.Fatalf("Require should honour PAYMENT-SIGNATURE; body=%s", rec.Body.String())
+		t.Fatalf("Require should honor PAYMENT-SIGNATURE; body=%s", rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
`golangci-lint` is red on `master`: `wrapper/x402/x402_settle_test.go` uses British spellings that the `misspell` linter (en_US locale) rejects —

```
x402_settle_test.go:76:71: `honoured` is a misspelling of `honored` (misspell)
x402_settle_test.go:89:28: `honour` is a misspelling of `honor` (misspell)
```

Introduced by #3676. Switch both to US spelling. `golangci-lint run ./wrapper/x402/...` and `go test ./wrapper/x402/...` are clean after.

**Note for follow-up:** a PR merged to `master` with a red `golangci-lint` — which shouldn't be possible if lint is a required status check gating auto-merge. Worth confirming branch protection lists the `golangci-lint` check as required, since "green CI is the gate" is the loop's only safety mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_