### PR TITLE
Document agent demo in first-agent on-ramp

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,16 @@ make harness
 After install and the first `micro new`/`micro run` smoke check, take the
 walkable agent path in this order:
 
-1. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
-2. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
+1. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
+2. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
+3. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
    maintained support agent with a mock model and see services → agents → workflows succeed without a key.
-3. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
+4. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
    service-backed agent and talk to it with `micro chat`.
-4. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
+5. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
    `micro agent inspect`, run history, memory, and provider checks when the first
    conversation does something unexpected.
-5. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
+6. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
    services → agents → workflows loop with scaffold, run, chat, inspect, flow
    history, and deploy dry-run commands that match the maintained harness.
 

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -88,6 +88,7 @@ func TestFirstAgentWayfindingDocs(t *testing.T) {
 			file:    filepath.Join(root, "README.md"),
 			heading: "### First agent on-ramp",
 			links: []string{
+				"micro agent demo",
 				"internal/website/docs/guides/no-secret-first-agent.md",
 				"internal/website/docs/guides/your-first-agent.md",
 				"internal/website/docs/guides/debugging-agents.md",
@@ -129,6 +130,7 @@ func TestFirstAgentWayfindingDocs(t *testing.T) {
 			file:    filepath.Join(root, "internal", "website", "docs", "getting-started.md"),
 			heading: "### First-agent on-ramp",
 			links: []string{
+				"micro agent demo",
 				"guides/no-secret-first-agent.html",
 				"guides/your-first-agent.html",
 				"guides/debugging-agents.html",
@@ -160,6 +162,7 @@ func TestNoSecretFirstAgentTranscript(t *testing.T) {
 	guide := readFile(t, filepath.Join(root, "internal", "website", "docs", "guides", "no-secret-first-agent.md"))
 
 	for _, want := range []string{
+		"micro agent demo",
 		"go run ./examples/first-agent",
 		"go test ./examples/first-agent -run TestRunFirstAgent -count=1",
 		"go run ./examples/support",

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -90,11 +90,12 @@ The console discovers services from the registry and orchestrates across them vi
 
 After this quick start, follow the agent path in order:
 
-1. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent) — run one service-backed agent with a mock model and no provider key.
-2. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — run a useful support agent with a mock model before setting up a provider key.
-3. [Your First Agent](guides/your-first-agent.html) — build a service-backed agent and talk to it with `micro chat`.
-4. [Debugging your agent](guides/debugging-agents.html) — inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
-5. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
+1. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
+2. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent) — run one service-backed agent with a mock model and no provider key.
+3. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — run a useful support agent with a mock model before setting up a provider key.
+4. [Your First Agent](guides/your-first-agent.html) — build a service-backed agent and talk to it with `micro chat`.
+5. [Debugging your agent](guides/debugging-agents.html) — inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
+6. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
 
 ## Quick Start: Write a Service
 

--- a/internal/website/docs/guides/no-secret-first-agent.md
+++ b/internal/website/docs/guides/no-secret-first-agent.md
@@ -25,6 +25,12 @@ end to end with no secrets.
 
 ## Transcript
 
+If you installed the CLI first, ask it for the no-secret path:
+
+```sh
+micro agent demo
+```
+
 From a fresh clone of the repository, first run the smallest service-backed agent:
 
 ```sh

--- a/internal/website/docs/index.md
+++ b/internal/website/docs/index.md
@@ -16,7 +16,7 @@ It's built on a pluggable architecture of Go interfaces: service discovery, clie
 
 ## Learn More
 
-Start with [Getting Started](getting-started.html) for install and the first local service. Then follow the first-agent on-ramp: [No-secret first-agent transcript](guides/no-secret-first-agent.html) to run a mock-model support agent, [Your First Agent](guides/your-first-agent.html) to build and chat with a service-backed agent, [Debugging your agent](guides/debugging-agents.html) to inspect runs and memory, and the [0→hero reference path](guides/zero-to-hero.html) to walk the full scaffold → run → chat → inspect → deploy dry-run lifecycle covered by CI.
+Start with [Getting Started](getting-started.html) for install and the first local service. Then follow the first-agent on-ramp: `micro agent demo` for the installed no-secret CLI affordance, [No-secret first-agent transcript](guides/no-secret-first-agent.html) to run a mock-model support agent, [Your First Agent](guides/your-first-agent.html) to build and chat with a service-backed agent, [Debugging your agent](guides/debugging-agents.html) to inspect runs and memory, and the [0→hero reference path](guides/zero-to-hero.html) to walk the full scaffold → run → chat → inspect → deploy dry-run lifecycle covered by CI.
 
 Otherwise continue to read the docs for more information about the framework.
 
@@ -24,6 +24,7 @@ Otherwise continue to read the docs for more information about the framework.
 
 - [Getting Started](getting-started.html)
 - [0→hero Reference](guides/zero-to-hero.html) - Walk scaffold → run → chat → inspect → deploy dry-run with CI-backed commands
+- `micro agent demo` - Show the provider-free first-agent demo command and next docs steps
 - [No-secret first-agent transcript](guides/no-secret-first-agent.html) - Run the first useful agent path without a provider key
 - [Your First Agent](guides/your-first-agent.html) - Build a service-backed agent end to end
 - [MCP & AI Agents](mcp.html) - Turn services into AI-callable tools with the Model Context Protocol


### PR DESCRIPTION
Summary:
- Add `micro agent demo` to the README and website first-agent on-ramp.
- Link the command from the no-secret transcript and docs index.
- Extend first-agent docs tests to keep the command visible.

Testing:
- go test ./internal/harness/zero-to-hero-ci -run 'TestFirstAgentWayfindingDocs|TestNoSecretFirstAgentTranscript' -count=1\n- go build ./...\n- go test ./... (fails in this environment: loopback targets forbidden in grpc transport/client tests)\n- golangci-lint run ./...\n\nCloses #4041\nCloses #4043