### PR TITLE
feat: add MiniMax provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ MCP exposes your services as tools; A2A exposes your agents as agents. See the [
 | MCP gateway | Every endpoint is an AI tool automatically |
 | A2A gateway | Every agent is reachable over the Agent2Agent protocol; cards generated from the registry (`micro a2a`) |
 | Payments (x402) | Opt-in per-call payments for tools via the x402 standard; pluggable facilitator (Base, Solana, …) |
-| 8 LLM providers | Anthropic, OpenAI, Gemini, Groq, Mistral, Together, Atlas Cloud, Ollama (local + cloud) |
+| 9 LLM providers | Anthropic, OpenAI, Gemini, Groq, Mistral, Together, Atlas Cloud, MiniMax, Ollama (local + cloud) |
 | Interactive console | `micro run` includes a chat console for talking to services |
 | Service generation | `micro run --prompt` — describe a system, get running services |
 
@@ -429,6 +429,7 @@ Swap providers with a single import — same interface everywhere:
 | Mistral | `mistral-large-latest` |
 | Together AI | `meta-llama/Llama-3.3-70B-Instruct-Turbo` |
 | Atlas Cloud | `deepseek-ai/DeepSeek-V3-0324` |
+| MiniMax | `MiniMax-M3` |
 | Ollama | `llama3.2` (local) |
 
 ```go

--- a/ai/README.md
+++ b/ai/README.md
@@ -300,6 +300,20 @@ Default base URL: `https://api.atlascloud.ai`
 
 Atlas Cloud is an enterprise AI infrastructure platform offering high-performance LLM APIs. It exposes an OpenAI-compatible chat completions endpoint with tool calling support.
 
+### MiniMax
+
+```go
+m := ai.New("minimax",
+    ai.WithAPIKey("your-key"),
+    ai.WithModel("MiniMax-M3"), // default
+)
+```
+
+Default model: `MiniMax-M3`
+Default base URL: `https://api.minimax.io`
+
+MiniMax offers its flagship MiniMax-M3 model via an OpenAI-compatible chat completions endpoint.
+
 ## Auto-Detection
 
 Use `AutoDetectProvider()` to detect the provider from a base URL:

--- a/ai/minimax/minimax.go
+++ b/ai/minimax/minimax.go
@@ -1,0 +1,196 @@
+// Package minimax implements the MiniMax model provider.
+//
+// MiniMax offers its flagship MiniMax-M3 model via an OpenAI-compatible
+// chat completions endpoint.
+//
+// Usage:
+//
+//	import _ "go-micro.dev/v6/ai/minimax"
+//
+//	m := ai.New("minimax",
+//	    ai.WithAPIKey("your-api-key"),
+//	)
+package minimax
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/ai/internal/openaiapi"
+)
+
+func init() {
+	ai.Register("minimax", func(opts ...ai.Option) ai.Model {
+		return NewProvider(opts...)
+	})
+	ai.RegisterStream("minimax")
+}
+
+type Provider struct {
+	opts ai.Options
+}
+
+func NewProvider(opts ...ai.Option) *Provider {
+	options := ai.NewOptions(opts...)
+	if options.Model == "" {
+		options.Model = "MiniMax-M3"
+	}
+	if options.BaseURL == "" {
+		options.BaseURL = "https://api.minimax.io"
+	}
+	return &Provider{opts: options}
+}
+
+func (p *Provider) Init(opts ...ai.Option) error {
+	for _, o := range opts {
+		o(&p.opts)
+	}
+	return nil
+}
+
+func (p *Provider) Options() ai.Options { return p.opts }
+func (p *Provider) String() string      { return "minimax" }
+
+func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (*ai.Response, error) {
+	var tools []map[string]any
+	for _, t := range req.Tools {
+		tools = append(tools, map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        t.Name,
+				"description": t.Description,
+				"parameters": map[string]any{
+					"type":       "object",
+					"properties": t.Properties,
+				},
+			},
+		})
+	}
+
+	messages := []map[string]any{
+		{"role": "system", "content": req.SystemPrompt},
+		{"role": "user", "content": req.Prompt},
+	}
+
+	apiReq := map[string]any{
+		"model":    p.opts.Model,
+		"messages": messages,
+	}
+	if len(tools) > 0 {
+		apiReq["tools"] = tools
+	}
+
+	resp, rawMessage, err := p.callAPI(ctx, apiReq)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.ToolCalls) == 0 {
+		return resp, nil
+	}
+
+	if p.opts.ToolHandler != nil {
+		followUpMessages := append(messages, map[string]any{
+			"role":       "assistant",
+			"content":    rawMessage["content"],
+			"tool_calls": rawMessage["tool_calls"],
+		})
+		for _, tc := range resp.ToolCalls {
+			content := p.opts.ToolHandler(ctx, tc).Content
+			followUpMessages = append(followUpMessages, map[string]any{
+				"role":         "tool",
+				"tool_call_id": tc.ID,
+				"content":      content,
+			})
+		}
+		followUpResp, _, err := p.callAPI(ctx, map[string]any{
+			"model":    p.opts.Model,
+			"messages": followUpMessages,
+		})
+		if err == nil && followUpResp.Reply != "" {
+			resp.Answer = followUpResp.Reply
+		}
+	}
+
+	return resp, nil
+}
+
+func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
+	return openaiapi.Stream(ctx, p.opts, req, "/v1/chat/completions")
+}
+
+func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Response, map[string]any, error) {
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	apiURL := strings.TrimRight(p.opts.BaseURL, "/") + "/v1/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+p.opts.APIKey)
+
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	respBody, _ := io.ReadAll(httpResp.Body)
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+	}
+
+	var chatResp struct {
+		Choices []struct {
+			Message struct {
+				Content   string `json:"content"`
+				ToolCalls []struct {
+					ID       string `json:"id"`
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	if len(chatResp.Choices) == 0 {
+		return nil, nil, fmt.Errorf("no response from API")
+	}
+
+	choice := chatResp.Choices[0]
+	response := &ai.Response{Reply: choice.Message.Content}
+
+	for _, tc := range choice.Message.ToolCalls {
+		var input map[string]any
+		if err := json.Unmarshal([]byte(tc.Function.Arguments), &input); err != nil {
+			input = map[string]any{}
+		}
+		response.ToolCalls = append(response.ToolCalls, ai.ToolCall{
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: input,
+		})
+	}
+
+	rawMessage := map[string]any{
+		"content":    choice.Message.Content,
+		"tool_calls": choice.Message.ToolCalls,
+	}
+
+	return response, rawMessage, nil
+}

--- a/ai/minimax/minimax_test.go
+++ b/ai/minimax/minimax_test.go
@@ -1,0 +1,96 @@
+package minimax
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go-micro.dev/v6/ai"
+)
+
+func TestProvider_String(t *testing.T) {
+	if NewProvider().String() != "minimax" {
+		t.Errorf("got %q", NewProvider().String())
+	}
+}
+
+func TestProvider_Defaults(t *testing.T) {
+	opts := NewProvider().Options()
+	if opts.Model != "MiniMax-M3" {
+		t.Errorf("default model = %q", opts.Model)
+	}
+	if opts.BaseURL != "https://api.minimax.io" {
+		t.Errorf("default base URL = %q", opts.BaseURL)
+	}
+}
+
+func TestProvider_Init(t *testing.T) {
+	p := NewProvider()
+	if err := p.Init(ai.WithModel("m"), ai.WithAPIKey("k")); err != nil {
+		t.Fatal(err)
+	}
+	if p.Options().Model != "m" || p.Options().APIKey != "k" {
+		t.Error("Init did not apply options")
+	}
+}
+
+func TestProvider_Generate_NoAPIKey(t *testing.T) {
+	if _, err := NewProvider().Generate(context.Background(), &ai.Request{Prompt: "hi"}); err == nil {
+		t.Error("expected error without API key")
+	}
+}
+
+func TestProvider_Stream(t *testing.T) {
+	var sawStream bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path = %s, want /v1/chat/completions", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		sawStream, _ = body["stream"].(bool)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hel\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	p := NewProvider(ai.WithAPIKey("test-key"), ai.WithBaseURL(ts.URL))
+	stream, err := p.Stream(context.Background(), &ai.Request{Prompt: "Hello"})
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+	defer stream.Close()
+	if !sawStream {
+		t.Fatal("stream request did not set stream=true")
+	}
+
+	first, err := stream.Recv()
+	if err != nil || first.Reply != "hel" {
+		t.Fatalf("first chunk = %#v, %v; want hel", first, err)
+	}
+	second, err := stream.Recv()
+	if err != nil || second.Reply != "lo" {
+		t.Fatalf("second chunk = %#v, %v; want lo", second, err)
+	}
+	if _, err := stream.Recv(); !errors.Is(err, io.EOF) {
+		t.Fatalf("final error = %v, want EOF", err)
+	}
+}
+
+func TestProvider_Registration(t *testing.T) {
+	m := ai.New("minimax", ai.WithAPIKey("test"))
+	if m == nil {
+		t.Fatal("provider not registered")
+	}
+	if m.String() != "minimax" {
+		t.Errorf("got %q", m.String())
+	}
+}

--- a/ai/model.go
+++ b/ai/model.go
@@ -212,6 +212,8 @@ func AutoDetectProvider(baseURL string) string {
 		return "gemini"
 	case strings.Contains(baseURL, "groq"):
 		return "groq"
+	case strings.Contains(baseURL, "minimax"):
+		return "minimax"
 	case strings.Contains(baseURL, "mistral"):
 		return "mistral"
 	case strings.Contains(baseURL, "together"):


### PR DESCRIPTION
## Summary
Add MiniMax as a new LLM provider, compatible with the existing OpenAI-compatible provider architecture.

## Changes
- Add `ai/minimax/minimax.go` implementing `ai.Model` (mirrors the `groq` provider — self-contained OpenAI-compatible chat completions + tool calls, streaming delegated to `ai/internal/openaiapi`)
- Register `minimax` in `init()` with `ai.Register` + `ai.RegisterStream`; default model `MiniMax-M3`, default base URL `https://api.minimax.io`
- Add `minimax` case to `AutoDetectProvider`
- Add unit tests in `ai/minimax/minimax_test.go` (mirrors `groq_test.go`)
- Document the provider in `ai/README.md` and the root README provider table

## Testing
- `go test ./ai/...` passes
- `go vet ./ai/minimax/ ./ai/` clean

## Note
Diff is slightly over 300 lines because the new provider and its test file are near-verbatim clones of the existing `groq` provider, keeping the integration consistent with the sibling OpenAI-compatible providers.