### PR TITLE
Make universe buyer notifications deterministic

### DIFF
--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -159,12 +159,25 @@ func isBuyerNotification(req *SendRequest) bool {
 }
 
 func canonicalBuyerRecipient(to string) string {
-	switch strings.ToLower(strings.TrimSpace(to)) {
+	recipient := strings.ToLower(strings.TrimSpace(to))
+	switch recipient {
 	case "buyer", "buyer@acme.com":
 		return "buyer@acme.com"
-	default:
-		return ""
 	}
+	for _, field := range strings.FieldsFunc(recipient, func(r rune) bool {
+		switch r {
+		case ' ', '\t', '\n', '\r', ',', ';', ':', '/', '\\', '(', ')', '[', ']', '{', '}':
+			return true
+		default:
+			return false
+		}
+	}) {
+		switch field {
+		case "buyer", "buyer@acme.com":
+			return "buyer@acme.com"
+		}
+	}
+	return ""
 }
 
 func notificationDedupeKeys(req *SendRequest) []string {

--- a/internal/harness/universe/main_test.go
+++ b/internal/harness/universe/main_test.go
@@ -154,3 +154,35 @@ func TestNotifyIgnoresNonBuyerRecipients(t *testing.T) {
 		t.Fatalf("buyer notifications sent = %d, want 1", got)
 	}
 }
+
+func TestNotifyAcceptsOrderScopedBuyerRecipient(t *testing.T) {
+	ntf := new(Notify)
+	ctx := context.Background()
+
+	var rsp SendResponse
+	if err := ntf.Send(ctx, &SendRequest{
+		To:      "order-1 buyer",
+		Message: "order-1 confirmed",
+	}, &rsp); err != nil {
+		t.Fatalf("send order-scoped buyer notification: %v", err)
+	}
+	if !rsp.Sent {
+		t.Fatal("order-scoped buyer notification did not report sent")
+	}
+	if got := atomic.LoadInt64(&ntf.sent); got != 1 {
+		t.Fatalf("order-scoped buyer notifications sent = %d, want 1", got)
+	}
+
+	if err := ntf.Send(ctx, &SendRequest{
+		To:      "non-buyer",
+		Message: "order-1 confirmed",
+	}, &rsp); err != nil {
+		t.Fatalf("send hyphenated non-buyer notification: %v", err)
+	}
+	if rsp.Sent {
+		t.Fatal("hyphenated non-buyer notification reported sent")
+	}
+	if got := atomic.LoadInt64(&ntf.sent); got != 1 {
+		t.Fatalf("notifications sent after hyphenated non-buyer = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary
- accept live-provider order-scoped buyer recipients such as `order-1 buyer` as the canonical buyer notification target
- keep hyphenated non-buyer recipients ignored so the universe harness assertion remains strict

Closes #3718
Closes #3725

## Testing
- `go build ./...`
- `go test -run TestNotify -count=1 ./internal/harness/universe`
- `go test ./...` (environment warning: loopback GRPC tests are blocked by sandbox envoy with `Loopback targets forbidden`)
- `golangci-lint run ./...`