### PR TITLE
Stabilize plan-delegate notify recovery

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -413,7 +413,10 @@ func runPlanDelegate(provider string) error {
 		executeDone <- f.Execute(ctx, "launch readiness")
 	}()
 
-	if err := waitForPlanDelegateExecution(executeDone, taskSvc, notifySvc); err != nil {
+	if err := waitForPlanDelegateExecution(executeDone, taskSvc, notifySvc, func(ctx context.Context) error {
+		_, err := conductor.Ask(ctx, "The Design, Build, and Ship tasks already exist, but the owner notification is still missing. Delegate exactly one notification to the \"comms\" agent now: ask comms to notify owner@acme.com that the launch plan is ready. Do not create more tasks and do not answer until comms has handled the notification.")
+		return err
+	}); err != nil {
 		return err
 	}
 
@@ -435,7 +438,7 @@ func runPlanDelegate(provider string) error {
 	return nil
 }
 
-func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notifySvc *NotifyService) error {
+func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notifySvc *NotifyService, recoverMissingNotify func(context.Context) error) error {
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -451,7 +454,19 @@ func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notif
 				return fmt.Errorf("flow execute after side effects tasks=%d notify=%d: %w", tasks, notify, err)
 			}
 			if notify != 1 {
-				return fmt.Errorf("delegation completed without required notify side effect: notify=%d, want 1", notify)
+				if recoverMissingNotify == nil || tasks != 3 || notify != 0 {
+					return fmt.Errorf("delegation completed without required notify side effect: notify=%d, want 1", notify)
+				}
+				fmt.Print("\n\033[33mwarning:\033[0m flow completed before delegated notify; retrying the missing comms handoff once.\n")
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				retryErr := recoverMissingNotify(ctx)
+				cancel()
+				if retryErr != nil {
+					return fmt.Errorf("delegation completed without required notify side effect and recovery failed: notify=%d, want 1: %w", notify, retryErr)
+				}
+				if notify = notifySvc.count(); notify != 1 {
+					return fmt.Errorf("delegation recovery completed without required notify side effect: notify=%d, want 1", notify)
+				}
 			}
 			return nil
 		case <-ticker.C:

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -258,7 +258,7 @@ func TestPlanDelegateExecutionReportsDuplicateNotifyBeforeTimeout(t *testing.T) 
 
 	done := make(chan error)
 	errCh := make(chan error, 1)
-	go func() { errCh <- waitForPlanDelegateExecution(done, new(TaskService), notifySvc) }()
+	go func() { errCh <- waitForPlanDelegateExecution(done, new(TaskService), notifySvc, nil) }()
 
 	select {
 	case err := <-errCh:
@@ -278,12 +278,41 @@ func TestPlanDelegateExecutionRejectsClaimedCompletionWithoutNotify(t *testing.T
 	done := make(chan error, 1)
 	done <- nil
 
-	err := waitForPlanDelegateExecution(done, new(TaskService), notifySvc)
+	err := waitForPlanDelegateExecution(done, new(TaskService), notifySvc, nil)
 	if err == nil {
 		t.Fatal("waitForPlanDelegateExecution returned nil, want missing notify side-effect error")
 	}
 	if got := err.Error(); !strings.Contains(got, "without required notify side effect") {
 		t.Fatalf("error = %q, want missing notify side-effect error", got)
+	}
+}
+
+func TestPlanDelegateExecutionRecoversMissingNotifyOnce(t *testing.T) {
+	taskSvc := new(TaskService)
+	for _, title := range []string{"Design", "Build", "Ship"} {
+		var rsp AddResponse
+		if err := taskSvc.Add(context.Background(), &AddRequest{Title: title}, &rsp); err != nil {
+			t.Fatalf("Add(%q): %v", title, err)
+		}
+	}
+	notifySvc := new(NotifyService)
+	done := make(chan error, 1)
+	done <- nil
+
+	recovered := false
+	err := waitForPlanDelegateExecution(done, taskSvc, notifySvc, func(ctx context.Context) error {
+		recovered = true
+		var rsp SendResponse
+		return notifySvc.Send(ctx, &SendRequest{To: "owner@acme.com", Message: "The launch plan is ready"}, &rsp)
+	})
+	if err != nil {
+		t.Fatalf("waitForPlanDelegateExecution returned %v, want recovery success", err)
+	}
+	if !recovered {
+		t.Fatal("missing notify recovery was not invoked")
+	}
+	if got := notifySvc.count(); got != 1 {
+		t.Fatalf("notify count = %d, want 1 after recovery", got)
 	}
 }
 
@@ -304,7 +333,7 @@ func TestPlanDelegateExecutionAcceptsClientTimeoutAfterSideEffects(t *testing.T)
 	done := make(chan error, 1)
 	done <- errors.New(`{"id":"go.micro.client","code":408,"detail":"<nil>","status":"Request Timeout"}`)
 
-	if err := waitForPlanDelegateExecution(done, taskSvc, notifySvc); err != nil {
+	if err := waitForPlanDelegateExecution(done, taskSvc, notifySvc, nil); err != nil {
 		t.Fatalf("waitForPlanDelegateExecution returned %v, want completed side effects to satisfy client timeout", err)
 	}
 }
@@ -313,7 +342,7 @@ func TestPlanDelegateExecutionRejectsClientTimeoutBeforeSideEffects(t *testing.T
 	done := make(chan error, 1)
 	done <- errors.New(`{"id":"go.micro.client","code":408,"detail":"<nil>","status":"Request Timeout"}`)
 
-	err := waitForPlanDelegateExecution(done, new(TaskService), new(NotifyService))
+	err := waitForPlanDelegateExecution(done, new(TaskService), new(NotifyService), nil)
 	if err == nil {
 		t.Fatal("waitForPlanDelegateExecution returned nil, want timeout before side effects to fail")
 	}


### PR DESCRIPTION
Summary:
- Retry the missing comms handoff once when the plan-delegate flow completes after creating tasks but before the delegated notify side effect lands.
- Preserve missing-notify and duplicate-notify failures for unrecoverable cases.
- Add deterministic coverage for the one-shot missing-notify recovery path.

Testing:
- go build ./...
- go test -timeout 120s -v ./internal/harness/plan-delegate
- go test ./... (fails in existing unrelated cache TTL and loopback-blocked grpc tests)
- golangci-lint run ./...

Closes #3760
Closes #3798