### PR TITLE
Add CLI docs wayfinding

### DIFF
--- a/cmd/micro/cli/cli.go
+++ b/cmd/micro/cli/cli.go
@@ -24,6 +24,30 @@ import (
 	_ "go-micro.dev/v6/cmd/micro/cli/remote"
 )
 
+const docsWayfinding = `First-agent and 0→hero docs:
+
+  1. No-secret first-agent transcript
+     https://go-micro.dev/docs/guides/no-secret-first-agent.html
+     Run the maintained support agent without a provider key:
+       go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1
+
+  2. Your First Agent
+     https://go-micro.dev/docs/guides/your-first-agent.html
+     Build a service-backed agent, then use:
+       micro agent preflight
+       micro run
+       micro chat
+
+  3. Debugging your agent
+     https://go-micro.dev/docs/guides/debugging-agents.html
+     Inspect agent runs and memory with:
+       micro inspect agent
+       micro runs <agent>
+
+  4. 0→hero Reference
+     https://go-micro.dev/docs/guides/zero-to-hero.html
+     Walk the scaffold → run → chat → inspect → deploy dry-run lifecycle.`
+
 func genProtoHandler(c *cli.Context) error {
 	cmd := exec.Command("find", ".", "-name", "*.proto", "-exec", "protoc", "--proto_path=.", "--micro_out=.", "--go_out=.", `{}`, `;`)
 	cmd.Stdout = os.Stdout
@@ -93,6 +117,17 @@ func init() {
 				for _, service := range services {
 					fmt.Println(service.Name)
 				}
+				return nil
+			},
+		},
+		{
+			Name:  "docs",
+			Usage: "Show the first-agent and 0→hero documentation path",
+			Description: `Print the maintained adoption on-ramp for new Go Micro developers:
+the no-secret first-agent transcript, Your First Agent, debugging guide, and
+0→hero lifecycle reference.`,
+			Action: func(ctx *cli.Context) error {
+				fmt.Fprintln(ctx.App.Writer, docsWayfinding)
 				return nil
 			},
 		},

--- a/cmd/micro/first_agent_walkthrough_test.go
+++ b/cmd/micro/first_agent_walkthrough_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 		}
 	}
 
-	for _, want := range []string{"new", "run", "chat", "inspect", "agent"} {
+	for _, want := range []string{"new", "run", "chat", "inspect", "agent", "docs"} {
 		if !commands[want] {
 			t.Fatalf("first-agent walkthrough missing %q command", want)
 		}
@@ -36,6 +37,31 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 	chat := commandByName(t, "chat")
 	if !strings.Contains(chat.Description, "services") || !strings.Contains(chat.Description, "agent") {
 		t.Fatalf("micro chat should describe the service-to-agent walkthrough boundary; description was %q", chat.Description)
+	}
+
+	docs := commandByName(t, "docs")
+	if !strings.Contains(docs.Usage, "first-agent") || !strings.Contains(docs.Usage, "0→hero") {
+		t.Fatalf("micro docs should advertise the first-agent and 0→hero docs path; usage was %q", docs.Usage)
+	}
+	var out bytes.Buffer
+	app := cli.NewApp()
+	app.Writer = &out
+	if err := docs.Action(cli.NewContext(app, nil, nil)); err != nil {
+		t.Fatalf("micro docs failed: %v", err)
+	}
+	for _, want := range []string{
+		"no-secret-first-agent.html",
+		"your-first-agent.html",
+		"debugging-agents.html",
+		"zero-to-hero.html",
+		"micro agent preflight",
+		"micro run",
+		"micro chat",
+		"micro inspect agent",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("micro docs output missing %q:\n%s", want, out.String())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a new `micro docs` command that prints the maintained first-agent and 0→hero docs path.
- Cover the command in the first-agent CLI boundary test so the no-secret, first-agent, debugging, and 0→hero links stay discoverable.

## Testing
- `go build ./...`
- `go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1`
- `go test ./...` (fails in this environment because loopback gRPC tests are blocked by the sandbox proxy: `Loopback targets forbidden`)
- `golangci-lint run ./...`

Closes #3801
Closes #3806