### PR TITLE
Require harness notification side effects

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -444,6 +444,9 @@ func waitForPlanDelegateExecution(done <-chan error, notifySvc *NotifyService) e
 			if err != nil {
 				return fmt.Errorf("flow execute: %w", err)
 			}
+			if got := notifySvc.count(); got != 1 {
+				return fmt.Errorf("delegation completed without required notify side effect: notify=%d, want 1", got)
+			}
 			return nil
 		case <-ticker.C:
 			if dup := notifySvc.duplicateAttempts(); dup > 0 {

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -272,6 +272,20 @@ func TestPlanDelegateExecutionReportsDuplicateNotifyBeforeTimeout(t *testing.T) 
 	}
 }
 
+func TestPlanDelegateExecutionRejectsClaimedCompletionWithoutNotify(t *testing.T) {
+	notifySvc := new(NotifyService)
+	done := make(chan error, 1)
+	done <- nil
+
+	err := waitForPlanDelegateExecution(done, notifySvc)
+	if err == nil {
+		t.Fatal("waitForPlanDelegateExecution returned nil, want missing notify side-effect error")
+	}
+	if got := err.Error(); !strings.Contains(got, "without required notify side effect") {
+		t.Fatalf("error = %q, want missing notify side-effect error", got)
+	}
+}
+
 func TestNotifyServiceSendIsIdempotentForDuplicateDelivery(t *testing.T) {
 	svc := new(NotifyService)
 	for i := 0; i < 3; i++ {

--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -204,10 +204,10 @@ func dispatchNotifyStep(agentName string, ntf *Notify) flow.StepFunc {
 	return func(ctx context.Context, in flow.State) (flow.State, error) {
 		before := atomic.LoadInt64(&ntf.sent)
 		out, err := dispatch(ctx, in)
-		if err == nil {
-			return out, nil
+		if err != nil {
+			out = in
 		}
-		return completeNotifyOnObservedSideEffect(ctx, in, ntf, before, 2*time.Second, err)
+		return completeNotifyOnObservedSideEffect(ctx, out, ntf, before, 2*time.Second, err)
 	}
 }
 
@@ -220,11 +220,17 @@ func completeNotifyOnObservedSideEffect(ctx context.Context, in flow.State, ntf 
 		}
 		select {
 		case <-ctx.Done():
-			return in, dispatchErr
+			if dispatchErr != nil {
+				return in, dispatchErr
+			}
+			return in, ctx.Err()
 		case <-time.After(25 * time.Millisecond):
 		}
 	}
-	return in, dispatchErr
+	if dispatchErr != nil {
+		return in, dispatchErr
+	}
+	return in, fmt.Errorf("concierge completed without notifying buyer: notify count stayed at %d", before)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/harness/universe/main_test.go
+++ b/internal/harness/universe/main_test.go
@@ -69,6 +69,26 @@ func TestNotifyStepCompletesAfterObservedSideEffectTimeout(t *testing.T) {
 	}
 }
 
+func TestNotifyStepRejectsClaimedCompletionWithoutSideEffect(t *testing.T) {
+	ntf := new(Notify)
+	before := atomic.LoadInt64(&ntf.sent)
+
+	_, err := completeNotifyOnObservedSideEffect(
+		context.Background(),
+		flow.State{Data: []byte(`claimed success`)},
+		ntf,
+		before,
+		25*time.Millisecond,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("notify completion returned nil, want missing buyer notification error")
+	}
+	if got := err.Error(); got != "concierge completed without notifying buyer: notify count stayed at 0" {
+		t.Fatalf("error = %q, want missing buyer notification error", got)
+	}
+}
+
 func TestNotifySuppressesEquivalentConfirmationMessages(t *testing.T) {
 	ntf := new(Notify)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Require the universe notify step to observe the buyer notification side effect before accepting a completed concierge dispatch.
- Require the plan/delegate harness to observe exactly one notification before accepting flow completion.
- Add regression coverage for claimed completion without notification side effects.

Closes #3736
Closes #3755

## Testing
- go test ./internal/harness/universe ./internal/harness/plan-delegate
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in grpc tests)
- golangci-lint run ./...
