### PR TITLE
harness: accept buyer alias notifications

### DIFF
--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -155,11 +155,24 @@ func isBuyerNotification(req *SendRequest) bool {
 	if req == nil {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(req.To), "buyer@acme.com")
+	return canonicalBuyerRecipient(req.To) != ""
+}
+
+func canonicalBuyerRecipient(to string) string {
+	switch strings.ToLower(strings.TrimSpace(to)) {
+	case "buyer", "buyer@acme.com":
+		return "buyer@acme.com"
+	default:
+		return ""
+	}
 }
 
 func notificationDedupeKeys(req *SendRequest) []string {
-	keys := []string{req.To + "\x00" + req.Message}
+	recipient := canonicalBuyerRecipient(req.To)
+	if recipient == "" {
+		recipient = strings.TrimSpace(req.To)
+	}
+	keys := []string{recipient + "\x00" + req.Message}
 	message := strings.ToLower(req.Message)
 	if strings.Contains(message, "confirm") {
 		// Live models occasionally emit equivalent confirmation copy more than
@@ -168,7 +181,7 @@ func notificationDedupeKeys(req *SendRequest) []string {
 		// harness has one checkout order, so treat confirmation messages to the
 		// same buyer as the same side effect while preserving exact-message
 		// idempotency for all other notifications.
-		keys = append(keys, req.To+"\x00confirmation")
+		keys = append(keys, recipient+"\x00confirmation")
 	}
 	return keys
 }

--- a/internal/harness/universe/main_test.go
+++ b/internal/harness/universe/main_test.go
@@ -91,6 +91,38 @@ func TestNotifySuppressesEquivalentConfirmationMessages(t *testing.T) {
 	}
 }
 
+func TestNotifyAcceptsBuyerAlias(t *testing.T) {
+	ntf := new(Notify)
+	ctx := context.Background()
+
+	var rsp SendResponse
+	if err := ntf.Send(ctx, &SendRequest{
+		To:      "buyer",
+		Message: "Your order order-1 has been confirmed.",
+	}, &rsp); err != nil {
+		t.Fatalf("send buyer alias notification: %v", err)
+	}
+	if !rsp.Sent {
+		t.Fatal("buyer alias notification did not report sent")
+	}
+	if got := atomic.LoadInt64(&ntf.sent); got != 1 {
+		t.Fatalf("buyer alias notifications sent = %d, want 1", got)
+	}
+
+	if err := ntf.Send(ctx, &SendRequest{
+		To:      "buyer@acme.com",
+		Message: "order-1 confirmed",
+	}, &rsp); err != nil {
+		t.Fatalf("send canonical buyer notification: %v", err)
+	}
+	if !rsp.Sent {
+		t.Fatal("canonical buyer notification did not report sent")
+	}
+	if got := atomic.LoadInt64(&ntf.sent); got != 1 {
+		t.Fatalf("alias/canonical confirmation notifications sent = %d, want 1", got)
+	}
+}
+
 func TestNotifyIgnoresNonBuyerRecipients(t *testing.T) {
 	ntf := new(Notify)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- accept `buyer` as the stable buyer alias for universe concierge notifications
- canonicalize buyer alias and email dedupe keys so equivalent confirmation messages still count once
- add regression coverage for alias acceptance and cross-alias dedupe

Closes #3693
Closes #3700

## Testing
- go test ./internal/harness/universe -run 'TestNotify|TestNotifyAcceptsBuyerAlias' -count=1\n- go build ./...\n- go test ./... (fails in this environment: client/grpc loopback targets are forbidden by envoy)\n- golangci-lint run ./...