### PR TITLE
Fix plan-delegate timeout completion

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -413,7 +413,7 @@ func runPlanDelegate(provider string) error {
 		executeDone <- f.Execute(ctx, "launch readiness")
 	}()
 
-	if err := waitForPlanDelegateExecution(executeDone, notifySvc); err != nil {
+	if err := waitForPlanDelegateExecution(executeDone, taskSvc, notifySvc); err != nil {
 		return err
 	}
 
@@ -435,17 +435,23 @@ func runPlanDelegate(provider string) error {
 	return nil
 }
 
-func waitForPlanDelegateExecution(done <-chan error, notifySvc *NotifyService) error {
+func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notifySvc *NotifyService) error {
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		select {
 		case err := <-done:
+			tasks := taskSvc.count()
+			notify := notifySvc.count()
 			if err != nil {
-				return fmt.Errorf("flow execute: %w", err)
+				if isClientTimeout(err) && tasks == 3 && notify == 1 {
+					fmt.Printf("\n\033[33mwarning:\033[0m flow execute returned after completed side effects: %v\n", err)
+					return nil
+				}
+				return fmt.Errorf("flow execute after side effects tasks=%d notify=%d: %w", tasks, notify, err)
 			}
-			if got := notifySvc.count(); got != 1 {
-				return fmt.Errorf("delegation completed without required notify side effect: notify=%d, want 1", got)
+			if notify != 1 {
+				return fmt.Errorf("delegation completed without required notify side effect: notify=%d, want 1", notify)
 			}
 			return nil
 		case <-ticker.C:
@@ -454,6 +460,11 @@ func waitForPlanDelegateExecution(done <-chan error, notifySvc *NotifyService) e
 			}
 		}
 	}
+}
+
+func isClientTimeout(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "request timeout") || strings.Contains(msg, "code=408") || strings.Contains(msg, "code\":408")
 }
 
 func main() {

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -257,7 +258,7 @@ func TestPlanDelegateExecutionReportsDuplicateNotifyBeforeTimeout(t *testing.T) 
 
 	done := make(chan error)
 	errCh := make(chan error, 1)
-	go func() { errCh <- waitForPlanDelegateExecution(done, notifySvc) }()
+	go func() { errCh <- waitForPlanDelegateExecution(done, new(TaskService), notifySvc) }()
 
 	select {
 	case err := <-errCh:
@@ -277,12 +278,47 @@ func TestPlanDelegateExecutionRejectsClaimedCompletionWithoutNotify(t *testing.T
 	done := make(chan error, 1)
 	done <- nil
 
-	err := waitForPlanDelegateExecution(done, notifySvc)
+	err := waitForPlanDelegateExecution(done, new(TaskService), notifySvc)
 	if err == nil {
 		t.Fatal("waitForPlanDelegateExecution returned nil, want missing notify side-effect error")
 	}
 	if got := err.Error(); !strings.Contains(got, "without required notify side effect") {
 		t.Fatalf("error = %q, want missing notify side-effect error", got)
+	}
+}
+
+func TestPlanDelegateExecutionAcceptsClientTimeoutAfterSideEffects(t *testing.T) {
+	taskSvc := new(TaskService)
+	for _, title := range []string{"Design", "Build", "Ship"} {
+		var rsp AddResponse
+		if err := taskSvc.Add(context.Background(), &AddRequest{Title: title}, &rsp); err != nil {
+			t.Fatalf("Add(%q): %v", title, err)
+		}
+	}
+	notifySvc := new(NotifyService)
+	var rsp SendResponse
+	if err := notifySvc.Send(context.Background(), &SendRequest{To: "owner@acme.com", Message: "The launch plan is ready"}, &rsp); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	done := make(chan error, 1)
+	done <- errors.New(`{"id":"go.micro.client","code":408,"detail":"<nil>","status":"Request Timeout"}`)
+
+	if err := waitForPlanDelegateExecution(done, taskSvc, notifySvc); err != nil {
+		t.Fatalf("waitForPlanDelegateExecution returned %v, want completed side effects to satisfy client timeout", err)
+	}
+}
+
+func TestPlanDelegateExecutionRejectsClientTimeoutBeforeSideEffects(t *testing.T) {
+	done := make(chan error, 1)
+	done <- errors.New(`{"id":"go.micro.client","code":408,"detail":"<nil>","status":"Request Timeout"}`)
+
+	err := waitForPlanDelegateExecution(done, new(TaskService), new(NotifyService))
+	if err == nil {
+		t.Fatal("waitForPlanDelegateExecution returned nil, want timeout before side effects to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "tasks=0 notify=0") {
+		t.Fatalf("error = %q, want side-effect counts", got)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Treat a post-side-effect client 408 in the plan-delegate harness as completed work when all required task and delegated notify side effects are present.
- Keep failing early when timeout happens before those side effects, and include counts for triage.
- Add deterministic coverage for completed-side-effect and incomplete-side-effect timeout paths.

Testing:
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in client/grpc and transport/grpc)
- go test ./internal/harness/plan-delegate -run 'TestPlanDelegateExecution' -count=1\n- golangci-lint run ./...\n\nCloses #3766\nCloses #3773