### PR TITLE
Guard provider conformance scheduling

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -47,7 +47,7 @@ jobs:
   harness-live:
     name: Provider harnesses (live LLM conformance)
     runs-on: ubuntu-latest
-    # Only on the daily schedule or a manual run — never automatically on
+    # Only on the hourly schedule or a manual run — never automatically on
     # every push/PR, so changes don't quietly burn API credits. Trigger it
     # by hand (Actions → Harness → Run workflow) when changing the agent,
     # flow, or AI internals and you want a real-model check.

--- a/internal/docs/AGENT_CONFORMANCE.md
+++ b/internal/docs/AGENT_CONFORMANCE.md
@@ -43,7 +43,7 @@ contract.
 
 ## Scheduled CI
 
-The daily/manual `Harness (E2E)` workflow runs the same matrix with
+The hourly/manual `Harness (E2E)` workflow runs the same matrix with
 `GO_MICRO_AGENT_CONFORMANCE_LIVE=1` and the provider secrets exported. Providers
 whose keys are absent still skip cleanly, while any configured provider must pass
 the shared tool-calling scenario. This keeps scheduled conformance key-gated: PR

--- a/internal/harness/provider-conformance/README.md
+++ b/internal/harness/provider-conformance/README.md
@@ -69,7 +69,7 @@ go run ./internal/harness/provider-conformance \
 ## Scheduled CI behavior
 
 The `Harness (E2E)` workflow runs on pushes and pull requests with deterministic
-mock LLMs, including `provider-conformance -providers mock`. On the daily
+mock LLMs, including `provider-conformance -providers mock`. On the hourly
 schedule and manual dispatch it also runs the live provider conformance job. A
 manual dispatch can narrow `providers` or `harnesses`, and can set
 `require_configured=true` to fail fast when an expected repository secret is

--- a/internal/harness/provider-conformance/workflow_test.go
+++ b/internal/harness/provider-conformance/workflow_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHarnessWorkflowSchedulesLiveProviderMatrix(t *testing.T) {
+	path := filepath.Join(repoRoot(), ".github", "workflows", "harness.yml")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read harness workflow: %v", err)
+	}
+	workflow := string(b)
+
+	checks := []string{
+		`name: Harness (E2E)`,
+		`schedule:`,
+		`cron: "17 * * * *"`,
+		`workflow_dispatch:`,
+		`harness-live:`,
+		`if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`,
+		`ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`,
+		`OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}`,
+		`GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}`,
+		`GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}`,
+		`MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}`,
+		`MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}`,
+		`TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}`,
+		`ATLASCLOUD_API_KEY: ${{ secrets.ATLASCLOUD_API_KEY }}`,
+		`-summary-json provider-conformance-summary.json`,
+		`-summary-markdown provider-conformance-summary.md`,
+		`-capabilities-markdown provider-capabilities.md`,
+		`actions/upload-artifact@v4`,
+	}
+	for _, want := range checks {
+		if !strings.Contains(workflow, want) {
+			t.Fatalf("harness workflow missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add a provider-conformance workflow contract test so the scheduled live matrix keeps its hourly schedule, manual dispatch, key-gated provider secrets, summary artifacts, and upload step.
- Align conformance docs and workflow comments with the hourly live-matrix cadence.

Closes #4110
Closes #4119

## Testing
- go build ./...
- go test ./... (fails in this sandbox because loopback gRPC targets are blocked by the environment)
- golangci-lint run ./...