### PR TITLE
docs: map examples to first-agent path

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,34 @@
 # Go Micro Examples
 
-This directory contains runnable examples demonstrating various go-micro features and patterns.
+This directory contains runnable examples that take you through the Go Micro
+lifecycle: start with a service, expose it as agent-usable capability, then
+coordinate work with workflows.
 
 ## Quick Start
 
-Each example can be run with `go run .` from its directory.
+Each example can be run with `go run .` from its directory unless its README says
+otherwise. If you are new to the repo, follow the first-agent path below instead
+of reading the directories alphabetically.
 
-## Examples
+## Recommended first-agent path
 
-### [hello-world](./hello-world/)
+| Step | Start here | What you learn | Next step |
+|------|------------|----------------|-----------|
+| 1. First service | [`hello-world`](./hello-world/) | Create and register a basic RPC service, add a handler, call it with a client, and expose health checks. | Move to [`agent-demo`](./agent-demo/) to see services used by an agent. |
+| 2. First agent | [`agent-demo`](./agent-demo/) | Run a small project-management app with Projects, Tasks, and Team services plus an agent playground. | Compare with the maintained 0-to-hero path in [`support`](./support/). |
+| 3. First workflow | [`support`](./support/) | Follow typed services into an agent chat loop, an event-driven `intake` flow, and an approval gate in one runnable reference. | Deepen the workflow model with [`flow-durable`](./flow-durable/). |
+
+For the shortest AI-tooling bridge, the MCP path is
+[`mcp/hello`](./mcp/hello/) → [`mcp/crud`](./mcp/crud/) →
+[`mcp/workflow`](./mcp/workflow/). For debugging and production hardening, keep
+[`agent-wrap-tool`](./agent-wrap-tool/), [`agent-durable`](./agent-durable/), and
+[`deployment`](./deployment/) nearby.
+
+## Lifecycle map
+
+### 1. Services — learn the runtime foundation
+
+#### [hello-world](./hello-world/)
 Basic RPC service demonstrating core concepts:
 - Service creation and registration
 - Handler implementation
@@ -21,7 +41,7 @@ cd hello-world
 go run .
 ```
 
-### [web-service](./web-service/)
+#### [web-service](./web-service/)
 HTTP web service with service discovery:
 - HTTP handlers
 - Service registration
@@ -34,7 +54,7 @@ cd web-service
 go run .
 ```
 
-### [multi-service](./multi-service/)
+#### [multi-service](./multi-service/)
 Multiple services in a single binary — the modular monolith pattern:
 - Isolated server, client, store, and cache per service
 - Shared registry and broker for inter-service communication
@@ -47,44 +67,76 @@ cd multi-service
 go run .
 ```
 
-### [deployment](./deployment/)
+#### [deployment](./deployment/)
 Docker Compose deployment with MCP gateway, Consul registry, and Jaeger tracing:
 - Production-like architecture in one `docker-compose up`
 - Standalone MCP gateway connected to service registry
 - Distributed tracing with OpenTelemetry + Jaeger
 
-### MCP Examples
+### 2. Agents — turn services into tool-using teammates
+
+#### [agent-demo](./agent-demo/)
+Recommended first agent: a multi-service project management app with Projects,
+Tasks, and Team services, seed data, and agent playground integration.
+
+#### [agent-plan-delegate](./agent-plan-delegate/)
+The two built-in agent capabilities in a small multi-agent system:
+- **plan** — an agent records an ordered plan in its store-backed memory before doing multi-step work
+- **delegate** — an agent hands a subtask to another agent (over RPC if it's registered, else to an ephemeral sub-agent)
+
+#### [agent-wrap-tool](./agent-wrap-tool/)
+Middleware around an agent's tool execution with `AgentWrapTool`, the tool-side analogue of client/server wrappers:
+- **observe** — time every tool call and record per-tool metrics, correlated by call ID
+- **retry** — re-run a call whose result is an error, recovering from a transient failure before the model sees it
+
+#### [agent-durable](./agent-durable/)
+Durable agent runs that can be checkpointed and resumed, useful once your first
+agent needs predictable recovery behavior.
+
+#### [agent-human-input](./agent-human-input/)
+Human-in-the-loop agent interaction for decisions that need an explicit person
+before the run can continue.
+
+#### [agent-ollama](./agent-ollama/)
+Local-model agent wiring for developers experimenting with Ollama-backed model
+calls.
+
+### 3. Workflows — coordinate longer-running work
+
+#### [support](./support/)
+A maintained 0-to-hero reference path in one runnable file:
+- **scaffold** typed `customers`, `tickets`, and `notify` services
+- **run/chat** with a support agent that uses those services as tools
+- **inspect** the event-driven `intake` flow and approval gate
+- **CI** keeps the deterministic mock-model journey runnable with `go test ./examples/support`
+
+#### [flow-durable](./flow-durable/)
+A workflow as ordered, checkpointed steps that survives a crash and resumes where it stopped:
+- **steps** — a flow is a task with stages (`reserve → charge → confirm`), not just one LLM turn
+- **Checkpoint** — each step is persisted; on `Resume`, completed steps are not re-run (no duplicate side effects)
+
+#### [flow-loop](./flow-loop/)
+A looping flow example for repeated workflow steps.
+
+### 4. MCP and agent integration examples
 
 See the [mcp/](./mcp/) directory for AI agent integration examples:
 - **[hello](./mcp/hello/)** - Minimal MCP service (start here)
 - **[crud](./mcp/crud/)** - CRUD contact book with full agent documentation
 - **[workflow](./mcp/workflow/)** - Cross-service orchestration via AI agents
 - **[documented](./mcp/documented/)** - All MCP features with auth scopes
+- **[platform](./mcp/platform/)** - Platform-oriented MCP service example
 
-### [agent-demo](./agent-demo/)
-Multi-service project management app (Projects, Tasks, Team) with seed data and agent playground integration.
+## Other examples
 
-### [agent-plan-delegate](./agent-plan-delegate/)
-The two built-in agent capabilities in a small multi-agent system:
-- **plan** — an agent records an ordered plan in its store-backed memory before doing multi-step work
-- **delegate** — an agent hands a subtask to another agent (over RPC if it's registered, else to an ephemeral sub-agent)
+### [auth](./auth/)
+Authentication and authorization example.
 
-### [agent-wrap-tool](./agent-wrap-tool/)
-Middleware around an agent's tool execution with `AgentWrapTool`, the tool-side analogue of client/server wrappers:
-- **observe** — time every tool call and record per-tool metrics, correlated by call ID
-- **retry** — re-run a call whose result is an error, recovering from a transient failure before the model sees it
+### [graceful-stop](./graceful-stop/)
+Graceful shutdown behavior for long-running services.
 
-### [flow-durable](./flow-durable/)
-A workflow as ordered, checkpointed steps that survives a crash and resumes where it stopped:
-- **steps** — a flow is a task with stages (`reserve → charge → confirm`), not just one LLM turn
-- **Checkpoint** — each step is persisted; on `Resume`, completed steps are not re-run (no duplicate side effects)
-
-### [support](./support/)
-A maintained 0-to-hero reference path in one runnable file:
-- **scaffold** typed `customers`, `tickets`, and `notify` services
-- **run/chat** with a support agent that uses those services as tools
-- **inspect** the event-driven `intake` flow and approval gate
-- **CI** keeps the deterministic mock-model journey runnable with `go test ./examples/support`
+### [grpc-interop](./grpc-interop/)
+gRPC interoperability example.
 
 ## Coming Soon
 
@@ -106,6 +158,5 @@ To add a new example:
 1. Create a new directory
 2. Add a descriptive README.md
 3. Include working code with comments
-4. Add to this index
+4. Add to this index under the lifecycle stage it supports
 5. Ensure it runs with `go run .`
-


### PR DESCRIPTION
Summary:
- Reworks examples/README.md around the services → agents → workflows lifecycle.
- Adds an explicit recommended path from first service to first agent to first workflow.
- Surfaces adjacent debugging, durability, MCP, and deployment examples for adoption wayfinding.

Testing:
- python3 local examples README link check
- go build ./...
- go test ./... (fails in this environment because loopback targets are forbidden for grpc tests)
- golangci-lint run ./...

Closes #3671
Closes #3694