### PR TITLE
harness: parse multi-event A2A SSE

### DIFF
--- a/internal/harness/a2a-stream-fallback/main.go
+++ b/internal/harness/a2a-stream-fallback/main.go
@@ -166,22 +166,48 @@ func main() {
 
 func readSSEData(r io.Reader) (string, error) {
 	scanner := bufio.NewScanner(r)
+	var event strings.Builder
 	var payload strings.Builder
+	seen := false
+	flush := func() error {
+		data := strings.TrimSpace(event.String())
+		event.Reset()
+		if data == "" {
+			return nil
+		}
+		if !json.Valid([]byte(data)) {
+			return fmt.Errorf("SSE data event is not JSON: %s", data)
+		}
+		seen = true
+		payload.WriteString(data)
+		payload.WriteByte('\n')
+		return nil
+	}
 	for scanner.Scan() {
 		line := scanner.Text()
-		if data, ok := strings.CutPrefix(line, "data: "); ok {
-			payload.WriteString(data)
-			payload.WriteByte('\n')
+		if strings.TrimSpace(line) == "" {
+			if err := flush(); err != nil {
+				return "", err
+			}
+			continue
 		}
+		data, ok := strings.CutPrefix(line, "data:")
+		if !ok {
+			continue
+		}
+		if event.Len() > 0 {
+			event.WriteByte('\n')
+		}
+		event.WriteString(strings.TrimSpace(data))
 	}
 	if err := scanner.Err(); err != nil {
 		return "", err
 	}
-	if payload.Len() == 0 {
-		return "", errors.New("no SSE data received")
+	if err := flush(); err != nil {
+		return "", err
 	}
-	if !json.Valid([]byte(strings.TrimSpace(payload.String()))) {
-		return "", fmt.Errorf("SSE data is not JSON: %s", payload.String())
+	if !seen {
+		return "", errors.New("no SSE data received")
 	}
 	return payload.String(), nil
 }

--- a/internal/harness/a2a-stream-fallback/main_test.go
+++ b/internal/harness/a2a-stream-fallback/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadSSEDataAcceptsMultipleJSONEvents(t *testing.T) {
+	payload, err := readSSEData(strings.NewReader("event: status\ndata: {\"phase\":\"started\"}\n\ndata:{\"result\":\"a2a-fallback-ok\"}\n\n"))
+	if err != nil {
+		t.Fatalf("readSSEData returned error: %v", err)
+	}
+	if !strings.Contains(payload, "started") || !strings.Contains(payload, "a2a-fallback-ok") {
+		t.Fatalf("payload = %q, want both event payloads", payload)
+	}
+}
+
+func TestReadSSEDataRejectsInvalidJSONEvent(t *testing.T) {
+	_, err := readSSEData(strings.NewReader("data: {\"ok\":true}\n\ndata: {bad json}\n\n"))
+	if err == nil {
+		t.Fatal("readSSEData returned nil error for invalid JSON event")
+	}
+}


### PR DESCRIPTION
## Summary
- Update the A2A stream fallback harness to parse each SSE data event independently instead of concatenating multiple events into invalid JSON.
- Add regression coverage for multi-event SSE payloads and invalid JSON events.

Closes #3662
Closes #3761

## Testing
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden for grpc client/transport tests)
- golangci-lint run ./...