### PR TITLE
Trace agent run event kinds

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -45,6 +45,7 @@ const (
 	AttrFlowStep         = "agent.flow.step"
 	AttrDispatch         = "agent.dispatch"
 	AttrTrigger          = "agent.trigger"
+	AttrRunEventKind     = "agent.event.kind"
 )
 
 type RunEvent struct {
@@ -323,6 +324,7 @@ func runEventAttributes(e RunEvent) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.String(AttrRunID, e.RunID),
 		attribute.String(AttrAgentName, e.Agent),
+		attribute.String(AttrRunEventKind, e.Kind),
 	}
 	if e.ParentID != "" {
 		attrs = append(attrs, attribute.String(AttrParentRunID, e.ParentID))

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -279,7 +279,8 @@ func spanEventHasRunInfo(events []trace.Event, name, runID, agentName string) bo
 			continue
 		}
 		attrs := spanAttributes(event.Attributes)
-		if attrs[AttrRunID] == runID && attrs[AttrAgentName] == agentName {
+		wantKind := strings.TrimPrefix(name, "agent.")
+		if attrs[AttrRunID] == runID && attrs[AttrAgentName] == agentName && attrs[AttrRunEventKind] == wantKind {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- Add a stable `agent.event.kind` OpenTelemetry attribute to agent run timeline span events so backends can query run/model/tool/checkpoint/resume/done events without parsing event names.
- Tighten the existing no-secret agent OTel test helper to assert the event kind attribute is present alongside RunInfo correlation.

Closes #3525
Closes #3854

## Testing
- go test ./agent
- go build ./...
- go test ./... (fails in sandbox: loopback targets forbidden in grpc client/transport tests)
- golangci-lint run ./...
