### PR TITLE
harness: verify first-agent on-ramp

### DIFF
--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -17,6 +17,7 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 		"go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1",
 		"go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1",
 		"go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1",
+		"go test ./examples/first-agent -run TestRunFirstAgent -count=1",
 		"go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1",
 		"./internal/harness/zero-to-hero-ci/run.sh",
 		"go run ./internal/harness/agent-flow",
@@ -129,6 +130,8 @@ func TestNoSecretFirstAgentTranscript(t *testing.T) {
 	guide := readFile(t, filepath.Join(root, "internal", "website", "docs", "guides", "no-secret-first-agent.md"))
 
 	for _, want := range []string{
+		"go run ./examples/first-agent",
+		"go test ./examples/first-agent -run TestRunFirstAgent -count=1",
 		"go run ./examples/support",
 		"go test ./examples/support -run TestRunSupportMockSmoke -count=1",
 		"make harness",

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -14,5 +14,6 @@ go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscrip
 # runtime and mock only the LLM provider. The support example is the maintained
 # runnable 0→hero app; keep it in this CI path so its documented run/chat/inspect
 # journey cannot drift from the framework.
+go test ./examples/first-agent -run TestRunFirstAgent -count=1
 go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1
 go test ./internal/harness/universe ./internal/harness/plan-delegate -run 'Test.*Harness|TestPlanDelegateEndToEnd|TestPlanDelegateFlowHandoff' -count=1

--- a/internal/website/docs/guides/no-secret-first-agent.md
+++ b/internal/website/docs/guides/no-secret-first-agent.md
@@ -25,11 +25,17 @@ end to end with no secrets.
 
 ## Transcript
 
-From a fresh clone of the repository:
+From a fresh clone of the repository, first run the smallest service-backed agent:
 
 ```sh
 git clone https://github.com/micro/go-micro.git
 cd go-micro
+go run ./examples/first-agent
+```
+
+Then run the maintained support-agent transcript that exercises the full lifecycle:
+
+```sh
 go run ./examples/support
 ```
 
@@ -56,9 +62,10 @@ trigger and inspect the work.
 
 ## CI-backed check
 
-Run the same deterministic path as a focused test:
+Run the same deterministic paths as focused tests:
 
 ```sh
+go test ./examples/first-agent -run TestRunFirstAgent -count=1
 go test ./examples/support -run TestRunSupportMockSmoke -count=1
 ```
 

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -24,12 +24,19 @@ cloud credentials?"
 | Chat | `micro chat` remains the interactive agent entry point. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
 | Inspect | `micro inspect agent`, `micro inspect flow`, and `micro flow runs` remain discoverable for run history. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
 | Deploy | `micro deploy --dry-run` resolves deploy targets without touching remote infrastructure. | `go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1` |
+| Smallest first agent | `examples/first-agent` runs one service-backed agent with a deterministic mock model and no provider key. | `go test ./examples/first-agent -run TestRunFirstAgent -count=1` |
 | Runtime reference app | `examples/support` runs typed services, an agent using those services as tools, an event-driven flow handoff, and an approval gate with only the model mocked. | `go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1` |
 | Runtime harnesses | Real services, agents, durable flows, store-backed history, delegation, and A2A run with only the model mocked. | `./internal/harness/zero-to-hero-ci/run.sh` and `make provider-conformance-mock` |
 
 ## Run the runnable example
 
-From the repository root, start with the support-desk example when you want to see the full lifecycle in one terminal:
+From the repository root, start with the smallest service-backed agent when you want the fastest no-secret success path:
+
+```sh
+go run ./examples/first-agent
+```
+
+Then run the support-desk example when you want to see the full lifecycle in one terminal:
 
 ```sh
 go run ./examples/support
@@ -68,6 +75,9 @@ go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1
 go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1
 go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
 
+# Smallest no-secret service-backed first agent.
+go test ./examples/first-agent -run TestRunFirstAgent -count=1
+
 # Maintained 0→hero support-desk reference app.
 go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1
 
@@ -83,6 +93,9 @@ make provider-conformance-mock
 
 ## Reference scenarios
 
+- [`examples/first-agent`](https://github.com/micro/go-micro/tree/master/examples/first-agent)
+  is the smallest no-secret service-backed agent: one notes service, one scoped
+  assistant agent, and a deterministic mock model.
 - [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support)
   is the runnable support-desk story: customers, tickets, notify, a support
   agent, an intake flow, and an approval gate in one no-secret example.


### PR DESCRIPTION
## Summary
- Add the smallest no-secret first-agent example to the zero-to-hero CI harness.
- Teach the zero-to-hero and no-secret first-agent guides to advertise the focused first-agent run/test commands.
- Extend doc drift tests so the documented on-ramp fails when the first-agent example command disappears.

Closes #3955
Closes #3966

## Testing
- go build ./...
- go test ./... (fails in this sandbox because loopback gRPC targets are blocked by envoy: client/grpc and transport/grpc)
- golangci-lint run ./...
