### PR TITLE
Add AP2 mandate foundation for A2A

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -201,12 +201,13 @@ type Part struct {
 
 // Message is a turn in an A2A conversation.
 type Message struct {
-	Role      string `json:"role"` // "user" | "agent"
-	Parts     []Part `json:"parts"`
-	MessageID string `json:"messageId,omitempty"`
-	TaskID    string `json:"taskId,omitempty"`
-	ContextID string `json:"contextId,omitempty"`
-	Kind      string `json:"kind"` // "message"
+	Role        string             `json:"role"` // "user" | "agent"
+	Parts       []Part             `json:"parts"`
+	MessageID   string             `json:"messageId,omitempty"`
+	TaskID      string             `json:"taskId,omitempty"`
+	ContextID   string             `json:"contextId,omitempty"`
+	Kind        string             `json:"kind"` // "message"
+	AP2Mandates []AP2SignedMandate `json:"ap2Mandates,omitempty"`
 }
 
 // TaskStatus is a task's lifecycle state.
@@ -223,12 +224,14 @@ type Artifact struct {
 
 // Task is the unit of work returned by message/send and tasks/get.
 type Task struct {
-	ID        string     `json:"id"`
-	ContextID string     `json:"contextId"`
-	Status    TaskStatus `json:"status"`
-	Artifacts []Artifact `json:"artifacts,omitempty"`
-	History   []Message  `json:"history,omitempty"`
-	Kind      string     `json:"kind"` // "task"
+	ID               string             `json:"id"`
+	ContextID        string             `json:"contextId"`
+	Status           TaskStatus         `json:"status"`
+	Artifacts        []Artifact         `json:"artifacts,omitempty"`
+	History          []Message          `json:"history,omitempty"`
+	Kind             string             `json:"kind"` // "task"
+	AP2Mandates      []AP2SignedMandate `json:"ap2Mandates,omitempty"`
+	AP2Verifications []AP2Verification  `json:"ap2Verifications,omitempty"`
 }
 
 // PushNotificationConfig tells the gateway where to POST task updates for a
@@ -848,12 +851,13 @@ func taskFromReplyWithIDsAndHistory(input Message, reply, state, taskID, context
 		input.Kind = "message"
 	}
 	task := &Task{
-		ID:        taskID,
-		ContextID: contextID,
-		Kind:      "task",
-		History:   append(append([]Message{}, history...), input),
-		Status:    TaskStatus{State: state, Timestamp: time.Now().UTC().Format(time.RFC3339)},
-		Artifacts: []Artifact{textArtifact(reply)},
+		ID:          taskID,
+		ContextID:   contextID,
+		Kind:        "task",
+		History:     append(append([]Message{}, history...), input),
+		Status:      TaskStatus{State: state, Timestamp: time.Now().UTC().Format(time.RFC3339)},
+		Artifacts:   []Artifact{textArtifact(reply)},
+		AP2Mandates: append([]AP2SignedMandate{}, input.AP2Mandates...),
 	}
 	task.History = append(task.History, Message{
 		Role:      "agent",

--- a/gateway/a2a/ap2.go
+++ b/gateway/a2a/ap2.go
@@ -1,0 +1,150 @@
+package a2a
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// AP2MandateKind identifies the AP2 mandate stage represented by a credential.
+type AP2MandateKind string
+
+const (
+	AP2CheckoutMandate AP2MandateKind = "checkout"
+	AP2PaymentMandate  AP2MandateKind = "payment"
+)
+
+// AP2RailRef names the settlement rail authorized by an AP2 payment mandate.
+type AP2RailRef struct {
+	Type      string `json:"type"`
+	Reference string `json:"reference"`
+}
+
+// AP2Mandate is a small verifiable AP2 credential. It is deliberately rail-neutral:
+// x402 is represented as one possible rail reference under a payment mandate.
+type AP2Mandate struct {
+	ID          string         `json:"id"`
+	Kind        AP2MandateKind `json:"kind"`
+	Subject     string         `json:"subject,omitempty"`
+	Merchant    string         `json:"merchant,omitempty"`
+	Amount      string         `json:"amount,omitempty"`
+	Currency    string         `json:"currency,omitempty"`
+	Description string         `json:"description,omitempty"`
+	TaskID      string         `json:"taskId,omitempty"`
+	ContextID   string         `json:"contextId,omitempty"`
+	Rail        *AP2RailRef    `json:"rail,omitempty"`
+	IssuedAt    time.Time      `json:"issuedAt"`
+}
+
+// AP2SignedMandate is an AP2 mandate plus an Ed25519 signature over its canonical JSON.
+type AP2SignedMandate struct {
+	Mandate   AP2Mandate `json:"mandate"`
+	KeyID     string     `json:"keyId,omitempty"`
+	Signature string     `json:"signature"`
+}
+
+// AP2Verification records mandate verification on an A2A task without mixing in
+// payment-settlement state.
+type AP2Verification struct {
+	MandateID string `json:"mandateId"`
+	Kind      string `json:"kind"`
+	Verified  bool   `json:"verified"`
+	Error     string `json:"error,omitempty"`
+}
+
+// NewAP2Keypair returns an Ed25519 keypair suitable for tests or local demos.
+func NewAP2Keypair() (ed25519.PublicKey, ed25519.PrivateKey, error) {
+	return ed25519.GenerateKey(rand.Reader)
+}
+
+// SignAP2Mandate signs a mandate as a verifiable AP2 credential.
+func SignAP2Mandate(m AP2Mandate, keyID string, private ed25519.PrivateKey) (AP2SignedMandate, error) {
+	if m.ID == "" {
+		return AP2SignedMandate{}, errors.New("ap2: mandate id is required")
+	}
+	if m.Kind == "" {
+		return AP2SignedMandate{}, errors.New("ap2: mandate kind is required")
+	}
+	if m.IssuedAt.IsZero() {
+		m.IssuedAt = time.Now().UTC()
+	}
+	payload, err := ap2Payload(m)
+	if err != nil {
+		return AP2SignedMandate{}, err
+	}
+	return AP2SignedMandate{Mandate: m, KeyID: keyID, Signature: base64.RawURLEncoding.EncodeToString(ed25519.Sign(private, payload))}, nil
+}
+
+// VerifyAP2Mandate verifies a signed mandate credential.
+func VerifyAP2Mandate(s AP2SignedMandate, public ed25519.PublicKey) error {
+	sig, err := base64.RawURLEncoding.DecodeString(s.Signature)
+	if err != nil {
+		return fmt.Errorf("ap2: invalid signature encoding: %w", err)
+	}
+	payload, err := ap2Payload(s.Mandate)
+	if err != nil {
+		return err
+	}
+	if !ed25519.Verify(public, payload, sig) {
+		return errors.New("ap2: mandate signature verification failed")
+	}
+	return nil
+}
+
+// AP2BindMandateToMessage returns a copy of m bound to the A2A message's task/context.
+func AP2BindMandateToMessage(m AP2Mandate, msg Message) AP2Mandate {
+	m.TaskID = msg.TaskID
+	m.ContextID = msg.ContextID
+	return m
+}
+
+// AP2AttachMandate returns a copy of msg carrying the signed AP2 mandate.
+func AP2AttachMandate(msg Message, mandate AP2SignedMandate) Message {
+	msg.AP2Mandates = append(append([]AP2SignedMandate{}, msg.AP2Mandates...), mandate)
+	return msg
+}
+
+// VerifyAP2ForTask verifies signature, task binding, and optional settlement rail reference.
+func VerifyAP2ForTask(s AP2SignedMandate, public ed25519.PublicKey, task Task, rail *AP2RailRef) AP2Verification {
+	out := AP2Verification{MandateID: s.Mandate.ID, Kind: string(s.Mandate.Kind), Verified: true}
+	if err := VerifyAP2Mandate(s, public); err != nil {
+		out.Verified = false
+		out.Error = err.Error()
+		return out
+	}
+	if s.Mandate.TaskID != "" && s.Mandate.TaskID != task.ID {
+		out.Verified = false
+		out.Error = "ap2: mandate task binding mismatch"
+		return out
+	}
+	if s.Mandate.ContextID != "" && s.Mandate.ContextID != task.ContextID {
+		out.Verified = false
+		out.Error = "ap2: mandate context binding mismatch"
+		return out
+	}
+	if s.Mandate.Kind == AP2PaymentMandate && rail != nil {
+		if s.Mandate.Rail == nil || *s.Mandate.Rail != *rail {
+			out.Verified = false
+			out.Error = "ap2: settlement rail reference mismatch"
+			return out
+		}
+	}
+	return out
+}
+
+// X402AP2Rail builds the x402 settlement rail reference carried under a payment mandate.
+func X402AP2Rail(reference string) AP2RailRef { return AP2RailRef{Type: "x402", Reference: reference} }
+
+func ap2Payload(m AP2Mandate) ([]byte, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("ap2: marshal mandate: %w", err)
+	}
+	sum := sha256.Sum256(b)
+	return sum[:], nil
+}

--- a/gateway/a2a/ap2_test.go
+++ b/gateway/a2a/ap2_test.go
@@ -1,0 +1,78 @@
+package a2a
+
+import (
+	"crypto/ed25519"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testAP2Key(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := NewAP2Keypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub, priv
+}
+
+func TestAP2CheckoutMandateSignAttachAndVerify(t *testing.T) {
+	pub, priv := testAP2Key(t)
+	msg := Message{Role: "user", Kind: "message", TaskID: "task-1", ContextID: "ctx-1", Parts: []Part{{Kind: "text", Text: "buy"}}}
+	mandate := AP2BindMandateToMessage(AP2Mandate{ID: "checkout-1", Kind: AP2CheckoutMandate, Subject: "alice", Merchant: "store", Amount: "10.00", Currency: "USD", Description: "demo", IssuedAt: time.Unix(1, 0).UTC()}, msg)
+	signed, err := SignAP2Mandate(mandate, "test-key", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg = AP2AttachMandate(msg, signed)
+	task := taskFromReplyWithIDs(msg, "ok", stateCompleted, msg.TaskID, msg.ContextID)
+
+	if len(task.AP2Mandates) != 1 {
+		t.Fatalf("expected mandate carried on task, got %d", len(task.AP2Mandates))
+	}
+	got := VerifyAP2ForTask(task.AP2Mandates[0], pub, *task, nil)
+	if !got.Verified || got.Error != "" {
+		t.Fatalf("expected verified mandate, got %+v", got)
+	}
+}
+
+func TestAP2PaymentMandateX402RailReference(t *testing.T) {
+	pub, priv := testAP2Key(t)
+	rail := X402AP2Rail("payreq_123")
+	task := Task{ID: "task-2", ContextID: "ctx-2"}
+	signed, err := SignAP2Mandate(AP2Mandate{ID: "payment-1", Kind: AP2PaymentMandate, TaskID: task.ID, ContextID: task.ContextID, Rail: &rail, IssuedAt: time.Unix(1, 0).UTC()}, "test-key", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := VerifyAP2ForTask(signed, pub, task, &rail)
+	if !got.Verified {
+		t.Fatalf("expected x402 rail to verify, got %+v", got)
+	}
+}
+
+func TestAP2TamperCasesFailDistinctly(t *testing.T) {
+	pub, priv := testAP2Key(t)
+	rail := X402AP2Rail("payreq_123")
+	task := Task{ID: "task-3", ContextID: "ctx-3"}
+	signed, err := SignAP2Mandate(AP2Mandate{ID: "payment-2", Kind: AP2PaymentMandate, TaskID: task.ID, ContextID: task.ContextID, Rail: &rail, IssuedAt: time.Unix(1, 0).UTC()}, "test-key", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tampered := signed
+	tampered.Mandate.Amount = "999.00"
+	if got := VerifyAP2ForTask(tampered, pub, task, &rail); got.Verified || !strings.Contains(got.Error, "signature") {
+		t.Fatalf("expected signature failure, got %+v", got)
+	}
+
+	wrongTask := task
+	wrongTask.ID = "other-task"
+	if got := VerifyAP2ForTask(signed, pub, wrongTask, &rail); got.Verified || !strings.Contains(got.Error, "task binding") {
+		t.Fatalf("expected task binding failure, got %+v", got)
+	}
+
+	otherRail := X402AP2Rail("payreq_other")
+	if got := VerifyAP2ForTask(signed, pub, task, &otherRail); got.Verified || !strings.Contains(got.Error, "rail reference") {
+		t.Fatalf("expected rail reference failure, got %+v", got)
+	}
+}

--- a/gateway/a2a/client.go
+++ b/gateway/a2a/client.go
@@ -107,12 +107,13 @@ func (c *Client) SendMessage(ctx context.Context, message Message) (*Task, error
 			return nil, err
 		}
 		return &Task{
-			ID:        m.TaskID,
-			ContextID: m.ContextID,
-			Kind:      "task",
-			Status:    TaskStatus{State: stateCompleted, Timestamp: time.Now().UTC().Format(time.RFC3339)},
-			Artifacts: []Artifact{textArtifact(textOf(m.Parts))},
-			History:   []Message{m},
+			ID:          m.TaskID,
+			ContextID:   m.ContextID,
+			Kind:        "task",
+			Status:      TaskStatus{State: stateCompleted, Timestamp: time.Now().UTC().Format(time.RFC3339)},
+			Artifacts:   []Artifact{textArtifact(textOf(m.Parts))},
+			History:     []Message{m},
+			AP2Mandates: append([]AP2SignedMandate{}, m.AP2Mandates...),
 		}, nil
 	}
 

--- a/internal/website/docs/guides/a2a-protocol.md
+++ b/internal/website/docs/guides/a2a-protocol.md
@@ -186,6 +186,16 @@ This is the JSON-RPC binding for task execution:
 
 Both directions work: the gateway exposes your agents, and `a2a.Client` (via `flow.A2A` or `delegate` to a URL) calls external ones. The task binding is what makes a Go Micro agent both reachable from, and able to reach, the A2A ecosystem today.
 
+## AP2 mandate layer (opt-in)
+
+AP2 sits above A2A as a verifiable-intent and audit layer. Go Micro keeps the
+A2A envelope separate from payment settlement: an A2A message can carry signed
+AP2 checkout or payment mandates, and the resulting task can retain the stable
+mandate reference plus verification result. Payment settlement state remains in
+the payment rail. For x402, use an AP2 payment mandate with an `x402` rail
+reference to name the payment requirement; the existing x402 facilitator still
+performs verification and settlement.
+
 ## See also
 
 - [MCP & AI Agents](../mcp.html) — exposing services as tools

--- a/internal/website/docs/guides/x402-payments.md
+++ b/internal/website/docs/guides/x402-payments.md
@@ -128,3 +128,11 @@ Leave those variables unset in normal CI; the live test skips unless the facilit
 - [Building Effective Agents — Agents and Workflows](agents-and-workflows.html)
 - [MCP & AI Agents](../mcp.html)
 - [x402 — Coinbase Developer Docs](https://docs.cdp.coinbase.com/x402/welcome) · [x402 on Solana](https://solana.com/x402/what-is-x402)
+
+## AP2 payment mandates
+
+AP2 can authorize an x402 payment without making A2A carry settlement state. A
+payment mandate records the buyer intent and names an `x402` rail reference; the
+existing x402 facilitator remains responsible for payment verification and
+settlement. This keeps AP2 as the signed mandate/audit layer while x402 stays the
+pluggable payment rail.


### PR DESCRIPTION
## Summary
- Add AP2 checkout/payment mandate credentials with Ed25519 sign/verify helpers.
- Carry optional AP2 mandates on A2A messages and tasks while keeping x402 as a settlement rail reference.
- Cover signature tampering, task binding mismatch, and x402 rail mismatch tests.
- Document the opt-in AP2 layer in the A2A and x402 guides.

Closes #3552
Closes #3898

## Testing
- go build ./...
- go test ./gateway/a2a/... ./wrapper/...
- golangci-lint run ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy: client/grpc and transport/grpc)