### PR TITLE
Record streamed agent replies in memory

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -222,12 +222,16 @@ func (a *agentImpl) Stream(ctx context.Context, message string) (ai.Stream, erro
 		return nil, fmt.Errorf("discover tools: %w", err)
 	}
 	a.mem.Add("user", message)
-	return a.model.Stream(ctx, &ai.Request{
+	stream, err := a.model.Stream(ctx, &ai.Request{
 		Prompt:       message,
 		SystemPrompt: a.buildPrompt(),
 		Tools:        toolList,
 		Messages:     a.mem.Messages(),
 	})
+	if err != nil {
+		return nil, err
+	}
+	return &memoryRecordingStream{stream: stream, memory: a.mem}, nil
 }
 
 // Pending returns checkpointed agent runs that have not completed. It mirrors

--- a/agent/integration_test.go
+++ b/agent/integration_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 // it with a deferred cleanup. Tests in this package are not parallel,
 // so a package-level hook is safe.
 var fakeGen func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error)
+var fakeStream func(ctx context.Context, opts ai.Options, req *ai.Request) (ai.Stream, error)
 
 type fakeModel struct{ opts ai.Options }
 
@@ -33,9 +35,32 @@ func (m *fakeModel) Generate(ctx context.Context, req *ai.Request, _ ...ai.Gener
 	return &ai.Response{Reply: "ok"}, nil
 }
 func (m *fakeModel) Stream(ctx context.Context, req *ai.Request, _ ...ai.GenerateOption) (ai.Stream, error) {
-	return nil, nil
+	if fakeStream != nil {
+		return fakeStream(ctx, m.opts, req)
+	}
+	return &sliceStream{chunks: []string{"ok"}}, nil
 }
 func (m *fakeModel) String() string { return "fake" }
+
+type sliceStream struct {
+	chunks []string
+	idx    int
+	closed bool
+}
+
+func (s *sliceStream) Recv() (*ai.Response, error) {
+	if s.idx >= len(s.chunks) {
+		return nil, io.EOF
+	}
+	chunk := s.chunks[s.idx]
+	s.idx++
+	return &ai.Response{Reply: chunk}, nil
+}
+
+func (s *sliceStream) Close() error {
+	s.closed = true
+	return nil
+}
 
 func init() {
 	ai.Register("fake", func(opts ...ai.Option) ai.Model {

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -185,6 +185,45 @@ type agentStreamAdapter struct {
 	stream AgentStream
 }
 
+type memoryRecordingStream struct {
+	stream ai.Stream
+	memory Memory
+
+	mu     sync.Mutex
+	chunks []string
+	closed bool
+}
+
+func (s *memoryRecordingStream) Recv() (*ai.Response, error) {
+	resp, err := s.stream.Recv()
+	if resp != nil && resp.Reply != "" {
+		s.mu.Lock()
+		s.chunks = append(s.chunks, resp.Reply)
+		s.mu.Unlock()
+	}
+	if errors.Is(err, io.EOF) {
+		s.recordAssistant()
+	}
+	return resp, err
+}
+
+func (s *memoryRecordingStream) Close() error {
+	s.recordAssistant()
+	return s.stream.Close()
+}
+
+func (s *memoryRecordingStream) recordAssistant() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	if reply := strings.Join(s.chunks, ""); reply != "" {
+		s.memory.Add("assistant", reply)
+	}
+}
+
 func (s *agentStreamAdapter) Recv() (*ai.Response, error) {
 	for {
 		event, err := s.stream.Recv()

--- a/agent/stream_test.go
+++ b/agent/stream_test.go
@@ -82,6 +82,52 @@ func TestStreamAskHelperRejectsUnsupportedAgent(t *testing.T) {
 	}
 }
 
+func TestAgentStreamUsesProviderStreamingAndRecordsAssistantMemory(t *testing.T) {
+	var sawRequest bool
+	fakeStream = func(ctx context.Context, opts ai.Options, req *ai.Request) (ai.Stream, error) {
+		sawRequest = true
+		if req.Prompt != "stream the answer" {
+			t.Fatalf("Prompt = %q, want stream the answer", req.Prompt)
+		}
+		if len(req.Messages) != 1 || req.Messages[0].Role != "user" || req.Messages[0].Content != "stream the answer" {
+			t.Fatalf("Messages = %#v, want current user turn in memory", req.Messages)
+		}
+		return &sliceStream{chunks: []string{"hel", "lo"}}, nil
+	}
+	defer func() { fakeStream = nil }()
+
+	a := newTestAgent(Name("provider-stream"))
+	stream, err := a.Stream(context.Background(), "stream the answer")
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var reply string
+	for {
+		chunk, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		reply += chunk.Reply
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !sawRequest {
+		t.Fatal("provider Stream was not called")
+	}
+	if reply != "hello" {
+		t.Fatalf("reply = %q, want hello", reply)
+	}
+	got := a.mem.Messages()
+	if len(got) != 2 || got[0].Role != "user" || got[0].Content != "stream the answer" || got[1].Role != "assistant" || got[1].Content != "hello" {
+		t.Fatalf("memory = %#v, want user turn and streamed assistant reply", got)
+	}
+}
+
 func TestResumeStreamAskDoesNotReplayCompletedTool(t *testing.T) {
 	ctx := context.Background()
 	cp := flow.StoreCheckpoint(store.NewStore(), "stream-resume-agent")


### PR DESCRIPTION
Summary:
- Wrap Agent.Stream provider streams so streamed assistant chunks are recorded in agent memory when the stream reaches EOF or is closed.
- Add mock-backed streaming coverage for the provider-backed Agent.Stream path and memory continuity.

Testing:
- go build ./...
- go test ./agent
- golangci-lint run ./...
- go test ./... (fails in this environment: loopback targets are blocked for grpc packages and cache expiry timing failed once)

Closes #3857
Closes #3864