### PR TITLE
Accept order-scoped buyer notifications

### DIFF
--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -109,9 +109,10 @@ type SendResponse struct {
 }
 
 type Notify struct {
-	mu   sync.Mutex
-	sent int64
-	seen map[string]struct{}
+	mu           sync.Mutex
+	sent         int64
+	seen         map[string]struct{}
+	lastRejected *SendRequest
 }
 
 // Send delivers a notification.
@@ -122,10 +123,13 @@ func (s *Notify) Send(_ context.Context, req *SendRequest, rsp *SendResponse) er
 		if req != nil {
 			to, message = req.To, req.Message
 		}
+		s.recordRejected(to, message)
 		fmt.Printf("    \033[35m[notify]\033[0m 📨 ignored non-buyer notification to=%s %q\n", to, message)
 		rsp.Sent = false
 		return nil
 	}
+
+	s.recordRejected("", "")
 
 	keys := notificationDedupeKeys(req)
 	s.mu.Lock()
@@ -158,10 +162,32 @@ func isBuyerNotification(req *SendRequest) bool {
 	return canonicalBuyerRecipient(req.To) != ""
 }
 
+func (s *Notify) recordRejected(to, message string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if strings.TrimSpace(to) == "" && strings.TrimSpace(message) == "" {
+		s.lastRejected = nil
+		return
+	}
+	s.lastRejected = &SendRequest{To: to, Message: message}
+}
+
+func (s *Notify) rejectedSummary() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lastRejected == nil {
+		return "no rejected notify call observed"
+	}
+	return fmt.Sprintf("last notify args to=%q message=%q", s.lastRejected.To, s.lastRejected.Message)
+}
+
 func canonicalBuyerRecipient(to string) string {
 	recipient := strings.ToLower(strings.TrimSpace(to))
 	switch recipient {
 	case "buyer", "buyer@acme.com":
+		return "buyer@acme.com"
+	}
+	if strings.HasPrefix(recipient, "buyer-of-order-") && len(recipient) > len("buyer-of-order-") {
 		return "buyer@acme.com"
 	}
 	for _, field := range strings.FieldsFunc(recipient, func(r rune) bool {
@@ -230,7 +256,7 @@ func completeNotifyOnObservedSideEffect(ctx context.Context, in flow.State, ntf 
 	if dispatchErr != nil {
 		return in, dispatchErr
 	}
-	return in, fmt.Errorf("concierge completed without notifying buyer: notify count stayed at %d", before)
+	return in, fmt.Errorf("concierge completed without notifying buyer: notify count stayed at %d; expected recipient buyer@acme.com, buyer, or buyer-of-order-<id>; %s", before, ntf.rejectedSummary())
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/harness/universe/main_test.go
+++ b/internal/harness/universe/main_test.go
@@ -84,8 +84,9 @@ func TestNotifyStepRejectsClaimedCompletionWithoutSideEffect(t *testing.T) {
 	if err == nil {
 		t.Fatal("notify completion returned nil, want missing buyer notification error")
 	}
-	if got := err.Error(); got != "concierge completed without notifying buyer: notify count stayed at 0" {
-		t.Fatalf("error = %q, want missing buyer notification error", got)
+	want := `concierge completed without notifying buyer: notify count stayed at 0; expected recipient buyer@acme.com, buyer, or buyer-of-order-<id>; no rejected notify call observed`
+	if got := err.Error(); got != want {
+		t.Fatalf("error = %q, want %q", got, want)
 	}
 }
 
@@ -181,7 +182,7 @@ func TestNotifyAcceptsOrderScopedBuyerRecipient(t *testing.T) {
 
 	var rsp SendResponse
 	if err := ntf.Send(ctx, &SendRequest{
-		To:      "order-1 buyer",
+		To:      "buyer-of-order-1",
 		Message: "order-1 confirmed",
 	}, &rsp); err != nil {
 		t.Fatalf("send order-scoped buyer notification: %v", err)
@@ -204,5 +205,32 @@ func TestNotifyAcceptsOrderScopedBuyerRecipient(t *testing.T) {
 	}
 	if got := atomic.LoadInt64(&ntf.sent); got != 1 {
 		t.Fatalf("notifications sent after hyphenated non-buyer = %d, want 1", got)
+	}
+}
+
+func TestNotifyStepReportsRejectedRecipientDiagnostics(t *testing.T) {
+	ntf := new(Notify)
+	var rsp SendResponse
+	if err := ntf.Send(context.Background(), &SendRequest{
+		To:      "order-1",
+		Message: "order-1 confirmed",
+	}, &rsp); err != nil {
+		t.Fatalf("send rejected notification: %v", err)
+	}
+
+	_, err := completeNotifyOnObservedSideEffect(
+		context.Background(),
+		flow.State{Data: []byte(`claimed success`)},
+		ntf,
+		0,
+		25*time.Millisecond,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("notify completion returned nil, want diagnostics")
+	}
+	want := `concierge completed without notifying buyer: notify count stayed at 0; expected recipient buyer@acme.com, buyer, or buyer-of-order-<id>; last notify args to="order-1" message="order-1 confirmed"`
+	if got := err.Error(); got != want {
+		t.Fatalf("error = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Summary:
- Accept buyer-of-order-* recipients as buyer notifications in the universe harness notify service.
- Preserve rejection of malformed non-buyer recipients and add actionable missing-side-effect diagnostics with the last rejected notify args.
- Add deterministic unit coverage for buyer-of-order-1 and rejected-recipient diagnostics.

Testing:
- go build ./...
- go test ./internal/harness/universe -run 'TestNotify' -count=1 -v
- go test ./... (fails in this environment because loopback targets are forbidden for grpc client/transport tests)
- golangci-lint run ./...

Closes #3772
Closes #3782