### PR TITLE
Classify plan-delegate provider timeouts

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -451,9 +451,12 @@ func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notif
 			tasks := taskSvc.count()
 			notify := notifySvc.count()
 			if err != nil {
-				if isClientTimeout(err) && tasks == 3 && notify == 1 {
-					fmt.Printf("\n\033[33mwarning:\033[0m flow execute returned after completed side effects: %v\n", err)
-					return nil
+				if isClientTimeout(err) {
+					if tasks == 3 && notify == 1 {
+						fmt.Printf("\n\033[33mwarning:\033[0m flow execute returned after completed side effects: %v\n", err)
+						return nil
+					}
+					return classifiedPlanDelegateTimeout(tasks, notify, err)
 				}
 				return fmt.Errorf("flow execute after side effects tasks=%d notify=%d: %w", tasks, notify, err)
 			}
@@ -479,6 +482,10 @@ func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notif
 			}
 		}
 	}
+}
+
+func classifiedPlanDelegateTimeout(tasks, notify int, err error) error {
+	return fmt.Errorf("provider latency/outage during plan-delegate before required side effects completed (tasks=%d/3 notify=%d/1); retry live provider or inspect provider logs if this recurs: %w", tasks, notify, err)
 }
 
 func isClientTimeout(err error) bool {

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -338,7 +338,7 @@ func TestPlanDelegateExecutionAcceptsClientTimeoutAfterSideEffects(t *testing.T)
 	}
 }
 
-func TestPlanDelegateExecutionRejectsClientTimeoutBeforeSideEffects(t *testing.T) {
+func TestPlanDelegateExecutionClassifiesClientTimeoutBeforeSideEffects(t *testing.T) {
 	done := make(chan error, 1)
 	done <- errors.New(`{"id":"go.micro.client","code":408,"detail":"<nil>","status":"Request Timeout"}`)
 
@@ -346,8 +346,35 @@ func TestPlanDelegateExecutionRejectsClientTimeoutBeforeSideEffects(t *testing.T
 	if err == nil {
 		t.Fatal("waitForPlanDelegateExecution returned nil, want timeout before side effects to fail")
 	}
-	if got := err.Error(); !strings.Contains(got, "tasks=0 notify=0") {
-		t.Fatalf("error = %q, want side-effect counts", got)
+	for _, want := range []string{
+		"provider latency/outage during plan-delegate",
+		"tasks=0/3 notify=0/1",
+		"retry live provider or inspect provider logs",
+		"Request Timeout",
+	} {
+		if got := err.Error(); !strings.Contains(got, want) {
+			t.Fatalf("error = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestPlanDelegateExecutionClassifiesPartialClientTimeout(t *testing.T) {
+	taskSvc := new(TaskService)
+	for _, title := range []string{"Design", "Build", "Ship"} {
+		var rsp AddResponse
+		if err := taskSvc.Add(context.Background(), &AddRequest{Title: title}, &rsp); err != nil {
+			t.Fatalf("Add(%q): %v", title, err)
+		}
+	}
+	done := make(chan error, 1)
+	done <- errors.New(`{"id":"go.micro.client","code":408,"detail":"<nil>","status":"Request Timeout"}`)
+
+	err := waitForPlanDelegateExecution(done, taskSvc, new(NotifyService), nil)
+	if err == nil {
+		t.Fatal("waitForPlanDelegateExecution returned nil, want timeout before notify to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "tasks=3/3 notify=0/1") {
+		t.Fatalf("error = %q, want partial side-effect counts", got)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Classifies plan-delegate client timeouts that occur before task/notify side effects complete as provider latency/outage diagnostics.
- Keeps completed-side-effect timeout tolerance intact.
- Adds CI-safe tests for zero-side-effect and partial-side-effect timeout classification.

Testing:
- go test ./internal/harness/plan-delegate
- go build ./...
- go test ./... (fails in client/grpc because this environment forbids loopback targets)
- golangci-lint run ./...

Closes #3826
Closes #3833