### PR TITLE
Constrain universe buyer notifications

### DIFF
--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -117,6 +117,16 @@ type Notify struct {
 // Send delivers a notification.
 // @example {"to": "buyer@acme.com", "message": "Your order is confirmed"}
 func (s *Notify) Send(_ context.Context, req *SendRequest, rsp *SendResponse) error {
+	if !isBuyerNotification(req) {
+		to, message := "", ""
+		if req != nil {
+			to, message = req.To, req.Message
+		}
+		fmt.Printf("    \033[35m[notify]\033[0m 📨 ignored non-buyer notification to=%s %q\n", to, message)
+		rsp.Sent = false
+		return nil
+	}
+
 	keys := notificationDedupeKeys(req)
 	s.mu.Lock()
 	if s.seen == nil {
@@ -139,6 +149,13 @@ func (s *Notify) Send(_ context.Context, req *SendRequest, rsp *SendResponse) er
 	fmt.Printf("    \033[35m[notify]\033[0m 📨 to=%s %q\n", req.To, req.Message)
 	rsp.Sent = true
 	return nil
+}
+
+func isBuyerNotification(req *SendRequest) bool {
+	if req == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(req.To), "buyer@acme.com")
 }
 
 func notificationDedupeKeys(req *SendRequest) []string {

--- a/internal/harness/universe/main_test.go
+++ b/internal/harness/universe/main_test.go
@@ -90,3 +90,35 @@ func TestNotifySuppressesEquivalentConfirmationMessages(t *testing.T) {
 		t.Fatalf("equivalent confirmation notifications sent = %d, want 1", got)
 	}
 }
+
+func TestNotifyIgnoresNonBuyerRecipients(t *testing.T) {
+	ntf := new(Notify)
+	ctx := context.Background()
+
+	var rsp SendResponse
+	if err := ntf.Send(ctx, &SendRequest{
+		To:      "order-1",
+		Message: "order-1 confirmed",
+	}, &rsp); err != nil {
+		t.Fatalf("send non-buyer notification: %v", err)
+	}
+	if rsp.Sent {
+		t.Fatal("non-buyer notification reported sent")
+	}
+	if got := atomic.LoadInt64(&ntf.sent); got != 0 {
+		t.Fatalf("non-buyer notifications sent = %d, want 0", got)
+	}
+
+	if err := ntf.Send(ctx, &SendRequest{
+		To:      "buyer@acme.com",
+		Message: "Your order order-1 has been confirmed.",
+	}, &rsp); err != nil {
+		t.Fatalf("send buyer notification: %v", err)
+	}
+	if !rsp.Sent {
+		t.Fatal("buyer notification did not report sent")
+	}
+	if got := atomic.LoadInt64(&ntf.sent); got != 1 {
+		t.Fatalf("buyer notifications sent = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary
- constrain the universe notify service to ignore non-buyer recipients so the concierge can only create the intended buyer side effect
- add regression coverage for suppressing an order-id notification before the buyer notification

Closes #3682
Closes #3688

## Testing
- go build ./...
- go test ./internal/harness/universe
- go test ./... (fails in this environment because grpc loopback tests receive Envoy "Loopback targets forbidden" 403s)
- golangci-lint run ./...