### PR TITLE
Guard plan delegation ordering

### DIFF
--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -290,6 +290,11 @@ func (a *agentImpl) planWrap(next ai.ToolHandler) ai.ToolHandler {
 		if call.Name == toolPlan {
 			return a.handlePlan(call)
 		}
+		if call.Name == toolDelegate {
+			if blocked := a.unfinishedPlanStepsBeforeDelegation(); len(blocked) > 0 {
+				return refused(call.ID, ai.RefusedApproval, "complete these plan steps before delegating: "+strings.Join(blocked, ", "))
+			}
+		}
 		res := next(ctx, call)
 		if res.Refused == "" && toolErrorMessage(res) == "" {
 			a.completeNextPlanStep()
@@ -464,6 +469,53 @@ func (a *agentImpl) completeNextPlanStep() {
 	}
 }
 
+func (a *agentImpl) unfinishedPlanStepsBeforeDelegation() []string {
+	plan := a.loadPlan()
+	if plan == "" {
+		return nil
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(plan), &data); err != nil {
+		return nil
+	}
+	steps, ok := data["steps"].([]any)
+	if !ok {
+		return nil
+	}
+	var unfinished []string
+	for _, raw := range steps {
+		step, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		task := planStepTask(step)
+		if isDelegationPlanTask(task) {
+			break
+		}
+		if !isUnfinishedPlanStatus(step["status"]) {
+			continue
+		}
+		if task == "" {
+			task = "<unnamed>"
+		}
+		unfinished = append(unfinished, task)
+	}
+	return unfinished
+}
+
+func planStepTask(step map[string]any) string {
+	if task, _ := step["task"].(string); task != "" {
+		return task
+	}
+	desc, _ := step["description"].(string)
+	return desc
+}
+
+func isDelegationPlanTask(task string) bool {
+	task = normalizePlanTask(task)
+	return strings.Contains(task, "delegate") || strings.Contains(task, "notify") || strings.Contains(task, "notification")
+}
+
 func (a *agentImpl) unfinishedPlanSteps() []string {
 	plan := a.loadPlan()
 	if plan == "" {
@@ -487,7 +539,7 @@ func (a *agentImpl) unfinishedPlanSteps() []string {
 		if status != "" && status != "pending" && status != "in_progress" {
 			continue
 		}
-		task, _ := step["task"].(string)
+		task := planStepTask(step)
 		if task == "" {
 			task = "<unnamed>"
 		}

--- a/agent/builtin_test.go
+++ b/agent/builtin_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -189,5 +190,47 @@ func TestIsAgent(t *testing.T) {
 	}
 	if a.isAgent("nonexistent") {
 		t.Error("isAgent(nonexistent) = true, want false")
+	}
+}
+
+func TestPlanWrapBlocksDelegationUntilPriorPlanStepsFinish(t *testing.T) {
+	mem := store.NewMemoryStore()
+	a := New(Name("planner"), WithStore(mem)).(*agentImpl)
+	a.handlePlan(ai.ToolCall{Name: toolPlan, Input: map[string]any{
+		"steps": []any{
+			map[string]any{"task": "Create Design task", "status": "pending"},
+			map[string]any{"task": "Create Build task", "status": "pending"},
+			map[string]any{"task": "Create Ship task", "status": "pending"},
+			map[string]any{"task": "Delegate readiness notification to comms agent", "status": "pending"},
+		},
+	}})
+
+	called := false
+	handle := a.planWrap(func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		called = true
+		return ai.ToolResult{ID: call.ID, Content: "ok"}
+	})
+
+	res := handle(context.Background(), ai.ToolCall{ID: "delegate-1", Name: toolDelegate, Input: map[string]any{"to": "comms"}})
+	if called {
+		t.Fatal("delegate handler was called before prior task plan steps completed")
+	}
+	if res.Refused == "" {
+		t.Fatalf("delegate result was not refused: %+v", res)
+	}
+	if got := res.Content; !containsStr(got, "Create Design task") || !containsStr(got, "Create Ship task") {
+		t.Fatalf("delegate refusal content = %q, want prior unfinished task steps", got)
+	}
+
+	for _, id := range []string{"add-design", "add-build", "add-ship"} {
+		_ = handle(context.Background(), ai.ToolCall{ID: id, Name: "task.Add", Input: map[string]any{"title": id}})
+	}
+	called = false
+	res = handle(context.Background(), ai.ToolCall{ID: "delegate-2", Name: toolDelegate, Input: map[string]any{"to": "comms"}})
+	if !called {
+		t.Fatal("delegate handler was not called after prior task plan steps completed")
+	}
+	if res.Refused != "" {
+		t.Fatalf("delegate result refused after prior task steps completed: %+v", res)
 	}
 }


### PR DESCRIPTION
## Summary
- Refuse delegate tool calls while earlier task-creation plan steps are still unfinished, preventing notification side effects from running before required launch tasks.
- Add deterministic coverage for the plan/delegate ordering guard.

Closes #3991
Closes #4002

## Testing
- go build ./...
- go test ./agent -run TestPlanWrapBlocksDelegationUntilPriorPlanStepsFinish -count=1
- go test ./agent -run 'TestPlanWrapBlocksDelegationUntilPriorPlanStepsFinish|TestAgentProviderConformanceMatrix/fake' -count=1\n- go test ./internal/harness/plan-delegate -run 'TestZeroToHeroContract|TestPlanDelegateRetriesAfterUnknownDelegateTool' -count=1\n- go test ./... (fails in environment: loopback targets forbidden for grpc tests; mdns registry isolation flake)\n- golangci-lint run ./...