### PR TITLE
Add install troubleshooting to first-agent on-ramp

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ curl -fsSL https://go-micro.dev/install.sh | sh
 go install go-micro.dev/v6/cmd/micro@latest
 ```
 
+If install or `PATH` checks fail, use the [install troubleshooting guide](internal/website/docs/guides/install-troubleshooting.md) before scaffolding your first service.
+
 ### Fastest start — no API key
 
 Scaffold a service, run it, call it:
@@ -87,16 +89,17 @@ make harness
 After install and the first `micro new`/`micro run` smoke check, take the
 walkable agent path in this order:
 
-1. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
-2. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
-3. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
+1. [Install troubleshooting](internal/website/docs/guides/install-troubleshooting.md) — verify the binary installer or `go install`, `PATH`, `micro --version`, and the no-secret smoke path before agent work.
+2. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
+3. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
+4. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
    maintained support agent with a mock model and see services → agents → workflows succeed without a key.
-4. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
+5. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
    service-backed agent and talk to it with `micro chat`.
-5. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
+6. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
    `micro agent inspect`, run history, memory, and provider checks when the first
    conversation does something unexpected.
-6. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
+7. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
    services → agents → workflows loop with scaffold, run, chat, inspect, flow
    history, and deploy dry-run commands that match the maintained harness.
 

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -89,6 +89,7 @@ func TestFirstAgentWayfindingDocs(t *testing.T) {
 			file:    filepath.Join(root, "README.md"),
 			heading: "### First agent on-ramp",
 			links: []string{
+				"internal/website/docs/guides/install-troubleshooting.md",
 				"micro agent demo",
 				"internal/website/docs/guides/no-secret-first-agent.md",
 				"internal/website/docs/guides/your-first-agent.md",
@@ -131,6 +132,7 @@ func TestFirstAgentWayfindingDocs(t *testing.T) {
 			file:    filepath.Join(root, "internal", "website", "docs", "getting-started.md"),
 			heading: "### First-agent on-ramp",
 			links: []string{
+				"guides/install-troubleshooting.html",
 				"micro agent demo",
 				"guides/no-secret-first-agent.html",
 				"guides/your-first-agent.html",
@@ -330,6 +332,7 @@ func TestGettingStartedDocsLeadWithNoSecretFirstRun(t *testing.T) {
 			file:    filepath.Join(root, "README.md"),
 			section: "## Quick Start",
 			want: []string{
+				"install troubleshooting guide",
 				"### Fastest start — no API key",
 				"micro new helloworld",
 				"micro run",
@@ -354,8 +357,9 @@ func TestGettingStartedDocsLeadWithNoSecretFirstRun(t *testing.T) {
 		{
 			name:    "website getting started",
 			file:    filepath.Join(root, "internal", "website", "docs", "getting-started.md"),
-			section: "## Quick Start: Scaffold, Run, Call",
+			section: "Install troubleshooting",
 			want: []string{
+				"Install troubleshooting",
 				"## Quick Start: Scaffold, Run, Call",
 				"micro new helloworld",
 				"micro run",

--- a/internal/website/_data/navigation.yml
+++ b/internal/website/_data/navigation.yml
@@ -3,6 +3,8 @@ core:
     url: /docs/
   - title: Getting Started
     url: /docs/getting-started.html
+  - title: Install Troubleshooting
+    url: /docs/guides/install-troubleshooting.html
   - title: AI Integration
     url: /docs/ai-integration.html
   - title: No-secret First Agent
@@ -80,6 +82,7 @@ project:
   - title: Server (optional)
     url: /docs/server.html
 search_order:
+  - /docs/guides/install-troubleshooting.html
   - /docs/guides/your-first-agent.html
   - /docs/guides/zero-to-hero.html
   - /docs/guides/debugging-agents.html

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -29,6 +29,8 @@ curl -fsSL https://go-micro.dev/install.sh | sh
 go install go-micro.dev/v6/cmd/micro@latest
 ```
 
+If install or shell setup fails, start with [Install troubleshooting](guides/install-troubleshooting.html) to verify the binary installer or `go install`, `PATH`, `micro --version`, and the no-secret smoke path.
+
 ## Quick Start: Scaffold, Run, Call
 
 Start with the path that proves the runtime works before any provider setup: install the CLI, scaffold one service, run it locally, then call it through the gateway.
@@ -53,12 +55,13 @@ That install → scaffold → run → call loop is the 0→1 contract. It requir
 
 After this quick start, follow the agent path in order:
 
-1. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
-2. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent) — run one service-backed agent with a mock model and no provider key.
-3. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — run a useful support agent with a mock model before setting up a provider key.
-4. [Your First Agent](guides/your-first-agent.html) — build a service-backed agent and talk to it with `micro chat`.
-5. [Debugging your agent](guides/debugging-agents.html) — inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
-6. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
+1. [Install troubleshooting](guides/install-troubleshooting.html) — verify the CLI install before agent work.
+2. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
+3. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent) — run one service-backed agent with a mock model and no provider key.
+4. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — run a useful support agent with a mock model before setting up a provider key.
+5. [Your First Agent](guides/your-first-agent.html) — build a service-backed agent and talk to it with `micro chat`.
+6. [Debugging your agent](guides/debugging-agents.html) — inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
+7. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
 
 ## Write a Service
 

--- a/internal/website/docs/guides/install-troubleshooting.md
+++ b/internal/website/docs/guides/install-troubleshooting.md
@@ -1,0 +1,96 @@
+---
+layout: default
+title: Install troubleshooting
+---
+
+# Install troubleshooting
+
+Use this page before `micro new` or `micro agent demo` when the CLI install is
+unclear. The goal is to prove three boundaries in order: the `micro` binary is on
+`PATH`, it is the version you expected, and the no-secret first-run path works
+without provider keys.
+
+## 1. Choose one install path
+
+### Binary installer (no Go required to install)
+
+```sh
+curl -fsSL https://go-micro.dev/install.sh | sh
+```
+
+Use this when you want the released `micro` binary without building it yourself.
+The generated services still need a Go toolchain when you run `micro run`, but the
+installer itself does not require Go.
+
+### Go install (build from source)
+
+```sh
+go install go-micro.dev/v6/cmd/micro@latest
+```
+
+Use this when Go is already installed and you want the binary in your Go bin
+directory. If the command succeeds but `micro` is not found, your Go bin directory
+is probably not on `PATH`.
+
+## 2. Verify `PATH` and version
+
+Check which binary your shell will run:
+
+```sh
+command -v micro
+micro --version
+```
+
+If `command -v micro` prints nothing, add the install directory to `PATH`, then
+open a new terminal and retry. Common locations are:
+
+```sh
+export PATH="$HOME/.micro/bin:$PATH"      # binary installer
+export PATH="$(go env GOPATH)/bin:$PATH"  # go install
+```
+
+If `micro --version` shows an older binary than expected, remove the stale copy or
+put the intended install directory earlier in `PATH`.
+
+## 3. Run the no-secret smoke path
+
+Once `micro` resolves, prove the local service runtime before adding LLM provider
+keys:
+
+```sh
+micro new helloworld
+cd helloworld
+micro run
+```
+
+In another terminal:
+
+```sh
+curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call \
+  -H 'Content-Type: application/json' -d '{"name":"World"}'
+```
+
+This checks the scaffold, local build, gateway, and service registration without
+calling a model provider.
+
+## 4. Recover common failures
+
+| Symptom | Check | Fix |
+|---------|-------|-----|
+| `micro: command not found` | `command -v micro` | Add the installer bin directory or `$(go env GOPATH)/bin` to `PATH`, then open a new terminal. |
+| `micro run` cannot find Go | `go version` | Install Go 1.24 or newer from <https://go.dev/doc/install>. |
+| The gateway port is busy | `lsof -i :8080` | Stop the process using the port, or run with a different address. |
+| Provider-key errors block an agent run | `micro agent preflight` | Stay on the no-secret path first: run `micro agent demo`, then the no-secret first-agent guide. |
+
+## 5. Continue the first-agent on-ramp
+
+After install verification succeeds, continue in order:
+
+1. `micro agent demo` — print the provider-free first-agent demo command and next docs steps.
+2. [No-secret first-agent transcript](no-secret-first-agent.html) — prove an agent can use services without a provider key.
+3. [Your First Agent](your-first-agent.html) — build and chat with your own service-backed agent.
+4. [Debugging your agent](debugging-agents.html) — inspect registration, tool calls, run history, and provider failures.
+5. [0→hero Reference](zero-to-hero.html) — walk the full services → agents → workflows lifecycle.
+
+For repository contributors, `make install-smoke` runs the same installer seam
+against a local build without network access.

--- a/internal/website/docs/quickstart.md
+++ b/internal/website/docs/quickstart.md
@@ -16,6 +16,8 @@ Or, if you have Go and prefer to build from source:
 go install go-micro.dev/v6/cmd/micro@latest
 ```
 
+If the installer finishes but your shell cannot find `micro`, open [Install troubleshooting](guides/install-troubleshooting.html) before creating your first service.
+
 ## Create Your First Service
 
 ```bash
@@ -39,12 +41,13 @@ curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call \
 
 You now have the service half of the services → agents → workflows lifecycle running locally. Keep the on-ramp going in this order:
 
-1. `micro agent demo` - print the provider-free first-agent demo command and the next docs steps from the installed CLI.
-2. **[Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent)** - run a mock-model, no-secret agent before adding provider keys.
-3. **[No-secret first-agent transcript](guides/no-secret-first-agent.html)** - run a useful support agent with a mock model before setting up a provider key.
-4. **[Your First Agent](guides/your-first-agent.html)** - turn this service into an agent-callable tool, chat with it, and learn the `micro agent preflight` → `micro run` → `micro chat` loop.
-5. **[Debugging your agent](guides/debugging-agents.html)** - inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent does something surprising.
-6. **[0→hero Reference](guides/zero-to-hero.html)** - walk the maintained scaffold → run → chat → inspect → deploy dry-run path that proves services, agents, and workflows together.
+1. **[Install troubleshooting](guides/install-troubleshooting.html)** - verify the binary installer or `go install`, `PATH`, `micro --version`, and the no-secret smoke path.
+2. `micro agent demo` - print the provider-free first-agent demo command and the next docs steps from the installed CLI.
+3. **[Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent)** - run a mock-model, no-secret agent before adding provider keys.
+4. **[No-secret first-agent transcript](guides/no-secret-first-agent.html)** - run a useful support agent with a mock model before setting up a provider key.
+5. **[Your First Agent](guides/your-first-agent.html)** - turn this service into an agent-callable tool, chat with it, and learn the `micro agent preflight` → `micro run` → `micro chat` loop.
+6. **[Debugging your agent](guides/debugging-agents.html)** - inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent does something surprising.
+7. **[0→hero Reference](guides/zero-to-hero.html)** - walk the maintained scaffold → run → chat → inspect → deploy dry-run path that proves services, agents, and workflows together.
 
 After that first-agent path, branch out to:
 


### PR DESCRIPTION
## Summary
- Adds a focused install troubleshooting guide for binary installer vs go install, PATH/version checks, the no-secret smoke path, and common recovery steps.
- Links the guide from README, website getting-started, website quickstart, and website navigation.
- Extends the docs harness to keep the install-recovery link in the first-agent journey.

Closes #4077
Closes #4083

## Testing
- go build ./...
- go test ./internal/harness/zero-to-hero-ci -run 'TestFirstAgentWayfinding|TestGettingStartedDocsLeadWithNoSecretFirstRun' -count=1
- go test ./... (environment warning: loopback grpc tests are blocked by sandbox envoy: "Loopback targets forbidden")
- golangci-lint run ./...