### PR TITLE
Require plan-delegate notify before flow completion

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -403,8 +403,14 @@ func runPlanDelegate(provider string) error {
 	}
 
 	f := flow.New("zero-to-hero",
-		flow.Agent("conductor"),
-		flow.Prompt("Create three launch tasks (Design, Build, Ship), then make sure owner@acme.com is notified: {{.Data}}"),
+		flow.Steps(
+			flow.Step{Name: "conductor", Run: planDelegateConductorStep(conductor)},
+			flow.Step{Name: "require-notify", Run: requireDelegatedNotifyStep(taskSvc, notifySvc, func(ctx context.Context) error {
+				_, err := conductor.Ask(ctx, "The Design, Build, and Ship tasks already exist, but the owner notification is still missing. Delegate exactly one notification to the \"comms\" agent now with this exact subtask: "+delegatedNotifyTask+" Do not create more tasks and do not answer until comms has handled the notification.")
+				return err
+			})},
+		),
+		flow.WithCheckpoint(flow.StoreCheckpoint(mem, "flow-zero-to-hero")),
 		flow.Timeout(harnessutil.LiveTimeout(provider)),
 	)
 	if err := f.Register(reg, broker.DefaultBroker, cl); err != nil {
@@ -419,15 +425,8 @@ func runPlanDelegate(provider string) error {
 		executeDone <- f.Execute(ctx, "launch readiness")
 	}()
 
-	if err := waitForPlanDelegateExecution(executeDone, taskSvc, notifySvc, func(ctx context.Context) error {
-		_, err := conductor.Ask(ctx, "The Design, Build, and Ship tasks already exist, but the owner notification is still missing. Delegate exactly one notification to the \"comms\" agent now with this exact subtask: "+delegatedNotifyTask+" Do not create more tasks and do not answer until comms has handled the notification.")
+	if err := waitForPlanDelegateExecution(executeDone, taskSvc, notifySvc); err != nil {
 		return err
-	}); err != nil {
-		return err
-	}
-
-	if rs := f.Results(); len(rs) > 0 {
-		fmt.Println("\n\033[1m< conductor reply:\033[0m", rs[len(rs)-1].Reply)
 	}
 
 	// Prove plan was persisted to the real store.
@@ -444,7 +443,48 @@ func runPlanDelegate(provider string) error {
 	return nil
 }
 
-func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notifySvc *NotifyService, recoverMissingNotify func(context.Context) error) error {
+func planDelegateConductorStep(conductor agent.Agent) flow.StepFunc {
+	return func(ctx context.Context, in flow.State) (flow.State, error) {
+		prompt := "Create three launch tasks (Design, Build, Ship), then make sure owner@acme.com is notified: " + in.String()
+		rsp, err := conductor.Ask(ctx, prompt)
+		if err != nil {
+			return in, err
+		}
+		if rsp != nil && rsp.Reply != "" {
+			fmt.Println("\n\033[1m< conductor reply:\033[0m", rsp.Reply)
+		}
+		return in, nil
+	}
+}
+
+func requireDelegatedNotifyStep(taskSvc *TaskService, notifySvc *NotifyService, recoverMissingNotify func(context.Context) error) flow.StepFunc {
+	return func(ctx context.Context, in flow.State) (flow.State, error) {
+		tasks := taskSvc.count()
+		notify := notifySvc.count()
+		if notify == 1 {
+			return in, nil
+		}
+		if recoverMissingNotify == nil || tasks != 3 || notify != 0 {
+			return in, fmt.Errorf("delegation completed without required notify side effect: notify=%d, want 1", notify)
+		}
+		settled, err := waitForNotifySideEffect(notifySvc, delegatedNotifySettleTimeout)
+		if err != nil {
+			return in, err
+		}
+		if !settled {
+			fmt.Print("\n\033[33mwarning:\033[0m conductor step completed before delegated notify; retrying the missing comms handoff once before the flow can complete.\n")
+			if err := recoverMissingNotify(ctx); err != nil {
+				return in, fmt.Errorf("delegation completed without required notify side effect and recovery failed: notify=%d, want 1: %w", notify, err)
+			}
+		}
+		if notify = notifySvc.count(); notify != 1 {
+			return in, fmt.Errorf("delegation recovery completed without required notify side effect: notify=%d, want 1", notify)
+		}
+		return in, nil
+	}
+}
+
+func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notifySvc *NotifyService) error {
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -463,25 +503,7 @@ func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notif
 				return fmt.Errorf("flow execute after side effects tasks=%d notify=%d: %w", tasks, notify, err)
 			}
 			if notify != 1 {
-				if recoverMissingNotify == nil || tasks != 3 || notify != 0 {
-					return fmt.Errorf("delegation completed without required notify side effect: notify=%d, want 1", notify)
-				}
-				settled, err := waitForNotifySideEffect(notifySvc, delegatedNotifySettleTimeout)
-				if err != nil {
-					return err
-				}
-				if !settled {
-					fmt.Print("\n\033[33mwarning:\033[0m flow completed before delegated notify; retrying the missing comms handoff once.\n")
-					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-					retryErr := recoverMissingNotify(ctx)
-					cancel()
-					if retryErr != nil {
-						return fmt.Errorf("delegation completed without required notify side effect and recovery failed: notify=%d, want 1: %w", notify, retryErr)
-					}
-				}
-				if notify = notifySvc.count(); notify != 1 {
-					return fmt.Errorf("delegation recovery completed without required notify side effect: notify=%d, want 1", notify)
-				}
+				return fmt.Errorf("delegation completed without required notify side effect: notify=%d, want 1", notify)
 			}
 			return nil
 		case <-ticker.C:

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -258,7 +258,7 @@ func TestPlanDelegateExecutionReportsDuplicateNotifyBeforeTimeout(t *testing.T) 
 
 	done := make(chan error)
 	errCh := make(chan error, 1)
-	go func() { errCh <- waitForPlanDelegateExecution(done, new(TaskService), notifySvc, nil) }()
+	go func() { errCh <- waitForPlanDelegateExecution(done, new(TaskService), notifySvc) }()
 
 	select {
 	case err := <-errCh:
@@ -278,7 +278,7 @@ func TestPlanDelegateExecutionRejectsClaimedCompletionWithoutNotify(t *testing.T
 	done := make(chan error, 1)
 	done <- nil
 
-	err := waitForPlanDelegateExecution(done, new(TaskService), notifySvc, nil)
+	err := waitForPlanDelegateExecution(done, new(TaskService), notifySvc)
 	if err == nil {
 		t.Fatal("waitForPlanDelegateExecution returned nil, want missing notify side-effect error")
 	}
@@ -296,15 +296,13 @@ func TestPlanDelegateExecutionRecoversMissingNotifyOnce(t *testing.T) {
 		}
 	}
 	notifySvc := new(NotifyService)
-	done := make(chan error, 1)
-	done <- nil
 
 	recovered := false
-	err := waitForPlanDelegateExecution(done, taskSvc, notifySvc, func(ctx context.Context) error {
+	_, err := requireDelegatedNotifyStep(taskSvc, notifySvc, func(ctx context.Context) error {
 		recovered = true
 		var rsp SendResponse
 		return notifySvc.Send(ctx, &SendRequest{To: "owner@acme.com", Message: "The launch plan is ready"}, &rsp)
-	})
+	})(context.Background(), flow.State{})
 	if err != nil {
 		t.Fatalf("waitForPlanDelegateExecution returned %v, want recovery success", err)
 	}
@@ -325,8 +323,6 @@ func TestPlanDelegateExecutionWaitsForInFlightNotifyAfterFlowCompletion(t *testi
 		}
 	}
 	notifySvc := new(NotifyService)
-	done := make(chan error, 1)
-	done <- nil
 
 	go func() {
 		time.Sleep(100 * time.Millisecond)
@@ -335,11 +331,11 @@ func TestPlanDelegateExecutionWaitsForInFlightNotifyAfterFlowCompletion(t *testi
 	}()
 
 	recovered := false
-	err := waitForPlanDelegateExecution(done, taskSvc, notifySvc, func(ctx context.Context) error {
+	_, err := requireDelegatedNotifyStep(taskSvc, notifySvc, func(ctx context.Context) error {
 		recovered = true
 		var rsp SendResponse
 		return notifySvc.Send(ctx, &SendRequest{To: "owner@acme.com", Message: "The launch plan is ready"}, &rsp)
-	})
+	})(context.Background(), flow.State{})
 	if err != nil {
 		t.Fatalf("waitForPlanDelegateExecution returned %v, want in-flight notify success", err)
 	}
@@ -374,7 +370,7 @@ func TestPlanDelegateExecutionAcceptsClientTimeoutAfterSideEffects(t *testing.T)
 	done := make(chan error, 1)
 	done <- errors.New(`{"id":"go.micro.client","code":408,"detail":"<nil>","status":"Request Timeout"}`)
 
-	if err := waitForPlanDelegateExecution(done, taskSvc, notifySvc, nil); err != nil {
+	if err := waitForPlanDelegateExecution(done, taskSvc, notifySvc); err != nil {
 		t.Fatalf("waitForPlanDelegateExecution returned %v, want completed side effects to satisfy client timeout", err)
 	}
 }
@@ -383,7 +379,7 @@ func TestPlanDelegateExecutionClassifiesClientTimeoutBeforeSideEffects(t *testin
 	done := make(chan error, 1)
 	done <- errors.New(`{"id":"go.micro.client","code":408,"detail":"<nil>","status":"Request Timeout"}`)
 
-	err := waitForPlanDelegateExecution(done, new(TaskService), new(NotifyService), nil)
+	err := waitForPlanDelegateExecution(done, new(TaskService), new(NotifyService))
 	if err == nil {
 		t.Fatal("waitForPlanDelegateExecution returned nil, want timeout before side effects to fail")
 	}
@@ -410,7 +406,7 @@ func TestPlanDelegateExecutionClassifiesPartialClientTimeout(t *testing.T) {
 	done := make(chan error, 1)
 	done <- errors.New(`{"id":"go.micro.client","code":408,"detail":"<nil>","status":"Request Timeout"}`)
 
-	err := waitForPlanDelegateExecution(done, taskSvc, new(NotifyService), nil)
+	err := waitForPlanDelegateExecution(done, taskSvc, new(NotifyService))
 	if err == nil {
 		t.Fatal("waitForPlanDelegateExecution returned nil, want timeout before notify to fail")
 	}


### PR DESCRIPTION
Summary:
- Run the plan-delegate harness as a stepped flow so the delegated notify postcondition is checked before the flow can complete.
- Keep one bounded recovery handoff inside the require-notify step, preserving exactly-one notification and duplicate detection.
- Update deterministic tests to cover completion, recovery, in-flight notify settling, timeouts, and duplicate notify protection.

Testing:
- go build ./...
- go test ./internal/harness/plan-delegate
- go test ./... (fails in existing environment: cache expiry flake plus loopback gRPC targets forbidden)
- golangci-lint run ./...

Closes #3972
Closes #3985