### PR TITLE
Surface agent demo in scaffold next steps

### DIFF
--- a/cmd/micro/cli/new/contract_test.go
+++ b/cmd/micro/cli/new/contract_test.go
@@ -68,6 +68,7 @@ func TestPrintNextStepsSurfacesFirstAgentPath(t *testing.T) {
 		"go run .",
 		"micro chat",
 		"micro inspect agent",
+		"micro agent demo",
 		"micro docs",
 		"your-first-agent.html",
 		"zero-to-hero.html",
@@ -83,7 +84,7 @@ func TestPrintNextStepsNoMCPSkipsMCPHints(t *testing.T) {
 	var out bytes.Buffer
 	printNextSteps(&out, "worker", true)
 
-	for _, want := range []string{"micro agent preflight", "micro chat", "micro inspect agent", "micro docs"} {
+	for _, want := range []string{"micro agent preflight", "micro chat", "micro inspect agent", "micro agent demo", "micro docs"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("--no-mcp next steps missing %q:\n%s", want, out.String())
 		}

--- a/cmd/micro/cli/new/new.go
+++ b/cmd/micro/cli/new/new.go
@@ -294,6 +294,7 @@ func printNextSteps(w io.Writer, dir string, noMCP bool) {
 	fmt.Fprintln(w, "    micro inspect agent")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  First-agent path:")
+	fmt.Fprintln(w, "    micro agent demo")
 	fmt.Fprintln(w, "    micro docs")
 	fmt.Fprintln(w, "    https://go-micro.dev/docs/guides/your-first-agent.html")
 	fmt.Fprintln(w, "    https://go-micro.dev/docs/guides/zero-to-hero.html")


### PR DESCRIPTION
Summary:
- Add `micro agent demo` to the `micro new` first-agent next steps so freshly scaffolded projects point at the no-secret demo before longer docs.
- Extend the CLI scaffold next-step tests to cover the new demo hint for both MCP and --no-mcp paths.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...

Closes #4051