### PR TITLE
Make config close idempotent

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -14,8 +14,10 @@ import (
 
 type config struct {
 	// the current values
-	vals reader.Values
-	exit chan bool
+	vals    reader.Values
+	exit    chan bool
+	closeMu sync.Mutex
+	closed  bool
 	// the current snapshot
 	snap *loader.Snapshot
 	opts Options
@@ -48,6 +50,9 @@ func (c *config) Init(opts ...Option) error {
 		Reader: json.NewReader(),
 	}
 	c.exit = make(chan bool)
+	c.closeMu.Lock()
+	c.closed = false
+	c.closeMu.Unlock()
 	for _, o := range opts {
 		o(&c.opts)
 	}
@@ -184,12 +189,15 @@ func (c *config) Sync() error {
 }
 
 func (c *config) Close() error {
-	select {
-	case <-c.exit:
+	c.closeMu.Lock()
+	defer c.closeMu.Unlock()
+
+	if c.closed {
 		return nil
-	default:
-		close(c.exit)
 	}
+
+	close(c.exit)
+	c.closed = true
 	return nil
 }
 

--- a/config/default_test.go
+++ b/config/default_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,6 +44,30 @@ func createFileForTest(t *testing.T) *os.File {
 	}
 
 	return fh
+}
+
+func TestConfigCloseConcurrentIdempotent(t *testing.T) {
+	conf, err := NewConfig(WithWatcherDisabled())
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if err := conf.Close(); err != nil {
+				t.Errorf("Expected close to be idempotent but got %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if err := conf.Close(); err != nil {
+		t.Fatalf("Expected repeated close to be idempotent but got %v", err)
+	}
 }
 
 func TestConfigLoadWithGoodFile(t *testing.T) {

--- a/config/loader/memory/memory.go
+++ b/config/loader/memory/memory.go
@@ -18,8 +18,10 @@ import (
 
 type memory struct {
 	// the current values
-	vals reader.Values
-	exit chan bool
+	vals    reader.Values
+	exit    chan bool
+	closeMu sync.Mutex
+	closed  bool
 	// the current snapshot
 	snap *loader.Snapshot
 
@@ -270,12 +272,15 @@ func (m *memory) Sync() error {
 }
 
 func (m *memory) Close() error {
-	select {
-	case <-m.exit:
+	m.closeMu.Lock()
+	defer m.closeMu.Unlock()
+
+	if m.closed {
 		return nil
-	default:
-		close(m.exit)
 	}
+
+	close(m.exit)
+	m.closed = true
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Make config Close safe for repeated and concurrent shutdown paths.
- Apply the same guarded shutdown to the memory config loader.
- Add a concurrent Close regression test.

## Testing
- go build ./...
- go test -race ./config ./config/source/file
- go test ./... (fails in this environment because loopback gRPC targets are forbidden by envoy)
- golangci-lint run ./...

Closes #4067
Closes #4074