### PR TITLE
Fail agent runs with unfinished delegated plans

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -368,6 +368,24 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		RunID:     a.runID,
 		ParentID:  parentRunID,
 	}
+	if a.opts.Checkpoint != nil {
+		if unfinished := a.unfinishedPlanSteps(); len(unfinished) > 0 {
+			err = fmt.Errorf("agent run %s has unfinished plan steps: %s", run.ID, strings.Join(unfinished, ", "))
+			run.Status = "failed"
+			run.State.Stage = agentAskStep
+			run.State.Data = []byte(message)
+			if a.currentRun != nil {
+				run.Steps = a.currentRun.Steps
+			}
+			if len(run.Steps) == 0 {
+				run.Steps = []flow.StepRecord{{Name: agentAskStep}}
+			}
+			run.Steps[0].Status = "failed"
+			run.Steps[0].Error = err.Error()
+			_ = a.saveRun(ctx, run)
+			return nil, err
+		}
+	}
 	run.Status = "done"
 	run.State.Stage = ""
 	if b, marshalErr := json.Marshal(res); marshalErr == nil {

--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -402,6 +402,38 @@ func (a *agentImpl) completeNextPlanStep() {
 	}
 }
 
+func (a *agentImpl) unfinishedPlanSteps() []string {
+	plan := a.loadPlan()
+	if plan == "" {
+		return nil
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(plan), &data); err != nil {
+		return nil
+	}
+	steps, ok := data["steps"].([]any)
+	if !ok {
+		return nil
+	}
+	var unfinished []string
+	for _, raw := range steps {
+		step, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		status, _ := step["status"].(string)
+		if status != "" && status != "pending" && status != "in_progress" {
+			continue
+		}
+		task, _ := step["task"].(string)
+		if task == "" {
+			task = "<unnamed>"
+		}
+		unfinished = append(unfinished, task)
+	}
+	return unfinished
+}
+
 // handleHumanInput records that the model needs operator input before it can continue.
 func (a *agentImpl) handleHumanInput(call ai.ToolCall) ai.ToolResult {
 	prompt, _ := call.Input["prompt"].(string)

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -141,6 +141,43 @@ func TestCheckpointSkipsDuplicateToolWithinAsk(t *testing.T) {
 	}
 }
 
+func TestCheckpointFailsRunWithUnfinishedPlanStep(t *testing.T) {
+	ctx := context.Background()
+	cp := flow.StoreCheckpoint(store.NewMemoryStore(), "unfinished-plan-agent")
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if opts.ToolHandler == nil {
+			t.Fatal("missing tool handler")
+		}
+		opts.ToolHandler(ctx, ai.ToolCall{ID: "plan-1", Name: toolPlan, Input: map[string]any{
+			"steps": []any{
+				map[string]any{"task": "create launch tasks", "status": "done"},
+				map[string]any{"task": "notify owner via comms", "status": "in_progress"},
+			},
+		}})
+		return &ai.Response{Reply: "all done"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("unfinished-plan-agent"), WithCheckpoint(cp))
+	_, err := a.Ask(ctx, "create tasks and notify owner")
+	if err == nil {
+		t.Fatal("Ask succeeded with unfinished plan step")
+	}
+	if !strings.Contains(err.Error(), "notify owner via comms") {
+		t.Fatalf("Ask error = %v, want unfinished delegate step named", err)
+	}
+	runs, err := Pending(ctx, a)
+	if err != nil {
+		t.Fatalf("Pending: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("Pending returned %d runs, want failed run remains actionable", len(runs))
+	}
+	if runs[0].Status != "failed" {
+		t.Fatalf("run status = %q, want failed", runs[0].Status)
+	}
+}
+
 func TestResumeFailedCheckpointAfterFreshAgentRestart(t *testing.T) {
 	ctx := context.Background()
 	cp := flow.StoreCheckpoint(store.NewMemoryStore(), "restart-resume-agent")


### PR DESCRIPTION
Summary:
- Fail checkpointed agent runs before completion when saved plans still contain pending or in-progress steps.
- Preserve the failed run as pending/actionable so resume/retry flows can inspect unfinished delegation work.
- Add a regression test for an unfinished delegate notification plan step.

Testing:
- go build ./...
- go test ./agent ./internal/harness/plan-delegate
- golangci-lint run ./...
- go test ./... (warning: environment blocks loopback gRPC targets in client/grpc and transport/grpc)

Closes #3674
Closes #3683