### PR TITLE
Add minimax to provider conformance

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -18,7 +18,7 @@ on:
       providers:
         description: "Comma-separated providers for live conformance (default: all supported)"
         required: false
-        default: "anthropic,openai,gemini,groq,mistral,together,atlascloud"
+        default: "anthropic,openai,gemini,groq,minimax,mistral,together,atlascloud"
       harnesses:
         description: "Comma-separated harnesses for live conformance"
         required: false
@@ -64,6 +64,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           ATLASCLOUD_API_KEY: ${{ secrets.ATLASCLOUD_API_KEY }}
@@ -73,7 +74,7 @@ jobs:
           # catalog id differs (Atlas uses org/model ids).
           ATLASCLOUD_MODEL: ${{ vars.ATLASCLOUD_MODEL || 'minimaxai/minimax-m3' }}
         run: |
-          PROVIDERS="${{ github.event.inputs.providers || 'anthropic,openai,gemini,groq,mistral,together,atlascloud' }}"
+          PROVIDERS="${{ github.event.inputs.providers || 'anthropic,openai,gemini,groq,minimax,mistral,together,atlascloud' }}"
           HARNESSES="${{ github.event.inputs.harnesses || 'agent,universe,agent-flow,plan-delegate,a2a-stream-fallback' }}"
           REQUIRE_CONFIGURED="${{ github.event.inputs.require_configured || 'false' }}"
 

--- a/internal/harness/provider-conformance/README.md
+++ b/internal/harness/provider-conformance/README.md
@@ -51,6 +51,7 @@ Provider keys are read from `MICRO_AI_API_KEY` or the provider-specific variable
 | OpenAI | `OPENAI_API_KEY` |
 | Gemini | `GEMINI_API_KEY` |
 | Groq | `GROQ_API_KEY` |
+| MiniMax | `MINIMAX_API_KEY` |
 | Mistral | `MISTRAL_API_KEY` |
 | Together | `TOGETHER_API_KEY` |
 | AtlasCloud | `ATLASCLOUD_API_KEY` |

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -29,6 +29,7 @@ import (
 	_ "go-micro.dev/v6/ai/atlascloud"
 	_ "go-micro.dev/v6/ai/gemini"
 	_ "go-micro.dev/v6/ai/groq"
+	_ "go-micro.dev/v6/ai/minimax"
 	_ "go-micro.dev/v6/ai/mistral"
 	_ "go-micro.dev/v6/ai/openai"
 	_ "go-micro.dev/v6/ai/together"
@@ -49,6 +50,7 @@ var providerEnv = map[string]string{
 	"openai":     "OPENAI_API_KEY",
 	"gemini":     "GEMINI_API_KEY",
 	"groq":       "GROQ_API_KEY",
+	"minimax":    "MINIMAX_API_KEY",
 	"mistral":    "MISTRAL_API_KEY",
 	"together":   "TOGETHER_API_KEY",
 	"atlascloud": "ATLASCLOUD_API_KEY",

--- a/internal/harness/provider-conformance/main_test.go
+++ b/internal/harness/provider-conformance/main_test.go
@@ -38,7 +38,7 @@ func TestValidateSelectionRejectsUnsafeHarnessName(t *testing.T) {
 
 func TestDefaultProvidersTracksLiveProviderSet(t *testing.T) {
 	got := defaultProviders()
-	for _, want := range []string{"anthropic", "openai", "gemini", "groq", "mistral", "together", "atlascloud"} {
+	for _, want := range []string{"anthropic", "openai", "gemini", "groq", "minimax", "mistral", "together", "atlascloud"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("defaultProviders() = %q, want %q", got, want)
 		}
@@ -54,7 +54,7 @@ func TestCapabilityMatrixHasRegisteredProviders(t *testing.T) {
 		t.Fatal("CapabilityRows returned no providers")
 	}
 
-	var foundOpenAI bool
+	var foundOpenAI, foundMiniMax bool
 	for _, row := range rows {
 		if row.Provider == "openai" {
 			foundOpenAI = true
@@ -62,9 +62,18 @@ func TestCapabilityMatrixHasRegisteredProviders(t *testing.T) {
 				t.Fatalf("openai capabilities = %#v, want model+image only", row.Capabilities)
 			}
 		}
+		if row.Provider == "minimax" {
+			foundMiniMax = true
+			if !row.Model || !row.Stream || row.Image || row.Video {
+				t.Fatalf("minimax capabilities = %#v, want model+stream only", row.Capabilities)
+			}
+		}
 	}
 	if !foundOpenAI {
 		t.Fatalf("CapabilityRows = %#v, want openai row", rows)
+	}
+	if !foundMiniMax {
+		t.Fatalf("CapabilityRows = %#v, want minimax row", rows)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Register minimax with the provider-conformance harness and live-provider key map.
- Include minimax in live Harness workflow defaults and secrets.
- Document MINIMAX_API_KEY and assert minimax appears in conformance capability fixtures.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback targets are forbidden for grpc client/transport tests)
- go test ./internal/harness/provider-conformance ./ai
- golangci-lint run ./...

Closes #3787
Closes #3793