### PR TITLE
Ensure canceled agent runs fail after tool calls

### DIFF
--- a/agent/resilience_test.go
+++ b/agent/resilience_test.go
@@ -132,6 +132,34 @@ func TestToolCallTimeoutPropagatesDeadlineToCustomTool(t *testing.T) {
 	}
 }
 
+func TestAskCancellationDuringToolCallFailsRun(t *testing.T) {
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if opts.ToolHandler == nil {
+			t.Fatal("missing tool handler")
+		}
+		res := opts.ToolHandler(ctx, ai.ToolCall{ID: "call-1", Name: "cancel-self"})
+		if !strings.Contains(res.Content, context.Canceled.Error()) {
+			t.Fatalf("tool result = %q, want cancellation error", res.Content)
+		}
+		return &ai.Response{Reply: "should not succeed"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	a := newTestAgent(
+		Name("cancel-during-tool"),
+		WithTool("cancel-self", "cancel the run context", nil, func(context.Context, map[string]any) (string, error) {
+			cancel()
+			return "", context.Canceled
+		}),
+	)
+
+	_, err := a.Ask(ctx, "cancel during tool")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Ask error = %v, want context canceled", err)
+	}
+}
+
 func TestAskCheckpointRecordsTerminalOperationalFailureStatus(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ai/retry.go
+++ b/ai/retry.go
@@ -99,15 +99,19 @@ func GenerateWithRetry(ctx context.Context, m Model, req *Request, policy Genera
 		}
 		resp, err := m.Generate(callCtx, req, opts...)
 		cancel()
+
+		// Caller cancellation/deadline always wins and is not retried, even if
+		// a provider or tool loop swallowed the canceled tool result and returned
+		// a final response. This keeps agent runs from appearing successful after
+		// their controlling context was abandoned.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		if err == nil {
 			return resp, nil
 		}
 		last = err
 
-		// Caller cancellation/deadline always wins and is not retried.
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
 		transient := IsTransientError(err)
 		if attempt == policy.MaxAttempts || !transient {
 			if attempt > 1 || transient {


### PR DESCRIPTION
Summary:
- Make GenerateWithRetry treat caller cancellation or deadline expiry as authoritative after provider generation returns, preventing canceled agent/tool runs from being reported as successful.
- Add regression coverage for cancellation during a tool call when the model returns a final response anyway.

Testing:
- go test ./agent ./ai
- go build ./...
- go test ./... (fails in this environment because loopback targets are forbidden for grpc client/transport tests)
- golangci-lint run ./...

Closes #3544
Closes #3844