### PR TITLE
Fix plan-delegate notify completion race

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -464,12 +464,18 @@ func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notif
 				if recoverMissingNotify == nil || tasks != 3 || notify != 0 {
 					return fmt.Errorf("delegation completed without required notify side effect: notify=%d, want 1", notify)
 				}
-				fmt.Print("\n\033[33mwarning:\033[0m flow completed before delegated notify; retrying the missing comms handoff once.\n")
-				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-				retryErr := recoverMissingNotify(ctx)
-				cancel()
-				if retryErr != nil {
-					return fmt.Errorf("delegation completed without required notify side effect and recovery failed: notify=%d, want 1: %w", notify, retryErr)
+				settled, err := waitForNotifySideEffect(notifySvc, 2*time.Second)
+				if err != nil {
+					return err
+				}
+				if !settled {
+					fmt.Print("\n\033[33mwarning:\033[0m flow completed before delegated notify; retrying the missing comms handoff once.\n")
+					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					retryErr := recoverMissingNotify(ctx)
+					cancel()
+					if retryErr != nil {
+						return fmt.Errorf("delegation completed without required notify side effect and recovery failed: notify=%d, want 1: %w", notify, retryErr)
+					}
 				}
 				if notify = notifySvc.count(); notify != 1 {
 					return fmt.Errorf("delegation recovery completed without required notify side effect: notify=%d, want 1", notify)
@@ -481,6 +487,22 @@ func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notif
 				return fmt.Errorf("duplicate notify attempts: got %d duplicate replay(s), want 0", dup)
 			}
 		}
+	}
+}
+
+func waitForNotifySideEffect(notifySvc *NotifyService, timeout time.Duration) (bool, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		if notifySvc.count() == 1 {
+			return true, nil
+		}
+		if dup := notifySvc.duplicateAttempts(); dup > 0 {
+			return false, fmt.Errorf("duplicate notify attempts: got %d duplicate replay(s), want 0", dup)
+		}
+		if !time.Now().Before(deadline) {
+			return false, nil
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }
 

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -316,6 +316,47 @@ func TestPlanDelegateExecutionRecoversMissingNotifyOnce(t *testing.T) {
 	}
 }
 
+func TestPlanDelegateExecutionWaitsForInFlightNotifyAfterFlowCompletion(t *testing.T) {
+	taskSvc := new(TaskService)
+	for _, title := range []string{"Design", "Build", "Ship"} {
+		var rsp AddResponse
+		if err := taskSvc.Add(context.Background(), &AddRequest{Title: title}, &rsp); err != nil {
+			t.Fatalf("Add(%q): %v", title, err)
+		}
+	}
+	notifySvc := new(NotifyService)
+	done := make(chan error, 1)
+	done <- nil
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		var rsp SendResponse
+		_ = notifySvc.Send(context.Background(), &SendRequest{To: "owner@acme.com", Message: "The launch plan is ready"}, &rsp)
+	}()
+
+	recovered := false
+	err := waitForPlanDelegateExecution(done, taskSvc, notifySvc, func(ctx context.Context) error {
+		recovered = true
+		var rsp SendResponse
+		return notifySvc.Send(ctx, &SendRequest{To: "owner@acme.com", Message: "The launch plan is ready"}, &rsp)
+	})
+	if err != nil {
+		t.Fatalf("waitForPlanDelegateExecution returned %v, want in-flight notify success", err)
+	}
+	if recovered {
+		t.Fatal("missing notify recovery ran while delegated notify was still in flight")
+	}
+	if got := taskSvc.count(); got != 3 {
+		t.Fatalf("task count = %d, want 3 after in-flight notify settles", got)
+	}
+	if got := notifySvc.count(); got != 1 {
+		t.Fatalf("notify count = %d, want 1 after in-flight notify settles", got)
+	}
+	if got := notifySvc.duplicateAttempts(); got != 0 {
+		t.Fatalf("duplicate notify attempts = %d, want 0", got)
+	}
+}
+
 func TestPlanDelegateExecutionAcceptsClientTimeoutAfterSideEffects(t *testing.T) {
 	taskSvc := new(TaskService)
 	for _, title := range []string{"Design", "Build", "Ship"} {


### PR DESCRIPTION
## Summary
- Wait briefly for an in-flight delegated notification to land before retrying the comms handoff.
- Keep duplicate-notify detection active while waiting.
- Add a regression that verifies the delayed notify settles with exactly three tasks, one notification, and no duplicate notification attempts.

## Testing
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy in client/grpc and transport/grpc)
- go test ./internal/harness/plan-delegate -run 'TestPlanDelegateExecution(WaitsForInFlightNotifyAfterFlowCompletion|RecoversMissingNotifyOnce)$' -count=1 -timeout=20s
- golangci-lint run ./...

Closes #3870
Closes #3876