### PR TITLE
agent: run mixed AtlasCloud text tool calls

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -352,6 +352,15 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 					resp.Reply = ""
 				}
 			}
+		} else if calls, answer, ok := a.executeAdditionalTextToolCalls(ctx, resp.Reply, toolList, resp.ToolCalls); ok {
+			resp.ToolCalls = append(resp.ToolCalls, calls...)
+			if answer != "" {
+				if resp.Answer == "" {
+					resp.Answer = answer
+				} else {
+					resp.Answer += "\n" + answer
+				}
+			}
 		}
 
 		if a.opts.Checkpoint != nil {

--- a/agent/conformance_test.go
+++ b/agent/conformance_test.go
@@ -504,3 +504,67 @@ func TestAgentExecutesProviderTextToolCallFallback(t *testing.T) {
 		t.Fatalf("Reply = %q, want tool result instead of raw JSON", resp.Reply)
 	}
 }
+
+func TestAgentExecutesTextToolCallFallbackAfterStructuredToolCall(t *testing.T) {
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if opts.ToolHandler == nil {
+			return nil, errors.New("missing tool handler")
+		}
+		echo := opts.ToolHandler(ctx, ai.ToolCall{
+			ID:    "structured-echo-1",
+			Name:  "conformance_echo",
+			Input: map[string]any{"value": "agent-conformance"},
+		})
+		return &ai.Response{
+			Reply:  echo.Content + "\n<tool_call name=\"delegate\">{\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}</tool_call>",
+			Answer: echo.Content,
+			ToolCalls: []ai.ToolCall{
+				{ID: "structured-echo-1", Name: "conformance_echo", Input: map[string]any{"value": "agent-conformance"}, Result: echo.Content},
+			},
+		}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	var sawTool bool
+	var sawBlockedDelegate bool
+	a := New(
+		Name("conformance-mixed-text-tool"),
+		Provider("fake"),
+		WithRegistry(registry.NewMemoryRegistry()),
+		WithStore(store.NewMemoryStore()),
+		WithMemory(NewInMemory(4)),
+		ApproveTool(func(tool string, input map[string]any) (bool, string) {
+			if tool == "delegate" {
+				sawBlockedDelegate = true
+				return false, "cross-provider conformance blocks delegate side effects"
+			}
+			return true, ""
+		}),
+		WithTool("conformance_echo", "Echo a conformance value.", map[string]any{
+			"value": map[string]any{"type": "string"},
+		}, func(ctx context.Context, input map[string]any) (string, error) {
+			sawTool = true
+			return `{"marker":"agent-conformance-ok"}`, nil
+		}),
+	)
+
+	resp, err := a.Ask(context.Background(), "Run the mixed structured/text tool fallback.")
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !sawTool {
+		t.Fatal("structured conformance_echo did not execute")
+	}
+	if !sawBlockedDelegate {
+		t.Fatal("tagged text delegate fallback did not execute")
+	}
+	if len(resp.ToolCalls) != 2 {
+		t.Fatalf("ToolCalls = %+v, want structured echo and text delegate", resp.ToolCalls)
+	}
+	if resp.ToolCalls[1].Name != "delegate" || resp.ToolCalls[1].Error != ai.RefusedApproval {
+		t.Fatalf("delegate ToolCall = %+v, want refused delegate", resp.ToolCalls[1])
+	}
+	if !strings.Contains(resp.Reply, "agent-conformance-ok") {
+		t.Fatalf("Reply = %q, want conformance marker", resp.Reply)
+	}
+}

--- a/agent/text_tool_calls.go
+++ b/agent/text_tool_calls.go
@@ -47,6 +47,48 @@ func (a *agentImpl) executeTextToolCalls(ctx context.Context, reply string, tool
 	return calls, strings.Join(results, "\n"), true
 }
 
+// executeAdditionalTextToolCalls runs text-encoded tool calls that accompany a
+// structured tool_calls response. Some OpenAI-compatible providers can mix the
+// two forms in a single assistant turn: for example, emitting a native
+// conformance_echo call while rendering a follow-up guarded delegate call as
+// <tool_call name="delegate">...</tool_call> text. Keep this fallback additive
+// and de-duplicate calls already represented in the structured tool_calls list.
+func (a *agentImpl) executeAdditionalTextToolCalls(ctx context.Context, reply string, tools []ai.Tool, existing []ai.ToolCall) ([]ai.ToolCall, string, bool) {
+	calls := parseTextToolCalls(reply, tools)
+	if len(calls) == 0 {
+		return nil, "", false
+	}
+
+	seen := map[string]bool{}
+	for _, call := range existing {
+		seen[textToolCallKey(call)] = true
+	}
+
+	handler := a.toolHandler()
+	out := make([]ai.ToolCall, 0, len(calls))
+	results := make([]string, 0, len(calls))
+	for i := range calls {
+		if seen[textToolCallKey(calls[i])] {
+			continue
+		}
+		result := handler(ctx, calls[i])
+		calls[i].Result = result.Content
+		if result.Refused != "" {
+			calls[i].Error = result.Refused
+		}
+		if result.Content != "" {
+			results = append(results, result.Content)
+		}
+		out = append(out, calls[i])
+	}
+	return out, strings.Join(results, "\n"), len(out) > 0
+}
+
+func textToolCallKey(call ai.ToolCall) string {
+	b, _ := json.Marshal(call.Input)
+	return call.Name + "\x00" + string(b)
+}
+
 func parseTextToolCalls(text string, tools []ai.Tool) []ai.ToolCall {
 	allowed := textToolNames(tools)
 	if len(allowed) == 0 {


### PR DESCRIPTION
Summary:
- Execute tagged text tool calls that accompany structured tool_calls responses so AtlasCloud can complete the guarded delegate conformance path after conformance_echo.
- Add deterministic fake-provider coverage for mixed structured/text tool-call output.

Testing:
- go build ./...
- go test ./agent
- go test ./... (fails in this environment because loopback targets are forbidden for grpc client/transport tests)
- golangci-lint run ./...

Closes #3990
Closes #3997