### PR TITLE
Stabilize first-agent broker isolation

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -460,7 +460,7 @@ func (a *agentImpl) Run() error {
 		a.setup()
 	}
 
-	a.server = server.NewServer(
+	serverOpts := []server.Option{
 		server.Name(a.opts.Name),
 		server.Address(a.opts.Address),
 		server.Registry(a.opts.Registry),
@@ -468,7 +468,11 @@ func (a *agentImpl) Run() error {
 			"type":     "agent",
 			"services": strings.Join(a.opts.Services, ","),
 		}),
-	)
+	}
+	if a.opts.Broker != nil {
+		serverOpts = append(serverOpts, server.Broker(a.opts.Broker))
+	}
+	a.server = server.NewServer(serverOpts...)
 
 	_ = pb.RegisterAgentHandler(a.server, a)
 

--- a/agent/options.go
+++ b/agent/options.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/broker"
 	"go-micro.dev/v6/client"
 	"go-micro.dev/v6/flow"
 	"go-micro.dev/v6/registry"
@@ -44,6 +45,7 @@ type Options struct {
 	Address      string
 	Registry     registry.Registry
 	Client       client.Client
+	Broker       broker.Broker
 	Store        store.Store
 	HistoryLimit int
 
@@ -190,6 +192,13 @@ func WithRegistry(r registry.Registry) Option {
 // WithClient sets the RPC client.
 func WithClient(c client.Client) Option {
 	return func(o *Options) { o.Client = c }
+}
+
+// WithBroker sets the broker used by the agent service endpoint. Use an
+// in-memory broker in local harnesses/tests to avoid sharing the package-wide
+// default broker listener across concurrently running examples.
+func WithBroker(b broker.Broker) Option {
+	return func(o *Options) { o.Broker = b }
 }
 
 // WithStore sets the store for agent memory.

--- a/examples/first-agent/main.go
+++ b/examples/first-agent/main.go
@@ -19,6 +19,7 @@ import (
 
 	"go-micro.dev/v6/agent"
 	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/broker"
 	"go-micro.dev/v6/client"
 	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/selector"
@@ -92,9 +93,17 @@ func runFirstAgent() error {
 	ai.Register("first-agent-mock", newMock)
 
 	reg := registry.NewMemoryRegistry()
-	cl := client.NewClient(client.Registry(reg), client.Selector(selector.NewSelector(selector.Registry(reg))))
+	br := broker.NewMemoryBroker()
+	if err := br.Init(); err != nil {
+		return fmt.Errorf("init broker: %w", err)
+	}
+	if err := br.Connect(); err != nil {
+		return fmt.Errorf("connect broker: %w", err)
+	}
+	defer br.Disconnect()
+	cl := client.NewClient(client.Registry(reg), client.Selector(selector.NewSelector(selector.Registry(reg))), client.Broker(br))
 
-	notes := service.New(service.Name("notes"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl), service.HandleSignal(false))
+	notes := service.New(service.Name("notes"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl), service.Broker(br), service.HandleSignal(false))
 	if err := notes.Handle(new(NotesService)); err != nil {
 		return fmt.Errorf("handle notes: %w", err)
 	}
@@ -110,6 +119,7 @@ func runFirstAgent() error {
 		agent.Provider("first-agent-mock"),
 		agent.WithRegistry(reg),
 		agent.WithClient(cl),
+		agent.WithBroker(br),
 		agent.WithStore(store.NewMemoryStore()),
 	)
 	agentErr := make(chan error, 1)


### PR DESCRIPTION
Summary:
- Add an optional agent broker setting so locally-run agents can use isolated broker instances.
- Wire the first-agent example to use a memory broker for its notes service, client, and assistant agent.

Testing:
- go test -race -count=5 ./examples/first-agent
- go build ./...
- go test ./... (fails in this environment due loopback gRPC targets forbidden in grpc tests)
- golangci-lint run ./...

Closes #3977
Closes #3980