### PR TITLE
agent: preserve otel child span events

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -215,13 +215,13 @@ func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.
 	} else {
 		span.SetStatus(codes.Ok, "")
 	}
-	span.End()
 	e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "model", Provider: provider, Model: model, Attempt: info.Attempt, MaxAttempts: info.MaxAttempts, LatencyMS: dur, Tokens: usage}
 	if err != nil {
 		e.Error = err.Error()
 		e.ErrorKind = string(ai.ClassifyError(err))
 	}
 	m.a.recordSpanEvent(span, e)
+	span.End()
 	return resp, err
 }
 
@@ -393,8 +393,8 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 		} else {
 			span.SetStatus(codes.Ok, "")
 		}
-		span.End()
 		a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr)})
+		span.End()
 		return res
 	}
 }

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -95,8 +95,16 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 		if attrs[AttrRunID] != runID || attrs[AttrAgentName] != "runner" {
 			t.Fatalf("%s missing run correlation attributes: %#v", s.Name(), attrs)
 		}
-		if s.Name() == spanNameModelCall && (attrs[AttrAttempt] != "1" || attrs[AttrMaxAttempts] != "1") {
-			t.Fatalf("model span missing attempt attributes: %#v", attrs)
+		if s.Name() == spanNameModelCall {
+			if attrs[AttrAttempt] != "1" || attrs[AttrMaxAttempts] != "1" {
+				t.Fatalf("model span missing attempt attributes: %#v", attrs)
+			}
+			if !spanEventHasRunInfo(s.Events(), "agent.model", runID, "runner") {
+				t.Fatalf("model span missing model event: %#v", s.Events())
+			}
+		}
+		if s.Name() == spanNameToolCall && !spanEventHasRunInfo(s.Events(), "agent.tool", runID, "runner") {
+			t.Fatalf("tool span missing tool event: %#v", s.Events())
 		}
 	}
 	keys, err := store.Scope(st, "agent", "runner").List(store.ListPrefix("runs/"))
@@ -654,6 +662,9 @@ func TestAgentOpenTelemetrySpansModelStream(t *testing.T) {
 		}
 		if attrs[AttrAttempt] != "2" || attrs[AttrMaxAttempts] != "3" || attrs[AttrTotalTokens] != "5" {
 			t.Fatalf("stream span missing attempt/usage attributes: %#v", attrs)
+		}
+		if !spanEventHasRunInfo(s.Events(), "agent.stream", "stream-run-1", "stream-runner") {
+			t.Fatalf("stream span missing stream event: %#v", s.Events())
 		}
 		sawStream = true
 	}


### PR DESCRIPTION
## Summary
- Record model and tool run events before ending their OpenTelemetry spans so child spans keep the correlated timeline event instead of only the persisted run event.
- Assert model, tool, and stream spans include their corresponding run events.

Closes #3908
Closes #4025

## Testing
- go build ./...
- go test ./agent
- go test ./... (fails in this environment because loopback gRPC tests are blocked by Envoy: "Loopback targets forbidden")
- golangci-lint run ./...