### PR TITLE
atlascloud: fall back to tool results

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -131,6 +131,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 	}
 
 	if p.opts.ToolHandler != nil {
+		var toolResults []string
 		followUpMessages := append(messages, map[string]any{
 			"role":       "assistant",
 			"content":    rawMessage["content"],
@@ -139,6 +140,9 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 
 		for _, tc := range resp.ToolCalls {
 			content := p.opts.ToolHandler(ctx, tc).Content
+			if content != "" {
+				toolResults = append(toolResults, content)
+			}
 			followUpMessages = append(followUpMessages, map[string]any{
 				"role":         "tool",
 				"tool_call_id": tc.ID,
@@ -154,6 +158,8 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		followUpResp, _, err := p.callAPI(ctx, followUpReq)
 		if err == nil && followUpResp.Reply != "" {
 			resp.Answer = followUpResp.Reply
+		} else if len(toolResults) > 0 {
+			resp.Answer = strings.Join(toolResults, "\n")
 		}
 	}
 

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -155,6 +155,54 @@ func TestProvider_StreamWithToolsFallsBack(t *testing.T) {
 	}
 }
 
+func TestProvider_GenerateToolCallEmptyFollowUpUsesToolResult(t *testing.T) {
+	var calls int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %s, want /v1/chat/completions", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"","tool_calls":[{"id":"call-1","function":{"name":"conformance_echo","arguments":"{\"value\":\"agent-conformance\"}"}}]}}]}`))
+		case 2:
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":""}}]}`))
+		default:
+			t.Fatalf("unexpected API call %d", calls)
+		}
+	}))
+	defer ts.Close()
+
+	p := NewProvider(
+		ai.WithAPIKey("test-key"),
+		ai.WithBaseURL(ts.URL),
+		ai.WithToolHandler(func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+			if call.Name != "conformance_echo" {
+				t.Fatalf("tool name = %q, want conformance_echo", call.Name)
+			}
+			return ai.ToolResult{ID: call.ID, Content: `{"marker":"agent-conformance-ok"}`}
+		}),
+	)
+	resp, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "call a tool",
+		Tools: []ai.Tool{{
+			Name:        "conformance_echo",
+			Description: "echo conformance marker",
+			Properties:  map[string]any{"value": map[string]any{"type": "string"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("API calls = %d, want 2", calls)
+	}
+	if resp.Answer != `{"marker":"agent-conformance-ok"}` {
+		t.Fatalf("Answer = %q, want tool result fallback", resp.Answer)
+	}
+}
+
 func TestProvider_Registration(t *testing.T) {
 	m := ai.New("atlascloud", ai.WithAPIKey("test"))
 	if m == nil {


### PR DESCRIPTION
Summary:
- Preserve AtlasCloud tool execution output when the post-tool follow-up response is empty.
- Add a CI-safe AtlasCloud test for a tool call followed by an empty assistant response.

Testing:
- go test ./ai/atlascloud
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in grpc client/transport tests)
- golangci-lint run ./...

Closes #3735
Closes #3743