### PR TITLE
Keep examples lifecycle map self-verifying

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,9 +12,11 @@ of reading the directories alphabetically.
 
 ## Recommended first-agent path
 
+This path is the canonical services → agents → workflows route through the examples map. Debugging and observability wayfinding stays nearby once the first run works.
+
 | Step | Start here | What you learn | Next step |
 |------|------------|----------------|-----------|
-| 1. First service | [`hello-world`](./hello-world/) | Create and register a basic RPC service, add a handler, call it with a client, and expose health checks. | Move to [`agent-demo`](./agent-demo/) to see services used by an agent. |
+| 1. First service | [`hello-world`](./hello-world/) | Build the 0→1 service path: create and register a basic RPC service, add a handler, call it with a client, and expose health checks. | Move to [`agent-demo`](./agent-demo/) to see services used by an agent. |
 | 2. First agent | [`first-agent`](./first-agent/) | Run the smallest service-backed agent with a deterministic mock model and no provider key. | Compare with [`agent-demo`](./agent-demo/) or the maintained 0-to-hero path in [`support`](./support/). |
 | 3. First workflow | [`support`](./support/) | Follow typed services into an agent chat loop, an event-driven `intake` flow, and an approval gate in one runnable reference. | Deepen the workflow model with [`flow-durable`](./flow-durable/). |
 

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -157,6 +157,73 @@ func TestFirstAgentWayfindingDocs(t *testing.T) {
 	}
 }
 
+func TestExamplesIndexesPreserveLifecycleMap(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	checks := []struct {
+		name    string
+		file    string
+		heading string
+		want    []string
+		ordered []string
+	}{
+		{
+			name:    "repository examples lifecycle map",
+			file:    filepath.Join(root, "examples", "README.md"),
+			heading: "## Recommended first-agent path",
+			want: []string{
+				"hello-world",
+				"0→1",
+				"first-agent",
+				"support",
+				"services",
+				"agents",
+				"workflows",
+				"Debugging and observability",
+			},
+			ordered: []string{"1. First service", "2. First agent", "3. First workflow"},
+		},
+		{
+			name:    "website examples lifecycle map",
+			file:    filepath.Join(root, "internal", "website", "docs", "examples", "index.md"),
+			heading: "## Start here",
+			want: []string{
+				"examples/hello-world",
+				"0→1",
+				"examples/first-agent",
+				"examples/support",
+				"services",
+				"agents",
+				"workflows",
+				"debugging-agents.html",
+			},
+			ordered: []string{"0→1 service", "Provider-free first agent", "0→hero lifecycle"},
+		},
+	}
+
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			section := firstMarkdownSection(t, readFile(t, check.file), check.heading)
+			for _, want := range check.want {
+				if !strings.Contains(section, want) {
+					t.Fatalf("%s missing lifecycle map marker %q", check.name, want)
+				}
+			}
+
+			last := -1
+			for _, marker := range check.ordered {
+				idx := strings.Index(section, marker)
+				if idx == -1 {
+					t.Fatalf("%s missing ordered example marker %q", check.name, marker)
+				}
+				if idx < last {
+					t.Fatalf("%s marker %q appeared out of order; keep examples flowing hello-world/0→1 → first-agent → support/0→hero", check.name, marker)
+				}
+				last = idx
+			}
+		})
+	}
+}
+
 func TestGettingStartedDocsLeadWithNoSecretFirstRun(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", "..", ".."))
 	checks := []struct {


### PR DESCRIPTION
## Summary
- Add a zero-to-hero CI docs assertion that repository and website examples indexes preserve the hello-world/0→1 → first-agent → support/0→hero lifecycle map.
- Clarify the repository examples recommended path with the services → agents → workflows route, 0→1 service marker, and debugging wayfinding.

Closes #4059
Closes #4061

## Testing
- go build ./...
- go test ./internal/harness/zero-to-hero-ci -run TestExamplesIndexesPreserveLifecycleMap -count=1
- go test ./... (fails in this environment because loopback gRPC targets are forbidden by envoy)
- golangci-lint run ./...