### PR TITLE
Fix Atlas Cloud tool streaming fallback

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -163,6 +163,10 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 // Stream generates a streaming response from Atlas Cloud's OpenAI-compatible
 // chat completions endpoint, emitting content deltas as they arrive.
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
+	if len(req.Tools) > 0 {
+		return nil, fmt.Errorf("%w: atlascloud streaming does not expose tools", ai.ErrStreamingUnsupported)
+	}
+
 	messages := []map[string]any{
 		{"role": "system", "content": req.SystemPrompt},
 	}

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -140,6 +140,21 @@ func TestProvider_Stream(t *testing.T) {
 	}
 }
 
+func TestProvider_StreamWithToolsFallsBack(t *testing.T) {
+	p := NewProvider(ai.WithAPIKey("test-key"))
+	_, err := p.Stream(context.Background(), &ai.Request{
+		Prompt: "call a tool",
+		Tools: []ai.Tool{{
+			Name:        "fallback_echo",
+			Description: "echo fallback marker",
+			Properties:  map[string]any{"value": map[string]any{"type": "string"}},
+		}},
+	})
+	if !errors.Is(err, ai.ErrStreamingUnsupported) {
+		t.Fatalf("Stream with tools error = %v, want ErrStreamingUnsupported", err)
+	}
+}
+
 func TestProvider_Registration(t *testing.T) {
 	m := ai.New("atlascloud", ai.WithAPIKey("test"))
 	if m == nil {


### PR DESCRIPTION
## Summary
- Return ErrStreamingUnsupported when Atlas Cloud streaming is requested with tools so the A2A message/stream gateway falls back to the Ask path that exposes fallback_echo.
- Add coverage for tool-bearing Atlas Cloud stream requests.

Closes #3560
Closes #3737

## Testing
- go build ./...
- go test ./ai/atlascloud ./internal/harness/a2a-stream-fallback
- go run ./internal/harness/a2a-stream-fallback -provider mock
- golangci-lint run ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy: client/grpc and transport/grpc)
