### PR TITLE
store: de-flake TestFileStoreTable timing windows

### DIFF
--- a/store/file_test.go
+++ b/store/file_test.go
@@ -94,7 +94,7 @@ func fileTest(s Store, t *testing.T) {
 		{
 			Key:    "foobar",
 			Value:  []byte("foobarfoobar"),
-			Expiry: time.Millisecond * 100,
+			Expiry: time.Second, // wide window: CI I/O under -race can exceed a 100ms expiry before the read below
 		},
 	}
 
@@ -113,8 +113,8 @@ func fileTest(s Store, t *testing.T) {
 		}
 	}
 
-	// wait for the expiry
-	time.Sleep(time.Millisecond * 200)
+	// wait for the expiry (must exceed the 1s Expiry above, with margin for slow CI)
+	time.Sleep(time.Second * 2)
 
 	if results, err := s.Read("foo", ReadPrefix()); err != nil {
 		t.Errorf("Couldn't read all \"foo\" keys, got %# v (%s)", spew.Sdump(results), err)
@@ -199,20 +199,20 @@ func fileTest(s Store, t *testing.T) {
 	if err := s.Write(&Record{
 		Key:   "foofoobarbar",
 		Value: []byte("something"),
-	}, WriteTTL(time.Millisecond*100)); err != nil {
+	}, WriteTTL(time.Second)); err != nil {
 		t.Error(err)
 	}
 	if err := s.Write(&Record{
 		Key:   "foofoo",
 		Value: []byte("something"),
-	}, WriteExpiry(time.Now().Add(time.Millisecond*100))); err != nil {
+	}, WriteExpiry(time.Now().Add(time.Second))); err != nil {
 		t.Error(err)
 	}
 	if err := s.Write(&Record{
 		Key:   "barbar",
 		Value: []byte("something"),
 		// TTL has higher precedence than expiry
-	}, WriteExpiry(time.Now().Add(time.Hour)), WriteTTL(time.Millisecond*100)); err != nil {
+	}, WriteExpiry(time.Now().Add(time.Hour)), WriteTTL(time.Second)); err != nil {
 		t.Error(err)
 	}
 
@@ -224,7 +224,7 @@ func fileTest(s Store, t *testing.T) {
 		}
 	}
 
-	time.Sleep(time.Millisecond * 100)
+	time.Sleep(time.Second * 2) // exceed the 1s TTL/expiry above so everything has expired
 
 	if results, err := s.List(); err != nil {
 		t.Errorf("List failed: %s", err)


### PR DESCRIPTION
## Problem
`TestFileStoreTable` (store package) failed intermittently on CI — [run 28653768382](https://github.com/micro/go-micro/actions/runs/28653768382), "Expected 2 items, got 1". It's a **flaky test, not a regression**: the *identical commit* (`a356ab3`) **passed** this `Unit Tests` job on the #3784 PR run and **failed** on the master-push run.

## Root cause
The test writes records with a **100ms expiry**, then immediately reads and expects them still present. Under `-race` on a loaded runner, the write loop + file I/O + read can take longer than 100ms, so a record expires *before* the "expect 2 / expect 1" read. It's a too-tight timing window — the store's expiry behavior itself is correct.

## Fix
Widen the expiry/TTL windows (100ms → 1s) and the paired post-expiry sleeps (→ 2s). The "read before expiry" reads happen in well under 200ms, so they stay safely inside the 1s window on any runner; the "read after expiry" waits comfortably exceed it. Test-only.

## Verification
`go test -race -count=5 -run TestFileStoreTable ./store/` — green (the flake reproduced ~1-in-N before; repeated race runs now pass).

Note: this is the kind of failure the `loop-triage` backstop (#3714) now watches `Run Tests` for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_