### PR TITLE
Detect duplicate plan-delegate notifications

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -135,9 +135,11 @@ type SendResponse struct {
 	Sent bool `json:"sent"`
 }
 type NotifyService struct {
-	mu     sync.Mutex
-	sent   int
-	bySend map[string]bool
+	mu         sync.Mutex
+	sent       int
+	attempts   int
+	duplicates int
+	bySend     map[string]bool
 }
 
 // Send delivers a notification message to a recipient. Duplicate delivery
@@ -150,11 +152,13 @@ func (s *NotifyService) Send(ctx context.Context, req *SendRequest, rsp *SendRes
 		s.bySend = map[string]bool{}
 	}
 	key := strings.ToLower(strings.TrimSpace(req.To)) + "\x00" + strings.ToLower(strings.TrimSpace(req.Message))
+	s.attempts++
 	if !s.bySend[key] {
 		s.bySend[key] = true
 		s.sent++
 		fmt.Printf("    \033[35m[notify]\033[0m 📨 to=%s message=%q\n", req.To, req.Message)
 	} else {
+		s.duplicates++
 		fmt.Printf("    \033[35m[notify]\033[0m reused to=%s message=%q\n", req.To, req.Message)
 	}
 	s.mu.Unlock()
@@ -166,6 +170,12 @@ func (s *NotifyService) count() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.sent
+}
+
+func (s *NotifyService) duplicateAttempts() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.duplicates
 }
 
 // ---------------------------------------------------------------------------
@@ -396,8 +406,15 @@ func runPlanDelegate(provider string) error {
 	}
 
 	fmt.Print("\n\033[1m> flow:\033[0m services + agents + workflow + plan/delegate, no API key.\n\n")
-	if err := f.Execute(context.Background(), "launch readiness"); err != nil {
-		return fmt.Errorf("flow execute: %w", err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	executeDone := make(chan error, 1)
+	go func() {
+		executeDone <- f.Execute(ctx, "launch readiness")
+	}()
+
+	if err := waitForPlanDelegateExecution(executeDone, notifySvc); err != nil {
+		return err
 	}
 
 	if rs := f.Results(); len(rs) > 0 {
@@ -416,6 +433,24 @@ func runPlanDelegate(provider string) error {
 
 	fmt.Println("\n\033[32m✓ 0→hero flow complete (services → agents → workflow)\033[0m")
 	return nil
+}
+
+func waitForPlanDelegateExecution(done <-chan error, notifySvc *NotifyService) error {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-done:
+			if err != nil {
+				return fmt.Errorf("flow execute: %w", err)
+			}
+			return nil
+		case <-ticker.C:
+			if dup := notifySvc.duplicateAttempts(); dup > 0 {
+				return fmt.Errorf("duplicate notify attempts: got %d duplicate replay(s), want 0", dup)
+			}
+		}
+	}
 }
 
 func main() {

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -242,6 +243,32 @@ func TestTaskServiceAddIsIdempotentForLaunchTitles(t *testing.T) {
 	}
 	if got := svc.count(); got != 3 {
 		t.Fatalf("task count = %d, want 3 after duplicate launch-title replays", got)
+	}
+}
+
+func TestPlanDelegateExecutionReportsDuplicateNotifyBeforeTimeout(t *testing.T) {
+	notifySvc := new(NotifyService)
+	for i := 0; i < 2; i++ {
+		var rsp SendResponse
+		if err := notifySvc.Send(context.Background(), &SendRequest{To: "owner@acme.com", Message: "The launch plan is ready"}, &rsp); err != nil {
+			t.Fatalf("Send attempt %d: %v", i+1, err)
+		}
+	}
+
+	done := make(chan error)
+	errCh := make(chan error, 1)
+	go func() { errCh <- waitForPlanDelegateExecution(done, notifySvc) }()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("waitForPlanDelegateExecution returned nil, want duplicate notify error")
+		}
+		if got := err.Error(); !strings.Contains(got, "duplicate notify attempts") {
+			t.Fatalf("error = %q, want duplicate notify attempts", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waitForPlanDelegateExecution did not report duplicate notify before timeout")
 	}
 }
 


### PR DESCRIPTION
Summary:
- Track duplicate notify attempts in the plan-delegate harness and fail with a scoped duplicate-notification error instead of waiting for the flow RPC timeout.
- Add CI-safe coverage proving duplicate notify replays are surfaced before timeout.

Testing:
- go build ./...
- go test ./internal/harness/plan-delegate -run TestPlanDelegateExecutionReportsDuplicateNotifyBeforeTimeout -count=1 -v
- go test ./... (fails in this environment: loopback targets forbidden in grpc client/transport tests)
- golangci-lint run ./...

Closes #3724
Closes #3730