### PR TITLE
Align website quickstart first-agent on-ramp

### DIFF
--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -365,6 +365,21 @@ func TestGettingStartedDocsLeadWithNoSecretFirstRun(t *testing.T) {
 				"## Generate from a Prompt — with an LLM key",
 			},
 		},
+		{
+			name:    "website quickstart",
+			file:    filepath.Join(root, "internal", "website", "docs", "quickstart.md"),
+			section: "## Create Your First Service",
+			want: []string{
+				"micro new helloworld",
+				"micro run",
+				"curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call",
+				"## Next Steps",
+				"micro agent demo",
+				"guides/no-secret-first-agent.html",
+				"guides/debugging-agents.html",
+				"guides/zero-to-hero.html",
+			},
+		},
 	}
 
 	for _, check := range checks {

--- a/internal/website/docs/quickstart.md
+++ b/internal/website/docs/quickstart.md
@@ -39,10 +39,12 @@ curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call \
 
 You now have the service half of the services → agents → workflows lifecycle running locally. Keep the on-ramp going in this order:
 
-1. **[Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent)** - run a mock-model, no-secret agent before adding provider keys.
-2. **[Your First Agent](guides/your-first-agent.html)** - turn this service into an agent-callable tool, chat with it, and learn the `micro agent preflight` → `micro run` → `micro chat` loop.
-3. **[Debugging your agent](guides/debugging-agents.html)** - inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent does something surprising.
-4. **[0→hero Reference](guides/zero-to-hero.html)** - walk the maintained scaffold → run → chat → inspect → deploy dry-run path that proves services, agents, and workflows together.
+1. `micro agent demo` - print the provider-free first-agent demo command and the next docs steps from the installed CLI.
+2. **[Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent)** - run a mock-model, no-secret agent before adding provider keys.
+3. **[No-secret first-agent transcript](guides/no-secret-first-agent.html)** - run a useful support agent with a mock model before setting up a provider key.
+4. **[Your First Agent](guides/your-first-agent.html)** - turn this service into an agent-callable tool, chat with it, and learn the `micro agent preflight` → `micro run` → `micro chat` loop.
+5. **[Debugging your agent](guides/debugging-agents.html)** - inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent does something surprising.
+6. **[0→hero Reference](guides/zero-to-hero.html)** - walk the maintained scaffold → run → chat → inspect → deploy dry-run path that proves services, agents, and workflows together.
 
 After that first-agent path, branch out to:
 
@@ -113,4 +115,3 @@ publisher.Publish(ctx, &UserCreatedEvent{
 - **[Discord Community](https://discord.gg/G8Gk5j3uXr)** - Chat with other users
 - **[GitHub Issues](https://github.com/micro/go-micro/issues)** - Report bugs or request features
 - **[Documentation](https://go-micro.dev/docs/)** - Complete docs
-


### PR DESCRIPTION
Summary:
- Add `micro agent demo` and the no-secret transcript to the website Quick Start next-step path.
- Extend the zero-to-hero docs harness so the website Quick Start keeps the first-agent on-ramp anchors in order.

Testing:
- go test ./internal/harness/zero-to-hero-ci -run TestGettingStartedDocsLeadWithNoSecretFirstRun -count=1
- go build ./...
- go test ./... (environment warning: loopback gRPC tests fail with envoy `Loopback targets forbidden`)
- golangci-lint run ./...

Closes #4071
Closes #4079