### PR TITLE
Harden A2A fallback stream validation

### DIFF
--- a/internal/harness/a2a-stream-fallback/main.go
+++ b/internal/harness/a2a-stream-fallback/main.go
@@ -148,13 +148,17 @@ func main() {
 		fmt.Fprintf(os.Stderr, "content-type = %q, want text/event-stream\n", ct)
 		os.Exit(1)
 	}
-	payload, err := readSSEData(res.Body)
+	summary, err := readSSESummary(res.Body)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	if !strings.Contains(payload, "a2a-fallback-ok") {
-		fmt.Fprintf(os.Stderr, "stream payload missing marker: %s\n", payload)
+	if summary.State != "completed" {
+		fmt.Fprintf(os.Stderr, "stream final state = %q, want completed; payload: %s\n", summary.State, summary.Payload)
+		os.Exit(1)
+	}
+	if !summary.HasArtifactText {
+		fmt.Fprintf(os.Stderr, "stream completed without artifact text: %s\n", summary.Payload)
 		os.Exit(1)
 	}
 	if !sawTool || !sawRunInfo {
@@ -164,10 +168,16 @@ func main() {
 	fmt.Println("\n\033[32m✓ A2A message/stream fell back to Ask and preserved tool/run metadata\033[0m")
 }
 
-func readSSEData(r io.Reader) (string, error) {
+type streamSummary struct {
+	Payload         string
+	State           string
+	HasArtifactText bool
+}
+
+func readSSESummary(r io.Reader) (streamSummary, error) {
 	scanner := bufio.NewScanner(r)
 	var event strings.Builder
-	var payload strings.Builder
+	var summary streamSummary
 	seen := false
 	flush := func() error {
 		data := strings.TrimSpace(event.String())
@@ -175,19 +185,40 @@ func readSSEData(r io.Reader) (string, error) {
 		if data == "" {
 			return nil
 		}
-		if !json.Valid([]byte(data)) {
+		var envelope struct {
+			Result struct {
+				Status struct {
+					State string `json:"state"`
+				} `json:"status"`
+				Artifacts []struct {
+					Parts []struct {
+						Text string `json:"text"`
+					} `json:"parts"`
+				} `json:"artifacts"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal([]byte(data), &envelope); err != nil {
 			return fmt.Errorf("SSE data event is not JSON: %s", data)
 		}
 		seen = true
-		payload.WriteString(data)
-		payload.WriteByte('\n')
+		summary.Payload += data + "\n"
+		if envelope.Result.Status.State != "" {
+			summary.State = envelope.Result.Status.State
+		}
+		for _, artifact := range envelope.Result.Artifacts {
+			for _, part := range artifact.Parts {
+				if strings.TrimSpace(part.Text) != "" {
+					summary.HasArtifactText = true
+				}
+			}
+		}
 		return nil
 	}
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.TrimSpace(line) == "" {
 			if err := flush(); err != nil {
-				return "", err
+				return streamSummary{}, err
 			}
 			continue
 		}
@@ -201,13 +232,13 @@ func readSSEData(r io.Reader) (string, error) {
 		event.WriteString(strings.TrimSpace(data))
 	}
 	if err := scanner.Err(); err != nil {
-		return "", err
+		return streamSummary{}, err
 	}
 	if err := flush(); err != nil {
-		return "", err
+		return streamSummary{}, err
 	}
 	if !seen {
-		return "", errors.New("no SSE data received")
+		return streamSummary{}, errors.New("no SSE data received")
 	}
-	return payload.String(), nil
+	return summary, nil
 }

--- a/internal/harness/a2a-stream-fallback/main_test.go
+++ b/internal/harness/a2a-stream-fallback/main_test.go
@@ -5,19 +5,26 @@ import (
 	"testing"
 )
 
-func TestReadSSEDataAcceptsMultipleJSONEvents(t *testing.T) {
-	payload, err := readSSEData(strings.NewReader("event: status\ndata: {\"phase\":\"started\"}\n\ndata:{\"result\":\"a2a-fallback-ok\"}\n\n"))
+func TestReadSSESummaryUsesCompletedTaskInvariants(t *testing.T) {
+	summary, err := readSSESummary(strings.NewReader("data: {\"jsonrpc\":\"2.0\",\"result\":{\"status\":{\"state\":\"working\"}}}\n\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"result\":{\"status\":{\"state\":\"completed\"},\"artifacts\":[{\"parts\":[{\"kind\":\"text\",\"text\":\"provider-specific answer\"}]}]}}\n\n"))
 	if err != nil {
-		t.Fatalf("readSSEData returned error: %v", err)
+		t.Fatalf("readSSESummary() error = %v", err)
 	}
-	if !strings.Contains(payload, "started") || !strings.Contains(payload, "a2a-fallback-ok") {
-		t.Fatalf("payload = %q, want both event payloads", payload)
+	if summary.State != "completed" {
+		t.Fatalf("State = %q, want completed", summary.State)
+	}
+	if !summary.HasArtifactText {
+		t.Fatal("HasArtifactText = false, want true")
+	}
+	if strings.Contains(summary.Payload, "a2a-fallback-ok") {
+		t.Fatalf("test fixture should not rely on marker text: %s", summary.Payload)
 	}
 }
 
-func TestReadSSEDataRejectsInvalidJSONEvent(t *testing.T) {
-	_, err := readSSEData(strings.NewReader("data: {\"ok\":true}\n\ndata: {bad json}\n\n"))
+func TestReadSSESummaryRejectsNonJSONData(t *testing.T) {
+	_, err := readSSESummary(strings.NewReader("data: not-json\n\n"))
 	if err == nil {
-		t.Fatal("readSSEData returned nil error for invalid JSON event")
+		t.Fatal("readSSESummary() error = nil, want non-JSON error")
 	}
 }


### PR DESCRIPTION
Summary:
- Validate A2A stream fallback completion using protocol-level task state and artifact presence instead of provider-specific marker text.
- Add unit coverage for the SSE summary parser to avoid marker-dependent validation drift.

Testing:
- go test ./internal/harness/a2a-stream-fallback
- go run ./internal/harness/a2a-stream-fallback --provider mock
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3832
Closes #3838