### PR TITLE
agent: continue unfinished plan steps

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -293,57 +293,77 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		}
 	}
 
-	resp, err := ai.GenerateWithRetry(ctx, a.model, &ai.Request{
-		Prompt:       message,
-		SystemPrompt: a.buildPrompt(),
-		Tools:        toolList,
-		Messages:     messages,
-	}, ai.GeneratePolicy{
-		Timeout:     a.opts.ModelTimeout,
-		MaxAttempts: a.opts.ModelMaxAttempts,
-		Backoff:     a.opts.ModelRetryBackoff,
-	})
-	if err != nil {
-		run.Status = agentRunFailureStatus(err)
-		if a.currentRun != nil {
-			run.Steps = a.currentRun.Steps
-		}
-		if len(run.Steps) == 0 {
-			run.Steps = []flow.StepRecord{{Name: agentAskStep}}
-		}
-		run.Steps[0].Status = run.Status
-		run.Steps[0].Error = err.Error()
-		_ = a.saveRun(ctx, run)
-		return nil, err
-	}
-	if a.pause != nil && a.opts.Checkpoint != nil {
-		run.Status = "paused"
-		run.State.Stage = agentApprovalStep
-		run.State.Data = []byte(message)
-		if a.pause.Tool == toolHumanInput {
-			run.State.Stage = agentInputStep
-			_ = run.State.Set(inputPause{OriginalMessage: message, Prompt: a.pause.Message})
-		}
-		run.Steps[0].Status = "paused"
-		run.Steps[0].Error = a.pause.Message
-		run.Steps[0].Result = a.pause.Tool
-		if err := a.saveRun(ctx, run); err != nil {
+	const maxPlanCompletionTurns = 3
+	var resp *ai.Response
+	for planCompletionTurn := 0; ; planCompletionTurn++ {
+		resp, err = ai.GenerateWithRetry(ctx, a.model, &ai.Request{
+			Prompt:       message,
+			SystemPrompt: a.buildPrompt(),
+			Tools:        toolList,
+			Messages:     messages,
+		}, ai.GeneratePolicy{
+			Timeout:     a.opts.ModelTimeout,
+			MaxAttempts: a.opts.ModelMaxAttempts,
+			Backoff:     a.opts.ModelRetryBackoff,
+		})
+		if err != nil {
+			run.Status = agentRunFailureStatus(err)
+			if a.currentRun != nil {
+				run.Steps = a.currentRun.Steps
+			}
+			if len(run.Steps) == 0 {
+				run.Steps = []flow.StepRecord{{Name: agentAskStep}}
+			}
+			run.Steps[0].Status = run.Status
+			run.Steps[0].Error = err.Error()
+			_ = a.saveRun(ctx, run)
 			return nil, err
 		}
-		return nil, fmt.Errorf("agent run %s paused for approval: %s", run.ID, a.pause.Message)
-	}
-
-	if len(resp.ToolCalls) == 0 {
-		if calls, answer, ok := a.executeTextToolCalls(ctx, resp.Reply, toolList); ok {
-			resp.ToolCalls = calls
-			if resp.Answer == "" {
-				resp.Answer = answer
+		if a.pause != nil && a.opts.Checkpoint != nil {
+			run.Status = "paused"
+			run.State.Stage = agentApprovalStep
+			run.State.Data = []byte(message)
+			if a.pause.Tool == toolHumanInput {
+				run.State.Stage = agentInputStep
+				_ = run.State.Set(inputPause{OriginalMessage: message, Prompt: a.pause.Message})
 			}
-			trimmedReply := strings.TrimSpace(resp.Reply)
-			if strings.HasPrefix(trimmedReply, "{") || strings.HasPrefix(trimmedReply, "[") || strings.HasPrefix(trimmedReply, "```") {
-				resp.Reply = ""
+			run.Steps[0].Status = "paused"
+			run.Steps[0].Error = a.pause.Message
+			run.Steps[0].Result = a.pause.Tool
+			if err := a.saveRun(ctx, run); err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("agent run %s paused for approval: %s", run.ID, a.pause.Message)
+		}
+
+		if len(resp.ToolCalls) == 0 {
+			if calls, answer, ok := a.executeTextToolCalls(ctx, resp.Reply, toolList); ok {
+				resp.ToolCalls = calls
+				if resp.Answer == "" {
+					resp.Answer = answer
+				}
+				trimmedReply := strings.TrimSpace(resp.Reply)
+				if strings.HasPrefix(trimmedReply, "{") || strings.HasPrefix(trimmedReply, "[") || strings.HasPrefix(trimmedReply, "```") {
+					resp.Reply = ""
+				}
 			}
 		}
+
+		if a.opts.Checkpoint != nil {
+			if unfinished := a.unfinishedPlanSteps(); len(unfinished) > 0 && planCompletionTurn < maxPlanCompletionTurns {
+				if resp.Reply != "" {
+					a.mem.Add("assistant", resp.Reply)
+				}
+				if resp.Answer != "" {
+					a.mem.Add("assistant", resp.Answer)
+				}
+				message = "Continue the run. These plan steps are still unfinished and must be completed before a final answer: " + strings.Join(unfinished, ", ")
+				a.mem.Add("user", message)
+				messages = a.mem.Messages()
+				continue
+			}
+		}
+		break
 	}
 
 	if resp.Reply != "" {

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 
 	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/client"
+	codecBytes "go-micro.dev/v6/codec/bytes"
 	"go-micro.dev/v6/flow"
+	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/store"
 )
 
@@ -141,40 +144,78 @@ func TestCheckpointSkipsDuplicateToolWithinAsk(t *testing.T) {
 	}
 }
 
-func TestCheckpointFailsRunWithUnfinishedPlanStep(t *testing.T) {
+func TestCheckpointContinuesRunWithUnfinishedPlanStep(t *testing.T) {
 	ctx := context.Background()
 	cp := flow.StoreCheckpoint(store.NewMemoryStore(), "unfinished-plan-agent")
+
+	reg := registry.NewMemoryRegistry()
+	if err := reg.Register(&registry.Service{
+		Name:     "comms",
+		Metadata: map[string]string{"type": "agent"},
+		Nodes:    []*registry.Node{{Id: "comms-1", Address: "127.0.0.1:0"}},
+	}); err != nil {
+		t.Fatalf("register comms agent: %v", err)
+	}
+
+	delegateCalls := 0
+	fc := &fakeClient{Client: client.DefaultClient}
+	fc.callFn = func(ctx context.Context, req client.Request, rsp interface{}) error {
+		delegateCalls++
+		if req.Service() != "comms" || req.Endpoint() != "Agent.Chat" {
+			t.Fatalf("delegate RPC = %s %s, want comms Agent.Chat", req.Service(), req.Endpoint())
+		}
+		frame := rsp.(*codecBytes.Frame)
+		frame.Data = []byte(`{"reply":"owner notified","agent":"comms"}`)
+		return nil
+	}
+
+	modelCalls := 0
 	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		modelCalls++
 		if opts.ToolHandler == nil {
 			t.Fatal("missing tool handler")
 		}
-		opts.ToolHandler(ctx, ai.ToolCall{ID: "plan-1", Name: toolPlan, Input: map[string]any{
-			"steps": []any{
-				map[string]any{"task": "create launch tasks", "status": "done"},
-				map[string]any{"task": "notify owner via comms", "status": "in_progress"},
-			},
-		}})
-		return &ai.Response{Reply: "all done"}, nil
+		switch modelCalls {
+		case 1:
+			opts.ToolHandler(ctx, ai.ToolCall{ID: "plan-1", Name: toolPlan, Input: map[string]any{
+				"steps": []any{
+					map[string]any{"task": "create launch tasks", "status": "done"},
+					map[string]any{"task": "delegate readiness notification to comms", "status": "in_progress"},
+				},
+			}})
+			return &ai.Response{Reply: "tasks are ready"}, nil
+		case 2:
+			if !strings.Contains(req.Prompt, "delegate readiness notification to comms") {
+				t.Fatalf("continuation prompt = %q, want unfinished step", req.Prompt)
+			}
+			res := opts.ToolHandler(ctx, ai.ToolCall{ID: "delegate-1", Name: toolDelegate, Input: map[string]any{"task": "Notify owner@acme.com that the launch plan is ready", "to": "comms"}})
+			if !strings.Contains(res.Content, "owner notified") {
+				t.Fatalf("delegate result = %q, want owner notified", res.Content)
+			}
+			return &ai.Response{Reply: "all done"}, nil
+		default:
+			t.Fatalf("unexpected model call %d", modelCalls)
+			return nil, nil
+		}
 	}
 	defer func() { fakeGen = nil }()
 
-	a := newTestAgent(Name("unfinished-plan-agent"), WithCheckpoint(cp))
-	_, err := a.Ask(ctx, "create tasks and notify owner")
-	if err == nil {
-		t.Fatal("Ask succeeded with unfinished plan step")
-	}
-	if !strings.Contains(err.Error(), "notify owner via comms") {
-		t.Fatalf("Ask error = %v, want unfinished delegate step named", err)
-	}
-	runs, err := Pending(ctx, a)
+	a := newTestAgent(Name("unfinished-plan-agent"), WithCheckpoint(cp), WithRegistry(reg), WithClient(fc))
+	resp, err := a.Ask(ctx, "create tasks and notify owner")
 	if err != nil {
-		t.Fatalf("Pending: %v", err)
+		t.Fatalf("Ask: %v", err)
 	}
-	if len(runs) != 1 {
-		t.Fatalf("Pending returned %d runs, want failed run remains actionable", len(runs))
+	if resp.Reply != "all done" {
+		t.Fatalf("reply = %q, want final continuation reply", resp.Reply)
 	}
-	if runs[0].Status != "failed" {
-		t.Fatalf("run status = %q, want failed", runs[0].Status)
+	if modelCalls != 2 {
+		t.Fatalf("model calls = %d, want initial plus continuation", modelCalls)
+	}
+	if delegateCalls != 1 {
+		t.Fatalf("delegate calls = %d, want exactly one", delegateCalls)
+	}
+	if unfinished := a.unfinishedPlanSteps(); len(unfinished) != 0 {
+		t.Fatalf("unfinished plan steps = %v, want none", unfinished)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Continue checkpointed agent runs when an intermediate model reply leaves plan steps unfinished.
- Add a regression test covering a continuation that completes exactly one delegated comms notification.

Testing:
- go build ./...
- go test ./agent -run TestCheckpointContinuesRunWithUnfinishedPlanStep -count=1
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3699
Closes #3705