### PR TITLE
Promote first-agent doctor recovery

### DIFF
--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -33,9 +33,10 @@ After it passes:
   - Walk the full 0→hero lifecycle:    https://go-micro.dev/docs/guides/zero-to-hero.html
 
 Use live-provider chat when you are ready for real model behavior:
-  micro agent preflight
+  micro agent preflight  # before micro run: prerequisites
   micro run
   micro chat
+  micro agent doctor     # after micro run: chat/gateway/inspect recovery
   micro inspect agent <name>`
 
 func init() {
@@ -80,7 +81,7 @@ for live-provider chat and inspect/debugging.`,
 			},
 			{
 				Name:  "doctor",
-				Usage: "Diagnose chat and inspect recovery after micro run",
+				Usage: "Diagnose chat, gateway, registration, provider, and inspect recovery after micro run",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "gateway", Value: "http://localhost:8080", Usage: "Gateway URL started by micro run"},
 				},

--- a/cmd/micro/cli/cli.go
+++ b/cmd/micro/cli/cli.go
@@ -40,10 +40,10 @@ const docsWayfinding = `First-agent and 0→hero docs:
   3. Your First Agent
      https://go-micro.dev/docs/guides/your-first-agent.html
      Build a service-backed agent, then use:
-       micro agent preflight
+       micro agent preflight  # before micro run: prerequisites
        micro run
        micro chat
-       micro agent doctor
+       micro agent doctor     # after micro run: chat/gateway/inspect recovery
 
   4. Debugging your agent
      https://go-micro.dev/docs/guides/debugging-agents.html

--- a/cmd/micro/first_agent_walkthrough_test.go
+++ b/cmd/micro/first_agent_walkthrough_test.go
@@ -64,10 +64,10 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 		"your-first-agent.html",
 		"debugging-agents.html",
 		"zero-to-hero.html",
-		"micro agent preflight",
+		"micro agent preflight  # before micro run: prerequisites",
 		"micro run",
 		"micro chat",
-		"micro agent doctor",
+		"micro agent doctor     # after micro run: chat/gateway/inspect recovery",
 		"micro inspect agent",
 	} {
 		if !strings.Contains(out.String(), want) {
@@ -79,6 +79,13 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 	if !strings.Contains(agent.Usage, "micro agent demo") {
 		t.Fatalf("micro agent help should advertise the no-secret demo; usage was %q", agent.Usage)
 	}
+	doctor := subcommandByName(t, agent, "doctor")
+	for _, want := range []string{"chat", "gateway", "registration", "provider", "inspect", "after micro run"} {
+		if !strings.Contains(doctor.Usage, want) {
+			t.Fatalf("micro agent doctor usage should advertise after-run recovery for %q; usage was %q", want, doctor.Usage)
+		}
+	}
+
 	demo := subcommandByName(t, agent, "demo")
 	out.Reset()
 	if err := demo.Action(cli.NewContext(app, nil, nil)); err != nil {
@@ -88,8 +95,9 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 		"No-secret first-agent demo",
 		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1",
 		"provider-free",
-		"micro agent preflight",
+		"micro agent preflight  # before micro run: prerequisites",
 		"micro chat",
+		"micro agent doctor     # after micro run: chat/gateway/inspect recovery",
 		"micro inspect agent <name>",
 		"your-first-agent.html",
 		"debugging-agents.html",

--- a/internal/website/docs/guides/debugging-agents.md
+++ b/internal/website/docs/guides/debugging-agents.md
@@ -17,9 +17,21 @@ micro inspect ...  # read the recorded run or workflow history
 
 Debug the lifecycle in the same order Go Micro runs it: first prove the service is
 registered and callable, then inspect the agent run that chose tools, then inspect
-any workflow that handed off to the agent. If the first local run fails before a
-chat turn, run `micro agent preflight`; failed checks include `Fix:` and `Next:`
-lines for Go, CLI installation, provider-key setup, and the local gateway port.
+any workflow that handed off to the agent.
+
+Use the recovery command that matches where you are in the first-agent journey:
+
+| Checkpoint | When to use it | Command |
+| --- | --- | --- |
+| Install troubleshooting | `micro` is not installed, not on `PATH`, or the shell cannot run it. | [Install troubleshooting](install-troubleshooting.html) |
+| Preflight before `micro run` | You have not started the local runtime yet and want to verify Go, CLI, provider-key, and gateway-port prerequisites. | `micro agent preflight` |
+| Doctor after `micro run` | `micro run` is active, but chat, the `/agent` gateway, agent registration, provider settings, or inspect/run history is not behaving. | `micro agent doctor` |
+
+`micro agent preflight` is read-only and runs before the first local run; failed
+checks include `Fix:` and `Next:` lines for Go, CLI installation, provider-key
+setup, and the local gateway port. Once `micro run` is already up, switch to
+`micro agent doctor` so the recovery output follows the live gateway, chat
+settings, registered agents, provider configuration, and inspectable run history.
 
 ## 1. Reproduce one small turn
 

--- a/internal/website/docs/guides/your-first-agent.md
+++ b/internal/website/docs/guides/your-first-agent.md
@@ -53,7 +53,11 @@ Run the read-only first-agent preflight before starting the walkthrough. The sam
 micro agent preflight
 ```
 
-It checks Go 1.24+, the `micro` binary, provider-key setup, and the default local gateway port without contacting a provider. Failed checks include a `Fix:` line and a `Next:` line that points back to this guide, the no-secret walkthrough, or the debugging guide.
+It checks Go 1.24+, the `micro` binary, provider-key setup, and the default local gateway port without contacting a provider. Failed checks include a `Fix:` line and a `Next:` line that points back to this guide, the no-secret walkthrough, or the debugging guide. Use it before `micro run`; if `micro run` is already active but `micro chat`, the `/agent` gateway, registration, provider settings, or inspect history is failing, run the after-run recovery check instead:
+
+```sh
+micro agent doctor
+```
 
 ## 1. Create a workspace
 


### PR DESCRIPTION
## Summary
- Clarify first-agent CLI wayfinding so preflight is the before-run checkpoint and doctor is the after-run recovery checkpoint.
- Add docs guidance linking install troubleshooting, preflight, and doctor in the first-agent debug loop.
- Extend the CLI boundary test to guard the doctor recovery copy.

Closes #4086
Closes #4089

## Testing
- go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1
- go build ./...
- go test ./... (fails in this environment because loopback grpc targets are blocked by envoy)
- golangci-lint run ./...