### PR TITLE
ai/minimax: complete provider surface (matrix, conformance, changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ next version when it ships.
 
 ## [Unreleased]
 
+### Added
+- **MiniMax provider** — run agents against MiniMax's `MiniMax-M3` model via its OpenAI-compatible endpoint, with tool calling and streaming; auto-detected from the base URL. (`ai/minimax/`)
+
 ### Fixed
 - **Plan/delegate completion** — agents now continue unfinished plan steps more reliably, fail checkpointed runs that leave delegated plans unfinished, recover from unknown plan-delegate tool calls, avoid duplicate side effects, and complete timeout paths deterministically. (`agent/`)
 - **AtlasCloud tool calls** — streaming and request fallback handling now recovers tool-call results from provider responses that omit the expected structured fields. (`ai/atlascloud/`)

--- a/ai/capabilities_test.go
+++ b/ai/capabilities_test.go
@@ -9,6 +9,7 @@ import (
 	_ "go-micro.dev/v6/ai/atlascloud"
 	_ "go-micro.dev/v6/ai/gemini"
 	_ "go-micro.dev/v6/ai/groq"
+	_ "go-micro.dev/v6/ai/minimax"
 	_ "go-micro.dev/v6/ai/mistral"
 	_ "go-micro.dev/v6/ai/openai"
 	_ "go-micro.dev/v6/ai/together"
@@ -16,7 +17,7 @@ import (
 
 func TestRegisteredProviders(t *testing.T) {
 	got := ai.RegisteredProviders("")
-	want := []string{"anthropic", "atlascloud", "gemini", "groq", "mistral", "openai", "together"}
+	want := []string{"anthropic", "atlascloud", "gemini", "groq", "minimax", "mistral", "openai", "together"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RegisteredProviders() = %#v, want %#v", got, want)
 	}
@@ -34,7 +35,7 @@ func TestRegisteredProviders(t *testing.T) {
 	}
 
 	got = ai.RegisteredProviders("stream")
-	want = []string{"atlascloud", "groq", "mistral", "openai", "together"}
+	want = []string{"atlascloud", "groq", "minimax", "mistral", "openai", "together"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RegisteredProviders(stream) = %#v, want %#v", got, want)
 	}
@@ -47,6 +48,7 @@ func TestCapabilityRows(t *testing.T) {
 		{Provider: "atlascloud", Capabilities: ai.Capabilities{Model: true, Image: true, Video: true, Stream: true}},
 		{Provider: "gemini", Capabilities: ai.Capabilities{Model: true}},
 		{Provider: "groq", Capabilities: ai.Capabilities{Model: true, Stream: true}},
+		{Provider: "minimax", Capabilities: ai.Capabilities{Model: true, Stream: true}},
 		{Provider: "mistral", Capabilities: ai.Capabilities{Model: true, Stream: true}},
 		{Provider: "openai", Capabilities: ai.Capabilities{Model: true, Image: true, Stream: true}},
 		{Provider: "together", Capabilities: ai.Capabilities{Model: true, Stream: true}},
@@ -59,7 +61,7 @@ func TestCapabilityRows(t *testing.T) {
 func TestCapabilityMatrix(t *testing.T) {
 	matrix := ai.CapabilityMatrix()
 
-	for _, provider := range []string{"anthropic", "atlascloud", "gemini", "groq", "mistral", "openai", "together"} {
+	for _, provider := range []string{"anthropic", "atlascloud", "gemini", "groq", "minimax", "mistral", "openai", "together"} {
 		caps, ok := matrix[provider]
 		if !ok {
 			t.Fatalf("CapabilityMatrix missing %q", provider)
@@ -88,7 +90,7 @@ func TestRegisterStream(t *testing.T) {
 	}
 
 	got := ai.RegisteredProviders("stream")
-	want := []string{"atlascloud", "groq", "mistral", "openai", "test-stream", "together"}
+	want := []string{"atlascloud", "groq", "minimax", "mistral", "openai", "test-stream", "together"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RegisteredProviders(stream) = %#v, want %#v", got, want)
 	}

--- a/ai/stream_conformance_test.go
+++ b/ai/stream_conformance_test.go
@@ -18,6 +18,7 @@ import (
 	_ "go-micro.dev/v6/ai/atlascloud"
 	_ "go-micro.dev/v6/ai/gemini"
 	_ "go-micro.dev/v6/ai/groq"
+	_ "go-micro.dev/v6/ai/minimax"
 	_ "go-micro.dev/v6/ai/mistral"
 	_ "go-micro.dev/v6/ai/openai"
 	_ "go-micro.dev/v6/ai/together"
@@ -278,6 +279,7 @@ func conformingStreamProviders(t *testing.T) []string {
 	allowed := map[string]struct{}{
 		"atlascloud": {},
 		"groq":       {},
+		"minimax":    {},
 		"mistral":    {},
 		"openai":     {},
 		"together":   {},
@@ -288,7 +290,7 @@ func conformingStreamProviders(t *testing.T) []string {
 			out = append(out, provider)
 		}
 	}
-	want := []string{"atlascloud", "groq", "mistral", "openai", "together"}
+	want := []string{"atlascloud", "groq", "minimax", "mistral", "openai", "together"}
 	if !reflect.DeepEqual(out, want) {
 		t.Fatalf("conforming stream providers = %#v, want %#v (registered stream providers: %#v)", out, want, providers)
 	}

--- a/internal/website/docs/guides/ai-provider-guide.md
+++ b/internal/website/docs/guides/ai-provider-guide.md
@@ -42,6 +42,7 @@ The built-in providers currently register these capability interfaces:
 | `atlascloud` | Yes | Yes | Yes | Yes |
 | `gemini` | Yes | No | No | No |
 | `groq` | Yes | No | No | Yes |
+| `minimax` | Yes | No | No | Yes |
 | `mistral` | Yes | No | No | Yes |
 | `ollama` | Yes | No | No | Yes |
 | `openai` | Yes | Yes | No | Yes |

--- a/internal/website/docs/guides/provider_capabilities_test.go
+++ b/internal/website/docs/guides/provider_capabilities_test.go
@@ -13,6 +13,7 @@ import (
 	_ "go-micro.dev/v6/ai/atlascloud"
 	_ "go-micro.dev/v6/ai/gemini"
 	_ "go-micro.dev/v6/ai/groq"
+	_ "go-micro.dev/v6/ai/minimax"
 	_ "go-micro.dev/v6/ai/mistral"
 	_ "go-micro.dev/v6/ai/ollama"
 	_ "go-micro.dev/v6/ai/openai"


### PR DESCRIPTION
Follow-up after merging the MiniMax provider (#3769) — the same completeness gaps I closed for Ollama in #3637.

## What
- **Capability matrix enforced.** Added the `minimax` row to `ai-provider-guide.md`, and blank-imported `ai/minimax` in `provider_capabilities_test.go` so the registry↔docs matrix now covers it (it was registered but unlisted).
- **Real conformance coverage.** Added `minimax` to the stream-conformance allowlist (+ import). Its streaming now runs against the OpenAI-compatible SSE contract instead of being merely registered — and it **passes** (via the shared `ai/internal/openaiapi` path, same as its siblings).
- **CHANGELOG** `[Unreleased]` entry.

## Why
The merged PR was clean but left MiniMax invisible to the registry-verified capability matrix and untested by the streaming conformance suite. CI stayed green because nothing required those, so the gaps were silent — exactly the Ollama situation. This closes them.

## Testing
- `go test ./ai/ -run TestStreamProviders` — **minimax PASS** (conformance + close-cancels).
- `go test ./internal/website/docs/guides/...` — matrix test passes with the new row.
- `go build ./...`, `golangci-lint` (0 issues), `gofmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_