### PR TITLE
docs: add no-secret first-agent transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,14 @@ make harness
 After install and the first `micro new`/`micro run` smoke check, take the
 walkable agent path in this order:
 
-1. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
+1. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
+   maintained support agent with a mock model and see services → agents → workflows succeed without a key.
+2. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
    service-backed agent and talk to it with `micro chat`.
-2. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
+3. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
    `micro agent inspect`, run history, memory, and provider checks when the first
    conversation does something unexpected.
-3. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
+4. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
    services → agents → workflows loop with scaffold, run, chat, inspect, flow
    history, and deploy dry-run commands that match the maintained harness.
 

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -45,6 +45,7 @@ func TestGuidesNavigationLeadsWithDoing(t *testing.T) {
 	nav := readFile(t, filepath.Join(root, "internal", "website", "_data", "navigation.yml"))
 
 	orderedGuides := []string{
+		"/docs/guides/no-secret-first-agent.html",
 		"/docs/guides/your-first-agent.html",
 		"/docs/guides/zero-to-hero.html",
 		"/docs/guides/plan-delegate.html",
@@ -70,6 +71,37 @@ func TestGuidesNavigationLeadsWithDoing(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(root, "internal", "website", "docs", doc)); err != nil {
 			t.Fatalf("navigation links to missing guide %s: %v", guide, err)
 		}
+	}
+}
+
+func TestNoSecretFirstAgentTranscript(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	guide := readFile(t, filepath.Join(root, "internal", "website", "docs", "guides", "no-secret-first-agent.md"))
+
+	for _, want := range []string{
+		"go run ./examples/support",
+		"go test ./examples/support -run TestRunSupportMockSmoke -count=1",
+		"make harness",
+		"micro agent preflight",
+		"micro run",
+		"micro chat assistant",
+		"micro inspect agent assistant",
+		"go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1",
+		"No-secret first-agent transcript",
+	} {
+		if !strings.Contains(guide, want) {
+			t.Fatalf("no-secret first-agent transcript missing %q", want)
+		}
+	}
+
+	readme := readFile(t, filepath.Join(root, "README.md"))
+	if !strings.Contains(readme, "internal/website/docs/guides/no-secret-first-agent.md") {
+		t.Fatal("README does not point to the no-secret first-agent transcript")
+	}
+
+	firstAgent := readFile(t, filepath.Join(root, "internal", "website", "docs", "guides", "your-first-agent.md"))
+	if !strings.Contains(firstAgent, "no-secret-first-agent.html") {
+		t.Fatal("Your First Agent guide does not point to the no-secret transcript")
 	}
 }
 

--- a/internal/website/_data/navigation.yml
+++ b/internal/website/_data/navigation.yml
@@ -5,6 +5,8 @@ core:
     url: /docs/getting-started.html
   - title: AI Integration
     url: /docs/ai-integration.html
+  - title: No-secret First Agent
+    url: /docs/guides/no-secret-first-agent.html
   - title: Your First Agent
     url: /docs/guides/your-first-agent.html
   - title: 0→hero Reference

--- a/internal/website/docs/guides/no-secret-first-agent.md
+++ b/internal/website/docs/guides/no-secret-first-agent.md
@@ -1,0 +1,94 @@
+---
+layout: default
+---
+
+# No-secret first-agent transcript
+
+This is the fastest first-agent success path when you do not have a provider key
+handy. It starts from the maintained `examples/support` app and uses the
+repository harness that CI already runs: real Go Micro services, registry,
+broker, client, store, agent loop, flow handoff, and guardrail code with only the
+LLM provider mocked.
+
+Use it before the live-provider [Your First Agent](your-first-agent.html)
+walkthrough when you want to see the services → agents → workflows lifecycle run
+end to end with no secrets.
+
+## What this proves
+
+- **Services** expose typed `customers`, `tickets`, and `notify` endpoints.
+- **The `support` agent** discovers those endpoints as tools and uses them to
+  triage a ticket.
+- **The `intake` flow** turns a `ticket.created` event into an agent run.
+- **The approval gate** intercepts the customer email action before the tool
+  executes.
+
+## Transcript
+
+From a fresh clone of the repository:
+
+```sh
+git clone https://github.com/micro/go-micro.git
+cd go-micro
+go run ./examples/support
+```
+
+The default provider is `mock`, so the command does not need `ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, or any other secret. A healthy run prints the event, service
+calls, guardrail decision, and final support-agent reply in one terminal:
+
+```text
+> event: events.ticket.created {"id":"ticket-1","customer":"alice@acme.com",...}
+
+    [customers] looked up Alice (pro plan)
+    [tickets]   ticket-1 → priority=high status=in_progress
+    ▣ approval gate notify_NotifyService_Send(alice@acme.com) — approved
+    [notify]    📨 to=alice@acme.com: "Hi Alice — thanks for reaching out..."
+
+support agent: Hi Alice — thanks for reaching out...
+
+✓ ticket triaged and the customer was replied to — triggered by an event
+```
+
+That single run is the no-secret version of the first-agent loop: a service
+capability exists, an agent calls it as a tool, and workflow infrastructure can
+trigger and inspect the work.
+
+## CI-backed check
+
+Run the same deterministic path as a focused test:
+
+```sh
+go test ./examples/support -run TestRunSupportMockSmoke -count=1
+```
+
+For the broader no-secret contract that also checks scaffold, chat/inspect CLI
+boundaries, flow history, deploy dry-run, and mock provider conformance, run:
+
+```sh
+make harness
+```
+
+## Equivalent scaffold → run → chat → inspect path
+
+When you are ready to build the smaller live-agent version yourself, follow
+[Your First Agent](your-first-agent.html). The command shape is the same, but a
+live `micro chat` turn needs a provider key because the model is no longer
+mocked:
+
+```sh
+micro agent preflight
+micro run
+micro chat assistant
+micro inspect agent assistant
+```
+
+CI keeps those CLI boundaries present with:
+
+```sh
+go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1
+```
+
+If chat behaves unexpectedly, continue to
+[Debugging your agent](debugging-agents.html) for provider checks, run history,
+memory, and tool-call inspection.

--- a/internal/website/docs/guides/your-first-agent.md
+++ b/internal/website/docs/guides/your-first-agent.md
@@ -13,13 +13,13 @@ run on events or schedules.
 
 ## Runnable reference first
 
-If you want to run the lifecycle before copying code, start with the maintained support-desk example from the repository root:
+If you want to run the lifecycle before copying code, start with the [no-secret first-agent transcript](no-secret-first-agent.html) or run the maintained support-desk example from the repository root:
 
 ```sh
 go run ./examples/support
 ```
 
-It uses a deterministic mock model by default, so it needs no provider key, and it exercises the same shape this guide teaches: services become tools, an agent uses them, and a flow can trigger the work. Use this guide when you are ready to build the smaller 0→1 version yourself.
+It uses a deterministic mock model by default, so it needs no provider key, and it exercises the same shape this guide teaches: services become tools, an agent uses them, and a flow can trigger the work. Use the transcript for expected output, then use this guide when you are ready to build the smaller 0→1 version yourself.
 
 ## What you'll build
 
@@ -219,7 +219,7 @@ agent for judgment, tool use, and handoffs when the path is not known up front.
 
 - Read the [0→hero reference path](zero-to-hero.html) for the CI-verified
   lifecycle contract.
-- Run [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support) for the no-secret 0→hero support-desk lifecycle.
+- Run the [no-secret first-agent transcript](no-secret-first-agent.html) or [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support) for the no-secret support-desk lifecycle.
 - Run [`examples/agent-plan-delegate`](https://github.com/micro/go-micro/tree/master/examples/agent-plan-delegate)
   to see planning and delegation across agents.
 - Read [Debugging your agent](debugging-agents.html) when a chat turn does not call the tool you expected, loops, refuses a call, loses memory, or fails after a flow handoff.

--- a/internal/website/docs/index.md
+++ b/internal/website/docs/index.md
@@ -16,7 +16,7 @@ It's built on a pluggable architecture of Go interfaces: service discovery, clie
 
 ## Learn More
 
-Start with [Getting Started](getting-started.html) for install and the first local service. Then follow the first-agent on-ramp: [Your First Agent](guides/your-first-agent.html) to build and chat with a service-backed agent, [Debugging your agent](guides/debugging-agents.html) to inspect runs and memory, and the [0→hero reference path](guides/zero-to-hero.html) to walk the full scaffold → run → chat → inspect → deploy dry-run lifecycle covered by CI.
+Start with [Getting Started](getting-started.html) for install and the first local service. Then follow the first-agent on-ramp: [No-secret first-agent transcript](guides/no-secret-first-agent.html) to run a mock-model support agent, [Your First Agent](guides/your-first-agent.html) to build and chat with a service-backed agent, [Debugging your agent](guides/debugging-agents.html) to inspect runs and memory, and the [0→hero reference path](guides/zero-to-hero.html) to walk the full scaffold → run → chat → inspect → deploy dry-run lifecycle covered by CI.
 
 Otherwise continue to read the docs for more information about the framework.
 
@@ -24,6 +24,7 @@ Otherwise continue to read the docs for more information about the framework.
 
 - [Getting Started](getting-started.html)
 - [0→hero Reference](guides/zero-to-hero.html) - Walk scaffold → run → chat → inspect → deploy dry-run with CI-backed commands
+- [No-secret first-agent transcript](guides/no-secret-first-agent.html) - Run the first useful agent path without a provider key
 - [Your First Agent](guides/your-first-agent.html) - Build a service-backed agent end to end
 - [MCP & AI Agents](mcp.html) - Turn services into AI-callable tools with the Model Context Protocol
 - [CLI & Gateway Guide](guides/cli-gateway.html) - Development vs Production modes
@@ -47,6 +48,7 @@ Otherwise continue to read the docs for more information about the framework.
 ## AI & Agents
 
 - [0→hero Reference](guides/zero-to-hero.html) - Walk scaffold → run → chat → inspect → deploy dry-run with CI-backed commands
+- [No-secret first-agent transcript](guides/no-secret-first-agent.html) - Run the first useful agent path without a provider key
 - [Your First Agent](guides/your-first-agent.html) - Build a service-backed agent end to end
 - [Building AI-Native Services](guides/ai-native-services.html) - End-to-end tutorial for MCP-enabled services
 - [MCP Security Guide](guides/mcp-security.html) - Auth, scopes, rate limiting, and audit logging


### PR DESCRIPTION
Summary:
- Add a no-secret first-agent transcript for the maintained support example.
- Link the transcript from the README, first-agent guide, docs index, and website navigation.
- Add docs tests that keep the transcript commands and links present.

Testing:
- go build ./...
- go test ./... (fails in this environment: cache expiry timing flake and loopback targets forbidden for grpc client/transport tests)
- golangci-lint run ./...
- go test ./internal/harness/zero-to-hero-ci ./cmd/micro ./examples/support -run 'TestNoSecretFirstAgentTranscript|TestGuidesNavigationLeadsWithDoing|TestFirstAgentWalkthroughCLIBoundaries|TestRunSupportMockSmoke' -count=1 -timeout=3m

Closes #3708
Closes #3712