### PR TITLE
Fix AtlasCloud tool-call request diagnostics

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -52,6 +52,15 @@ type Provider struct {
 	opts ai.Options
 }
 
+type atlasToolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
 // NewProvider creates a new Atlas Cloud provider.
 func NewProvider(opts ...ai.Option) *Provider {
 	options := ai.NewOptions(opts...)
@@ -121,7 +130,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		apiReq["tools"] = tools
 	}
 
-	resp, rawMessage, err := p.callAPI(ctx, apiReq)
+	resp, rawMessage, err := p.callAPI(ctx, "chat", apiReq)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +164,11 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 			"messages": followUpMessages,
 		}
 
-		followUpResp, _, err := p.callAPI(ctx, followUpReq)
-		if err == nil && followUpResp.Reply != "" {
+		followUpResp, _, err := p.callAPI(ctx, "tool-follow-up", followUpReq)
+		if err != nil {
+			return nil, err
+		}
+		if followUpResp.Reply != "" {
 			resp.Answer = followUpResp.Reply
 		} else if len(toolResults) > 0 {
 			resp.Answer = strings.Join(toolResults, "\n")
@@ -277,7 +289,7 @@ func (s *atlasStream) Close() error {
 	return s.body.Close()
 }
 
-func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Response, map[string]any, error) {
+func (p *Provider) callAPI(ctx context.Context, phase string, req map[string]any) (*ai.Response, map[string]any, error) {
 	reqBody, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal request: %w", err)
@@ -300,20 +312,14 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 
 	respBody, _ := io.ReadAll(httpResp.Body)
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+		return nil, nil, fmt.Errorf("API error (%s) during atlascloud %s request (%s): %s", httpResp.Status, phase, atlascloudRequestSummary(req), string(respBody))
 	}
 
 	var chatResp struct {
 		Choices []struct {
 			Message struct {
-				Content   string `json:"content"`
-				ToolCalls []struct {
-					ID       string `json:"id"`
-					Function struct {
-						Name      string `json:"name"`
-						Arguments string `json:"arguments"`
-					} `json:"function"`
-				} `json:"tool_calls"`
+				Content   string          `json:"content"`
+				ToolCalls []atlasToolCall `json:"tool_calls"`
 			} `json:"message"`
 		} `json:"choices"`
 	}
@@ -345,10 +351,66 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 
 	rawMessage := map[string]any{
 		"content":    choice.Message.Content,
-		"tool_calls": choice.Message.ToolCalls,
+		"tool_calls": normalizeAtlasCloudToolCalls(choice.Message.ToolCalls),
 	}
 
 	return response, rawMessage, nil
+}
+
+func normalizeAtlasCloudToolCalls(toolCalls []atlasToolCall) []map[string]any {
+	out := make([]map[string]any, 0, len(toolCalls))
+	for _, tc := range toolCalls {
+		toolType := tc.Type
+		if toolType == "" {
+			toolType = "function"
+		}
+		out = append(out, map[string]any{
+			"id":   tc.ID,
+			"type": toolType,
+			"function": map[string]any{
+				"name":      tc.Function.Name,
+				"arguments": tc.Function.Arguments,
+			},
+		})
+	}
+	return out
+}
+
+func atlascloudRequestSummary(req map[string]any) string {
+	parts := []string{}
+	if model, ok := req["model"].(string); ok && model != "" {
+		parts = append(parts, "model="+model)
+	}
+	if messages, ok := req["messages"].([]map[string]any); ok {
+		parts = append(parts, fmt.Sprintf("messages=%d", len(messages)))
+		if len(messages) > 0 {
+			last := messages[len(messages)-1]
+			if role, ok := last["role"].(string); ok && role != "" {
+				parts = append(parts, "last_role="+role)
+			}
+			if _, ok := last["tool_call_id"].(string); ok {
+				parts = append(parts, "last_has_tool_call_id=true")
+			}
+		}
+	}
+	if tools, ok := req["tools"].([]map[string]any); ok {
+		names := make([]string, 0, len(tools))
+		for _, tool := range tools {
+			fn, _ := tool["function"].(map[string]any)
+			name, _ := fn["name"].(string)
+			if name != "" {
+				names = append(names, name)
+			}
+		}
+		parts = append(parts, fmt.Sprintf("tools=%d", len(tools)))
+		if len(names) > 0 {
+			parts = append(parts, "tool_names="+strings.Join(names, ","))
+		}
+	}
+	if len(parts) == 0 {
+		return "request_context=unavailable"
+	}
+	return strings.Join(parts, " ")
 }
 
 const defaultImageModel = "openai/gpt-image-2/text-to-image"

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"go-micro.dev/v6/ai"
@@ -200,6 +201,124 @@ func TestProvider_GenerateToolCallEmptyFollowUpUsesToolResult(t *testing.T) {
 	}
 	if resp.Answer != `{"marker":"agent-conformance-ok"}` {
 		t.Fatalf("Answer = %q, want tool result fallback", resp.Answer)
+	}
+}
+
+func TestProvider_GenerateMinimaxToolRequests(t *testing.T) {
+	var bodies []map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		bodies = append(bodies, body)
+		w.Header().Set("Content-Type", "application/json")
+		switch len(bodies) {
+		case 1:
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"","tool_calls":[{"id":"call-1","function":{"name":"conformance_echo","arguments":"{\"value\":\"agent-conformance\"}"}}]}}]}`))
+		case 2:
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"done"}}]}`))
+		default:
+			t.Fatalf("unexpected API call %d", len(bodies))
+		}
+	}))
+	defer ts.Close()
+
+	p := NewProvider(
+		ai.WithAPIKey("test-key"),
+		ai.WithBaseURL(ts.URL),
+		ai.WithModel("minimaxai/minimax-m3"),
+		ai.WithToolHandler(func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+			return ai.ToolResult{ID: call.ID, Content: `{"marker":"agent-conformance-ok"}`}
+		}),
+	)
+	resp, err := p.Generate(context.Background(), &ai.Request{
+		SystemPrompt: "You are helpful.",
+		Prompt:       "call a tool",
+		Tools: []ai.Tool{{
+			Name:        "conformance_echo",
+			Description: "echo conformance marker",
+			Properties:  map[string]any{"value": map[string]any{"type": "string"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if resp.Answer != "done" {
+		t.Fatalf("Answer = %q, want done", resp.Answer)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("captured requests = %d, want 2", len(bodies))
+	}
+	if got := bodies[0]["model"]; got != "minimaxai/minimax-m3" {
+		t.Fatalf("initial model = %v", got)
+	}
+	tools, ok := bodies[0]["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("initial tools = %#v, want one tool", bodies[0]["tools"])
+	}
+	tool := tools[0].(map[string]any)
+	if tool["type"] != "function" {
+		t.Fatalf("tool type = %v, want function", tool["type"])
+	}
+	fn := tool["function"].(map[string]any)
+	if fn["name"] != "conformance_echo" {
+		t.Fatalf("tool function name = %v", fn["name"])
+	}
+	params := fn["parameters"].(map[string]any)
+	if params["type"] != "object" {
+		t.Fatalf("parameters type = %v, want object", params["type"])
+	}
+
+	followUpMessages := bodies[1]["messages"].([]any)
+	if len(followUpMessages) != 4 {
+		t.Fatalf("follow-up messages = %d, want 4", len(followUpMessages))
+	}
+	assistant := followUpMessages[2].(map[string]any)
+	if assistant["role"] != "assistant" {
+		t.Fatalf("assistant role = %v", assistant["role"])
+	}
+	assistantCalls := assistant["tool_calls"].([]any)
+	assistantCall := assistantCalls[0].(map[string]any)
+	if assistantCall["type"] != "function" {
+		t.Fatalf("assistant tool call type = %v, want function", assistantCall["type"])
+	}
+	toolResult := followUpMessages[3].(map[string]any)
+	if toolResult["role"] != "tool" || toolResult["tool_call_id"] != "call-1" {
+		t.Fatalf("tool result message = %#v", toolResult)
+	}
+}
+
+func TestProvider_GenerateToolCallHTTPErrorIncludesRequestContext(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"code":400,"msg":"bad request"}`, http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	p := NewProvider(
+		ai.WithAPIKey("test-key"),
+		ai.WithBaseURL(ts.URL),
+		ai.WithModel("minimaxai/minimax-m3"),
+	)
+	_, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "call a tool",
+		Tools: []ai.Tool{{
+			Name:        "conformance_echo",
+			Description: "echo conformance marker",
+			Properties:  map[string]any{"value": map[string]any{"type": "string"}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("Generate error = nil, want 400")
+	}
+	msg := err.Error()
+	for _, want := range []string{"400 Bad Request", "atlascloud chat request", "model=minimaxai/minimax-m3", "tools=1", "tool_names=conformance_echo"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q missing %q", msg, want)
+		}
+	}
+	if strings.Contains(msg, "test-key") {
+		t.Fatalf("error leaked API key: %s", msg)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Preserve OpenAI-compatible tool call types when replaying AtlasCloud assistant tool calls in follow-up requests.
- Surface sanitized AtlasCloud request context on HTTP errors so provider 400s identify phase, model, message/tool shape, and tool names without leaking secrets.
- Add CI-safe AtlasCloud minimax tool-call request-shape and diagnostic tests.

Testing:
- go build ./...
- go test ./ai/atlascloud
- go test ./... (fails in this sandbox because loopback targets are forbidden for grpc tests)
- golangci-lint run ./...

Closes #3742
Closes #3748