### PR TITLE
docs: route security reports through GitHub advisories

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: 🔒 Report a vulnerability
+    url: https://github.com/micro/go-micro/security/advisories/new
+    about: Privately disclose security vulnerabilities to the maintainers.
   - name: 💖 Sponsor Go Micro
     url: https://github.com/sponsors/asim
     about: Fund ongoing development and see your name or logo on the project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,10 +17,10 @@ We actively support the following versions of go-micro:
 
 ### How to Report
 
-Send security vulnerability reports to: **security@go-micro.dev**
-
-Or use GitHub's private security advisory feature:
+Use GitHub's private security advisory feature:
 https://github.com/micro/go-micro/security/advisories/new
+
+This keeps vulnerability reports private, ties follow-up to the affected repository, and avoids relying on project email routing.
 
 ### What to Include
 
@@ -175,5 +175,4 @@ We currently do not offer a bug bounty program, but we greatly appreciate respon
 For security questions that are not vulnerabilities, please:
 - Open a discussion: https://github.com/micro/go-micro/discussions
 - Join Discord: https://discord.gg/G8Gk5j3uXr
-- Email: support@go-micro.dev
 


### PR DESCRIPTION
## Summary
- route vulnerability reporting to GitHub private security advisories instead of bouncing project email
- add a security report contact link to the GitHub issue chooser

Closes #4026
Closes #4028

## Testing
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in grpc loopback tests)
- golangci-lint run ./...