### PR TITLE
Add zero-to-hero CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,16 @@ walkable agent path in this order:
 
 1. [Install troubleshooting](internal/website/docs/guides/install-troubleshooting.md) — verify the binary installer or `go install`, `PATH`, `micro --version`, and the no-secret smoke path before agent work.
 2. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
-3. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
-4. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
+3. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
+4. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
+5. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
    maintained support agent with a mock model and see services → agents → workflows succeed without a key.
-5. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
+6. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
    service-backed agent and talk to it with `micro chat`.
-6. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
+7. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
    `micro agent inspect`, run history, memory, and provider checks when the first
    conversation does something unexpected.
-7. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
+8. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
    services → agents → workflows loop with scaffold, run, chat, inspect, flow
    history, and deploy dry-run commands that match the maintained harness.
 

--- a/cmd/micro/cli/cli.go
+++ b/cmd/micro/cli/cli.go
@@ -24,6 +24,28 @@ import (
 	_ "go-micro.dev/v6/cmd/micro/cli/remote"
 )
 
+const zeroToHeroHelp = `0→hero no-secret lifecycle demo
+
+Run this from a go-micro repository checkout when you want one command that
+proves the maintained services → agents → workflows path without provider keys:
+
+  ./internal/harness/zero-to-hero-ci/run.sh
+
+That script runs the same deterministic path CI uses:
+  - CLI discovery for scaffold, run, chat, inspect, flow runs, and deploy dry-run
+  - the smallest first-agent example
+  - the support-desk reference app with services, an agent, a flow, and an approval gate
+  - plan/delegate and universe harnesses with only the model mocked
+
+If you only want the runnable examples first:
+  go run ./examples/first-agent
+  go run ./examples/support
+
+Full local contract:
+  make harness
+
+Guide: https://go-micro.dev/docs/guides/zero-to-hero.html`
+
 const docsWayfinding = `First-agent and 0→hero docs:
 
   1. Start with the no-secret CLI demo
@@ -125,6 +147,17 @@ func init() {
 				for _, service := range services {
 					fmt.Println(service.Name)
 				}
+				return nil
+			},
+		},
+		{
+			Name:  "zero-to-hero",
+			Usage: "Show the no-secret 0→hero lifecycle demo command",
+			Description: `Print the maintained provider-free services → agents → workflows
+lifecycle command and the smaller runnable examples it covers.`,
+			Aliases: []string{"hero"},
+			Action: func(ctx *cli.Context) error {
+				fmt.Fprintln(ctx.App.Writer, zeroToHeroHelp)
 				return nil
 			},
 		},

--- a/cmd/micro/zero_to_hero_cli_test.go
+++ b/cmd/micro/zero_to_hero_cli_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	microcmd "go-micro.dev/v6/cmd"
@@ -19,7 +21,7 @@ func TestZeroToHeroCLIBoundaries(t *testing.T) {
 		}
 	}
 
-	for _, want := range []string{"run", "chat", "flow", "inspect", "deploy"} {
+	for _, want := range []string{"run", "chat", "flow", "inspect", "deploy", "zero-to-hero"} {
 		if !commands[want] {
 			t.Fatalf("missing %q command", want)
 		}
@@ -46,5 +48,31 @@ func TestZeroToHeroCLIBoundaries(t *testing.T) {
 	}
 	if !hasDeployDryRun {
 		t.Fatal("missing deploy boundary: deploy --dry-run")
+	}
+}
+
+func TestZeroToHeroCommandPrintsMaintainedNoSecretPath(t *testing.T) {
+	app := microcmd.DefaultCmd.App()
+	var out bytes.Buffer
+	oldWriter := app.Writer
+	app.Writer = &out
+	t.Cleanup(func() { app.Writer = oldWriter })
+
+	if err := app.Run([]string{"micro", "zero-to-hero"}); err != nil {
+		t.Fatalf("micro zero-to-hero failed: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"0→hero no-secret lifecycle demo",
+		"./internal/harness/zero-to-hero-ci/run.sh",
+		"go run ./examples/first-agent",
+		"go run ./examples/support",
+		"make harness",
+		"services → agents → workflows",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("micro zero-to-hero output missing %q:\n%s", want, got)
+		}
 	}
 }

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -21,6 +21,7 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 		"go test ./examples/first-agent -run TestRunFirstAgent -count=1",
 		"go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1",
 		"./internal/harness/zero-to-hero-ci/run.sh",
+		"micro zero-to-hero",
 		"go run ./internal/harness/agent-flow",
 		"make provider-conformance-mock",
 		"internal/harness/plan-delegate",
@@ -126,6 +127,7 @@ func TestFirstAgentWayfindingDocs(t *testing.T) {
 			links: []string{
 				"internal/website/docs/guides/install-troubleshooting.md",
 				"micro agent demo",
+				"micro zero-to-hero",
 				"internal/website/docs/guides/no-secret-first-agent.md",
 				"internal/website/docs/guides/your-first-agent.md",
 				"internal/website/docs/guides/debugging-agents.md",
@@ -169,6 +171,7 @@ func TestFirstAgentWayfindingDocs(t *testing.T) {
 			links: []string{
 				"guides/install-troubleshooting.html",
 				"micro agent demo",
+				"micro zero-to-hero",
 				"guides/no-secret-first-agent.html",
 				"guides/your-first-agent.html",
 				"guides/debugging-agents.html",
@@ -414,6 +417,7 @@ func TestGettingStartedDocsLeadWithNoSecretFirstRun(t *testing.T) {
 				"curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call",
 				"## Next Steps",
 				"micro agent demo",
+				"micro zero-to-hero",
 				"guides/no-secret-first-agent.html",
 				"guides/debugging-agents.html",
 				"guides/zero-to-hero.html",

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -57,11 +57,12 @@ After this quick start, follow the agent path in order:
 
 1. [Install troubleshooting](guides/install-troubleshooting.html) — verify the CLI install before agent work.
 2. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
-3. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent) — run one service-backed agent with a mock model and no provider key.
-4. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — run a useful support agent with a mock model before setting up a provider key.
-5. [Your First Agent](guides/your-first-agent.html) — build a service-backed agent and talk to it with `micro chat`.
-6. [Debugging your agent](guides/debugging-agents.html) — inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
-7. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
+3. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
+4. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent) — run one service-backed agent with a mock model and no provider key.
+5. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — run a useful support agent with a mock model before setting up a provider key.
+6. [Your First Agent](guides/your-first-agent.html) — build a service-backed agent and talk to it with `micro chat`.
+7. [Debugging your agent](guides/debugging-agents.html) — inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
+8. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
 
 ## Write a Service
 

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -28,6 +28,16 @@ cloud credentials?"
 | Runtime reference app | `examples/support` runs typed services, an agent using those services as tools, an event-driven flow handoff, and an approval gate with only the model mocked. | `go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1` |
 | Runtime harnesses | Real services, agents, durable flows, store-backed history, delegation, and A2A run with only the model mocked. | `./internal/harness/zero-to-hero-ci/run.sh` and `make provider-conformance-mock` |
 
+## Find the one-command entrypoint
+
+After installing the CLI, ask `micro` for the maintained no-secret lifecycle command:
+
+```sh
+micro zero-to-hero
+```
+
+The command prints the exact harness command below plus the smaller runnable examples, so a new developer can discover the 0→hero path from CLI help instead of translating this guide by hand.
+
 ## Run the runnable example
 
 From the repository root, start with the smallest service-backed agent when you want the fastest no-secret success path:

--- a/internal/website/docs/quickstart.md
+++ b/internal/website/docs/quickstart.md
@@ -43,11 +43,12 @@ You now have the service half of the services → agents → workflows lifecycle
 
 1. **[Install troubleshooting](guides/install-troubleshooting.html)** - verify the binary installer or `go install`, `PATH`, `micro --version`, and the no-secret smoke path.
 2. `micro agent demo` - print the provider-free first-agent demo command and the next docs steps from the installed CLI.
-3. **[Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent)** - run a mock-model, no-secret agent before adding provider keys.
-4. **[No-secret first-agent transcript](guides/no-secret-first-agent.html)** - run a useful support agent with a mock model before setting up a provider key.
-5. **[Your First Agent](guides/your-first-agent.html)** - turn this service into an agent-callable tool, chat with it, and learn the `micro agent preflight` → `micro run` → `micro chat` loop.
-6. **[Debugging your agent](guides/debugging-agents.html)** - inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent does something surprising.
-7. **[0→hero Reference](guides/zero-to-hero.html)** - walk the maintained scaffold → run → chat → inspect → deploy dry-run path that proves services, agents, and workflows together.
+3. `micro zero-to-hero` - print the maintained one-command no-secret lifecycle harness and runnable examples.
+4. **[Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent)** - run a mock-model, no-secret agent before adding provider keys.
+5. **[No-secret first-agent transcript](guides/no-secret-first-agent.html)** - run a useful support agent with a mock model before setting up a provider key.
+6. **[Your First Agent](guides/your-first-agent.html)** - turn this service into an agent-callable tool, chat with it, and learn the `micro agent preflight` → `micro run` → `micro chat` loop.
+7. **[Debugging your agent](guides/debugging-agents.html)** - inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent does something surprising.
+8. **[0→hero Reference](guides/zero-to-hero.html)** - walk the maintained scaffold → run → chat → inspect → deploy dry-run path that proves services, agents, and workflows together.
 
 After that first-agent path, branch out to:
 


### PR DESCRIPTION
Summary:
- Adds `micro zero-to-hero` / `micro hero` as a discoverable no-secret lifecycle entrypoint that prints the maintained harness command and runnable examples.
- Links the command from README, getting-started, quickstart, and the 0→hero guide.
- Adds CLI/docs tests to keep the entrypoint and wayfinding visible.

Testing:
- `go build ./...`
- `go test ./cmd/micro -run 'TestZeroToHero|TestFirstAgentWalkthroughCLIBoundaries' -count=1`\n- `go test ./internal/harness/zero-to-hero-ci -run 'TestGettingStartedDocsLeadWithNoSecretFirstRun|TestZeroToHeroReferenceDocs|TestFirstAgentWayfindingDocs' -count=1`\n- `go test ./...` (environment warning: local loopback gRPC tests are blocked by sandbox envoy with "Loopback targets forbidden")\n- `golangci-lint run ./...`\n\nCloses #4097\nCloses #4101