### PR TITLE
feat(cli): surface no-secret agent demo

### DIFF
--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -14,6 +14,30 @@ import (
 	"go-micro.dev/v6/store"
 )
 
+const noSecretDemoHelp = `No-secret first-agent demo
+
+Use this when you want the fastest provider-free agent success path before
+configuring API keys. It runs the maintained support/first-agent transcript with
+the deterministic mock model used by CI:
+
+  go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1
+
+What this proves:
+  - service tools can be called by an agent
+  - chat behavior is exercised without contacting a live provider
+  - run history can be inspected after the prompt
+
+After it passes:
+  - Build your own service-backed agent: https://go-micro.dev/docs/guides/your-first-agent.html
+  - Diagnose provider-backed chat:     https://go-micro.dev/docs/guides/debugging-agents.html
+  - Walk the full 0→hero lifecycle:    https://go-micro.dev/docs/guides/zero-to-hero.html
+
+Use live-provider chat when you are ready for real model behavior:
+  micro agent preflight
+  micro run
+  micro chat
+  micro inspect agent <name>`
+
 func init() {
 	cmd.Register(&cli.Command{
 		Name:      "runs",
@@ -34,8 +58,19 @@ func init() {
 
 	cmd.Register(&cli.Command{
 		Name:  "agent",
-		Usage: "Manage AI agents",
+		Usage: "Manage AI agents (try: micro agent demo)",
 		Subcommands: []*cli.Command{
+			{
+				Name:  "demo",
+				Usage: "Show the no-secret first-agent demo command",
+				Description: `Print the provider-free first-agent path for new developers:
+the deterministic mock-model transcript, when to use it, and where to go next
+for live-provider chat and inspect/debugging.`,
+				Action: func(c *cli.Context) error {
+					fmt.Fprintln(c.App.Writer, noSecretDemoHelp)
+					return nil
+				},
+			},
 			{
 				Name:  "preflight",
 				Usage: "Check local prerequisites before the first provider-backed agent",

--- a/cmd/micro/first_agent_walkthrough_test.go
+++ b/cmd/micro/first_agent_walkthrough_test.go
@@ -30,6 +30,9 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 	if !subcommands["agent"]["preflight"] {
 		t.Fatal("first-agent walkthrough missing preflight boundary: agent preflight")
 	}
+	if !subcommands["agent"]["demo"] {
+		t.Fatal("first-agent walkthrough missing no-secret boundary: agent demo")
+	}
 	if !subcommands["agent"]["doctor"] {
 		t.Fatal("first-agent walkthrough missing recovery boundary: agent doctor")
 	}
@@ -67,6 +70,31 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 			t.Fatalf("micro docs output missing %q:\n%s", want, out.String())
 		}
 	}
+
+	agent := commandByName(t, "agent")
+	if !strings.Contains(agent.Usage, "micro agent demo") {
+		t.Fatalf("micro agent help should advertise the no-secret demo; usage was %q", agent.Usage)
+	}
+	demo := subcommandByName(t, agent, "demo")
+	out.Reset()
+	if err := demo.Action(cli.NewContext(app, nil, nil)); err != nil {
+		t.Fatalf("micro agent demo failed: %v", err)
+	}
+	for _, want := range []string{
+		"No-secret first-agent demo",
+		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1",
+		"provider-free",
+		"micro agent preflight",
+		"micro chat",
+		"micro inspect agent <name>",
+		"your-first-agent.html",
+		"debugging-agents.html",
+		"zero-to-hero.html",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("micro agent demo output missing %q:\n%s", want, out.String())
+		}
+	}
 }
 
 func commandByName(t *testing.T, name string) *cli.Command {
@@ -77,5 +105,16 @@ func commandByName(t *testing.T, name string) *cli.Command {
 		}
 	}
 	t.Fatalf("missing command %q", name)
+	return nil
+}
+
+func subcommandByName(t *testing.T, command *cli.Command, name string) *cli.Command {
+	t.Helper()
+	for _, subcommand := range command.Subcommands {
+		if subcommand.Name == name {
+			return subcommand
+		}
+	}
+	t.Fatalf("missing subcommand %q under %q", name, command.Name)
 	return nil
 }


### PR DESCRIPTION
Summary:
- Add `micro agent demo` to print the provider-free first-agent transcript command and next-step docs.
- Advertise the demo from `micro agent` help and cover the CLI surface with tests.

Testing:
- `go build ./...`
- `go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1`
- `go test ./...` (fails in this sandbox due pre-existing/environment-sensitive loopback and store test failures)
- `golangci-lint run ./...`

Closes #4036
Closes #4038