### PR TITLE
docs: surface the first-agent example path

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,9 +440,12 @@ resp, _ := m.Generate(ctx, &ai.Request{Prompt: "hello"})
 
 ## Examples
 
+New to agents? Follow the [first-agent on-ramp](#first-agent-on-ramp), then use the [examples index](examples/README.md) for the full services → agents → workflows map.
+
 - [hello-world](examples/hello-world/) — Basic RPC service
 - [multi-service](examples/multi-service/) — Multiple services in one binary
 - [mcp](examples/mcp/) — MCP integration with AI agents
+- [first-agent](examples/first-agent/) — Smallest provider-free service-backed agent
 - [agent-plan-delegate](examples/agent-plan-delegate/) — Agent planning and multi-agent delegation
 - [agent-durable](examples/agent-durable/) — Checkpoint and resume an agent run without replaying completed tool side effects
 - [grpc-interop](examples/grpc-interop/) — Call go-micro from any gRPC client

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -95,6 +95,36 @@ func TestFirstAgentWayfindingDocs(t *testing.T) {
 			},
 		},
 		{
+			name:    "README examples list",
+			file:    filepath.Join(root, "README.md"),
+			heading: "## Examples",
+			links: []string{
+				"examples/README.md",
+				"examples/first-agent/",
+			},
+		},
+		{
+			name:    "repository examples index",
+			file:    filepath.Join(root, "examples", "README.md"),
+			heading: "## Recommended first-agent path",
+			links: []string{
+				"./first-agent/",
+				"./support/",
+			},
+		},
+		{
+			name:    "website examples index",
+			file:    filepath.Join(root, "internal", "website", "docs", "examples", "index.md"),
+			heading: "## Start here",
+			links: []string{
+				"https://github.com/micro/go-micro/tree/master/examples/first-agent",
+				"../guides/no-secret-first-agent.html",
+				"../guides/your-first-agent.html",
+				"../guides/debugging-agents.html",
+				"../guides/zero-to-hero.html",
+			},
+		},
+		{
 			name:    "website getting-started on-ramp",
 			file:    filepath.Join(root, "internal", "website", "docs", "getting-started.md"),
 			heading: "### First-agent on-ramp",
@@ -169,6 +199,23 @@ func TestNoSecretFirstAgentTranscript(t *testing.T) {
 	firstAgent := readFile(t, filepath.Join(root, "internal", "website", "docs", "guides", "your-first-agent.md"))
 	if !strings.Contains(firstAgent, "no-secret-first-agent.html") {
 		t.Fatal("Your First Agent guide does not point to the no-secret transcript")
+	}
+}
+
+func TestFirstAgentWayfindingTargetsExist(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	for _, target := range []string{
+		"examples/README.md",
+		"examples/first-agent/README.md",
+		"internal/website/docs/examples/index.md",
+		"internal/website/docs/guides/no-secret-first-agent.md",
+		"internal/website/docs/guides/your-first-agent.md",
+		"internal/website/docs/guides/debugging-agents.md",
+		"internal/website/docs/guides/zero-to-hero.md",
+	} {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(target))); err != nil {
+			t.Fatalf("first-agent wayfinding target %s disappeared: %v", target, err)
+		}
 	}
 }
 

--- a/internal/website/docs/examples/index.md
+++ b/internal/website/docs/examples/index.md
@@ -10,9 +10,12 @@ agents → workflows lifecycle.
 
 ## Start here
 
+For the provider-free first-agent route, run [`examples/first-agent`](https://github.com/micro/go-micro/tree/master/examples/first-agent), then follow [No-secret First Agent](../guides/no-secret-first-agent.html), [Your First Agent](../guides/your-first-agent.html), [Debugging your agent](../guides/debugging-agents.html), and the [0→hero Reference](../guides/zero-to-hero.html).
+
 | Goal | Runnable example | Why it is useful |
 | --- | --- | --- |
 | 0→1 service | [`examples/hello-world`](https://github.com/micro/go-micro/tree/master/examples/hello-world) | Smallest RPC service with a client call and health checks. |
+| Provider-free first agent | [`examples/first-agent`](https://github.com/micro/go-micro/tree/master/examples/first-agent) | Smallest service-backed agent with a deterministic mock model; no provider key required. |
 | First service-backed agent | [`examples/agent-demo`](https://github.com/micro/go-micro/tree/master/examples/agent-demo) | Multi-service project/task/team app with agent playground integration. |
 | 0→hero lifecycle | [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support) | No-secret support-desk story: typed services, an agent, an event-driven flow, and a guardrail. |
 | Planning and delegation | [`examples/agent-plan-delegate`](https://github.com/micro/go-micro/tree/master/examples/agent-plan-delegate) | Two agents collaborate through `plan` and `delegate` over normal Go Micro RPC. |
@@ -25,10 +28,16 @@ agents → workflows lifecycle.
 - [Getting Started](../getting-started.html) → run
   [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support)
   to see the full lifecycle before generating your own service.
+- [No-secret First Agent](../guides/no-secret-first-agent.html) → run
+  [`examples/first-agent`](https://github.com/micro/go-micro/tree/master/examples/first-agent)
+  first for the smallest provider-free agent transcript.
 - [Your First Agent](../guides/your-first-agent.html) → run
   [`examples/agent-demo`](https://github.com/micro/go-micro/tree/master/examples/agent-demo)
   or [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support)
   when you want a complete service-backed agent to inspect.
+- [Debugging your agent](../guides/debugging-agents.html) → keep
+  [`examples/first-agent`](https://github.com/micro/go-micro/tree/master/examples/first-agent)
+  nearby as the smallest mock-model reproduction before inspecting richer runs.
 - [0→hero Reference](../guides/zero-to-hero.html) → run
   [`examples/support`](https://github.com/micro/go-micro/tree/master/examples/support)
   for the human-readable scenario, then `make harness` for the full CI contract.


### PR DESCRIPTION
## Summary
- Add first-agent wayfinding from the README examples section.
- Promote the provider-free first-agent example and related guides from the website examples index.
- Extend the zero-to-hero docs tests so first-agent wayfinding links and targets cannot drift silently.

## Testing
- go build ./...
- go test ./... (fails in this sandbox because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #3969
Closes #3973