### PR TITLE
Align first-agent inspect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ walkable agent path in this order:
 6. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
    service-backed agent and talk to it with `micro chat`.
 7. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
-   `micro agent inspect`, run history, memory, and provider checks when the first
+   `micro inspect agent <name>`, run history, memory, and provider checks when the first
    conversation does something unexpected.
 8. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
    services → agents → workflows loop with scaffold, run, chat, inspect, flow

--- a/cmd/micro/cli/cli.go
+++ b/cmd/micro/cli/cli.go
@@ -71,8 +71,8 @@ const docsWayfinding = `First-agent and 0→hero docs:
      https://go-micro.dev/docs/guides/debugging-agents.html
      Inspect agent runs and memory with:
        micro agent doctor
-       micro inspect agent
-       micro runs <agent>
+       micro inspect agent <name>
+       micro agent history <name>
 
   5. 0→hero Reference
      https://go-micro.dev/docs/guides/zero-to-hero.html

--- a/cmd/micro/cli/new/contract_test.go
+++ b/cmd/micro/cli/new/contract_test.go
@@ -67,7 +67,7 @@ func TestPrintNextStepsSurfacesFirstAgentPath(t *testing.T) {
 		"micro agent preflight",
 		"go run .",
 		"micro chat",
-		"micro inspect agent",
+		"micro inspect agent <name>",
 		"micro agent demo",
 		"micro docs",
 		"your-first-agent.html",
@@ -84,7 +84,7 @@ func TestPrintNextStepsNoMCPSkipsMCPHints(t *testing.T) {
 	var out bytes.Buffer
 	printNextSteps(&out, "worker", true)
 
-	for _, want := range []string{"micro agent preflight", "micro chat", "micro inspect agent", "micro agent demo", "micro docs"} {
+	for _, want := range []string{"micro agent preflight", "micro chat", "micro inspect agent <name>", "micro agent demo", "micro docs"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("--no-mcp next steps missing %q:\n%s", want, out.String())
 		}

--- a/cmd/micro/cli/new/new.go
+++ b/cmd/micro/cli/new/new.go
@@ -291,7 +291,7 @@ func printNextSteps(w io.Writer, dir string, noMCP bool) {
 	fmt.Fprintln(w, "    micro agent preflight")
 	fmt.Fprintln(w, "    go run .")
 	fmt.Fprintln(w, "    micro chat")
-	fmt.Fprintln(w, "    micro inspect agent")
+	fmt.Fprintln(w, "    micro inspect agent <name>")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  First-agent path:")
 	fmt.Fprintln(w, "    micro agent demo")

--- a/cmd/micro/first_agent_walkthrough_test.go
+++ b/cmd/micro/first_agent_walkthrough_test.go
@@ -68,11 +68,15 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 		"micro run",
 		"micro chat",
 		"micro agent doctor     # after micro run: chat/gateway/inspect recovery",
-		"micro inspect agent",
+		"micro inspect agent <name>",
+		"micro agent history <name>",
 	} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("micro docs output missing %q:\n%s", want, out.String())
 		}
+	}
+	if strings.Contains(out.String(), "micro runs") {
+		t.Fatalf("micro docs output should use the first-agent inspect command, not the legacy runs shortcut:\n%s", out.String())
 	}
 
 	agent := commandByName(t, "agent")

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -19,10 +19,10 @@ cloud credentials?"
 | --- | --- | --- |
 | Scaffold | `micro new` generates a runnable service with and without MCP support. | `go test ./cmd/micro/cli/new -run TestZeroToOne -count=1` |
 | First-agent wayfinding | README and the website getting-started docs keep the no-secret → first-agent → debugging → 0→hero links present and in order. | `go test ./internal/harness/zero-to-hero-ci -run TestFirstAgentWayfindingDocs -count=1` |
-| First agent | `micro new`, `micro agent preflight`, `micro run`, `micro chat`, and `micro inspect agent` stay available for the documented first-agent walkthrough. | `go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1` |
+| First agent | `micro new`, `micro agent preflight`, `micro run`, `micro chat`, and `micro inspect agent <name>` stay available for the documented first-agent walkthrough. | `go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1` |
 | Run | `micro run` remains the local development entry point. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
 | Chat | `micro chat` remains the interactive agent entry point. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
-| Inspect | `micro inspect agent`, `micro inspect flow`, and `micro flow runs` remain discoverable for run history. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
+| Inspect | `micro inspect agent <name>`, `micro inspect flow <flow>`, and `micro flow runs <flow>` remain discoverable for run history. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
 | Deploy | `micro deploy --dry-run` resolves deploy targets without touching remote infrastructure. | `go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1` |
 | Smallest first agent | `examples/first-agent` runs one service-backed agent with a deterministic mock model and no provider key. | `go test ./examples/first-agent -run TestRunFirstAgent -count=1` |
 | Runtime reference app | `examples/support` runs typed services, an agent using those services as tools, an event-driven flow handoff, and an approval gate with only the model mocked. | `go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1` |


### PR DESCRIPTION
## Summary
- align first-agent CLI docs and scaffold next steps on the copy/pasteable `micro inspect agent <name>` command
- keep the docs boundary focused on `micro agent history <name>` for memory instead of the legacy `micro runs` shortcut
- update focused CLI/docs tests to guard the first-agent inspect command path

## Testing
- `go build ./...`
- `go test ./...` (fails in this environment because loopback gRPC targets are blocked by the sandbox envoy)
- `golangci-lint run ./...`

Closes #4104
Closes #4112