### PR TITLE
Surface durable agent resume example

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ resp, _ := m.Generate(ctx, &ai.Request{Prompt: "hello"})
 - [multi-service](examples/multi-service/) — Multiple services in one binary
 - [mcp](examples/mcp/) — MCP integration with AI agents
 - [agent-plan-delegate](examples/agent-plan-delegate/) — Agent planning and multi-agent delegation
+- [agent-durable](examples/agent-durable/) — Checkpoint and resume an agent run without replaying completed tool side effects
 - [grpc-interop](examples/grpc-interop/) — Call go-micro from any gRPC client
 
 See [all examples](examples/README.md).

--- a/internal/website/docs/examples/index.md
+++ b/internal/website/docs/examples/index.md
@@ -16,6 +16,7 @@ agents → workflows lifecycle.
 | First service-backed agent | [`examples/agent-demo`](https://github.com/micro/go-micro/tree/master/examples/agent-demo) | Multi-service project/task/team app with agent playground integration. |
 | 0→hero lifecycle | [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support) | No-secret support-desk story: typed services, an agent, an event-driven flow, and a guardrail. |
 | Planning and delegation | [`examples/agent-plan-delegate`](https://github.com/micro/go-micro/tree/master/examples/agent-plan-delegate) | Two agents collaborate through `plan` and `delegate` over normal Go Micro RPC. |
+| Durable agent runs | [`examples/agent-durable`](https://github.com/micro/go-micro/tree/master/examples/agent-durable) | Checkpoint and resume a model-directed run without replaying completed tool side effects. |
 | Durable workflows | [`examples/flow-durable`](https://github.com/micro/go-micro/tree/master/examples/flow-durable) | Ordered, checkpointed flow steps resume without duplicating completed side effects. |
 | AI-callable services | [`examples/mcp`](https://github.com/micro/go-micro/tree/master/examples/mcp) | MCP examples that expose service endpoints as model tools. |
 
@@ -35,7 +36,11 @@ agents → workflows lifecycle.
   [`examples/agent-plan-delegate`](https://github.com/micro/go-micro/tree/master/examples/agent-plan-delegate).
 - [Agents and Workflows](../guides/agents-and-workflows.html) → run
   [`examples/flow-durable`](https://github.com/micro/go-micro/tree/master/examples/flow-durable)
-  and [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support).
+  for deterministic checkpointed steps,
+  [`examples/agent-durable`](https://github.com/micro/go-micro/tree/master/examples/agent-durable)
+  for model-directed checkpointed runs, and
+  [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support)
+  for the full services → agents → workflows lifecycle.
 
 ## Repository examples
 


### PR DESCRIPTION
## Summary
- Add the durable agent resume example to the README examples list.
- Add the durable agent resume example to the website examples start-here table and Agents and Workflows guide map.

Closes #3847
Closes #3860

## Testing
- go build ./...
- go test ./... (environment blocks loopback gRPC tests in client/grpc)
- golangci-lint run ./... --timeout 10m