### PR TITLE
Lead Getting Started with no-secret first run

### DIFF
--- a/cmd/micro/README.md
+++ b/cmd/micro/README.md
@@ -52,6 +52,25 @@ This starts:
 
 Open http://localhost:8080 to see your services and call them from the browser.
 
+Call the generated service from another terminal:
+
+```
+curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call \
+  -H 'Content-Type: application/json' -d '{"name":"World"}'
+```
+
+## First agent on-ramp
+
+Once the scaffold → run → call path works, ask the installed CLI for the
+provider-free agent path:
+
+```
+micro agent demo
+```
+
+That points at the smallest mock-model first-agent example and the no-secret
+transcript before you add provider-backed chat.
+
 ### Output
 
 ```

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -157,6 +157,81 @@ func TestFirstAgentWayfindingDocs(t *testing.T) {
 	}
 }
 
+func TestGettingStartedDocsLeadWithNoSecretFirstRun(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	checks := []struct {
+		name    string
+		file    string
+		section string
+		want    []string
+	}{
+		{
+			name:    "README quick start",
+			file:    filepath.Join(root, "README.md"),
+			section: "## Quick Start",
+			want: []string{
+				"### Fastest start — no API key",
+				"micro new helloworld",
+				"micro run",
+				"curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call",
+				"### First agent on-ramp",
+				"micro agent demo",
+				"### Generate from a prompt — with an LLM key",
+			},
+		},
+		{
+			name:    "CLI README",
+			file:    filepath.Join(root, "cmd", "micro", "README.md"),
+			section: "## Create a service",
+			want: []string{
+				"## Create a service",
+				"micro new helloworld",
+				"## Run the service",
+				"micro run",
+				"micro agent demo",
+			},
+		},
+		{
+			name:    "website getting started",
+			file:    filepath.Join(root, "internal", "website", "docs", "getting-started.md"),
+			section: "## Quick Start: Scaffold, Run, Call",
+			want: []string{
+				"## Quick Start: Scaffold, Run, Call",
+				"micro new helloworld",
+				"micro run",
+				"curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call",
+				"### First-agent on-ramp",
+				"micro agent demo",
+				"## Generate from a Prompt — with an LLM key",
+			},
+		},
+	}
+
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			doc := readFile(t, check.file)
+			if check.section != "" {
+				start := strings.Index(doc, check.section)
+				if start == -1 {
+					t.Fatalf("%s missing %q section", check.name, check.section)
+				}
+				doc = doc[start:]
+			}
+			last := -1
+			for _, want := range check.want {
+				idx := strings.Index(doc, want)
+				if idx == -1 {
+					t.Fatalf("%s missing no-secret first-run marker %q", check.name, want)
+				}
+				if idx < last {
+					t.Fatalf("%s marker %q appeared out of order; keep install/scaffold/run/call before provider-backed generation", check.name, want)
+				}
+				last = idx
+			}
+		})
+	}
+}
+
 func TestNoSecretFirstAgentTranscript(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", "..", ".."))
 	guide := readFile(t, filepath.Join(root, "internal", "website", "docs", "guides", "no-secret-first-agent.md"))

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -17,15 +17,7 @@ Go Micro has three core abstractions:
 ## Prerequisites
 
 - **Go 1.24+** for development. The `curl` install below gives you the `micro` binary without Go, but `micro run` compiles your services, so you'll want Go installed to build them.
-- An **LLM provider key** (Anthropic, OpenAI, Gemini, …) *only* for the AI features — `micro run --prompt`, `micro chat`, and agents. Plain services need no key. Set it before running, e.g. `export ANTHROPIC_API_KEY=sk-ant-...`.
-
-Before your first provider-backed agent run, check the local path with:
-
-```bash
-micro agent preflight
-```
-
-The preflight is read-only: it verifies Go 1.24+, the `micro` binary, provider-key setup, and whether the default `micro run` gateway port is free, without calling an LLM provider. When a check fails it prints the exact fix plus the next guide to open, so the scaffold → run → chat path stays walkable.
+- **No LLM provider key is required** for the first run below. Add an Anthropic, OpenAI, Gemini, or other provider key only when you reach the provider-backed generation and chat steps.
 
 ## Install
 
@@ -37,54 +29,25 @@ curl -fsSL https://go-micro.dev/install.sh | sh
 go install go-micro.dev/v6/cmd/micro@latest
 ```
 
-## Quick Start: Generate from a Prompt
+## Quick Start: Scaffold, Run, Call
 
-Prefer to start from a runnable reference? Clone the repository and run the maintained support-desk lifecycle example first:
-
-```bash
-git clone https://github.com/micro/go-micro.git
-cd go-micro
-go run ./examples/support
-```
-
-That example is the no-secret 0→hero path: services expose ticket/customer/notification tools, an agent handles the work, and an event-driven flow triggers the agent. See [Learn by Example](examples/) when you want more runnable starting points.
-
-Describe what you need. The AI designs services, writes handlers, compiles, and starts them:
+Start with the path that proves the runtime works before any provider setup: install the CLI, scaffold one service, run it locally, then call it through the gateway.
 
 ```bash
-micro run --prompt "task management system"
+micro new helloworld
+cd helloworld
+micro run
 ```
 
-You'll see the design, confirm, and services + agent start:
+In another terminal, call the generated service:
 
-```text
-Services:
-  ● task — Core task management
-  ● project — Project organization
-
-Generate? [Y/n]
-
-Micro
-  Services:
-    ● task
-    ● project
-  Agents:
-    ◆ agent
+```bash
+curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call \
+  -H 'Content-Type: application/json' -d '{"name":"World"}'
 ```
 
-The interactive console lets you talk to your services immediately:
+That install → scaffold → run → call loop is the 0→1 contract. It requires Go and the `micro` binary, but no LLM key. Once this succeeds, you know the local runtime, hot reload, gateway, and service registration are working.
 
-```text
-> Create a project called Launch, then add a task called 'Write docs'
-
-→ project_Project_Create({"name":"Launch"})
-← {"record":{"id":"p1..."},"success":true}
-→ task_Task_Create({"title":"Write docs","project_id":"p1..."})
-
-Created project Launch and added task 'Write docs' to it.
-```
-
-The console discovers services from the registry and orchestrates across them via the agent. Use `micro run -d` for detached mode without the console, or `micro chat` as a standalone command.
 
 ### First-agent on-ramp
 
@@ -97,7 +60,7 @@ After this quick start, follow the agent path in order:
 5. [Debugging your agent](guides/debugging-agents.html) — inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
 6. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
 
-## Quick Start: Write a Service
+## Write a Service
 
 Create and run a service manually:
 
@@ -160,6 +123,43 @@ micro new contacts --template crud
 micro new events --template pubsub
 micro new gateway --template api
 ```
+
+
+## Generate from a Prompt — with an LLM key
+
+After the no-secret path works, set a provider key if you want Go Micro to design services and an agent from a prompt:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY, GEMINI_API_KEY, ...
+micro run --prompt "task management system" --provider anthropic
+```
+
+You'll see the design, confirm it, and then services plus an agent start:
+
+```text
+Services:
+  ● task — Core task management
+  ● project — Project organization
+
+Generate? [Y/n]
+
+Micro
+  Services:
+    ● task
+    ● project
+  Agents:
+    ◆ agent
+```
+
+Use the interactive console, `micro run -d` plus `micro chat`, or the agent playground to talk to the generated services.
+
+Before your first provider-backed agent run, check the local path with:
+
+```bash
+micro agent preflight
+```
+
+The preflight is read-only: it verifies Go 1.24+, the `micro` binary, provider-key setup, and whether the default `micro run` gateway port is free, without calling an LLM provider. When a check fails it prints the exact fix plus the next guide to open, so the scaffold → run → chat path stays walkable.
 
 ## Building Agents
 


### PR DESCRIPTION
## Summary
- Reorder website Getting Started so the first runnable path is install → scaffold → run → curl with no LLM key.
- Add CLI README wayfinding from the scaffold/run/call path to `micro agent demo`.
- Add zero-to-hero docs assertions so README, CLI docs, and website Getting Started keep the no-secret first-run order before provider-backed generation.

## Testing
- go build ./...
- go test ./internal/harness/zero-to-hero-ci -run 'TestGettingStartedDocsLeadWithNoSecretFirstRun|TestFirstAgentWayfindingDocs' -count=1
- go test ./... (fails in this environment: loopback targets forbidden for grpc client/transport tests, plus cache expiry flake)
- golangci-lint run ./...

Closes #4054
Closes #4056