### PR TITLE
Add first-agent examples CLI wayfinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,16 +91,17 @@ walkable agent path in this order:
 
 1. [Install troubleshooting](internal/website/docs/guides/install-troubleshooting.md) — verify the binary installer or `go install`, `PATH`, `micro --version`, and the no-secret smoke path before agent work.
 2. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
-3. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
-4. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
-5. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
+3. `micro examples` — print the maintained provider-free runnable examples in copy/paste order.
+4. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
+5. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
+6. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
    maintained support agent with a mock model and see services → agents → workflows succeed without a key.
-6. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
+7. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
    service-backed agent and talk to it with `micro chat`.
-7. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
+8. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
    `micro inspect agent <name>`, run history, memory, and provider checks when the first
    conversation does something unexpected.
-8. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
+9. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
    services → agents → workflows loop with scaffold, run, chat, inspect, flow
    history, and deploy dry-run commands that match the maintained harness.
 

--- a/cmd/micro/README.md
+++ b/cmd/micro/README.md
@@ -66,10 +66,11 @@ provider-free agent path:
 
 ```
 micro agent demo
+micro examples
 ```
 
-That points at the smallest mock-model first-agent example and the no-secret
-transcript before you add provider-backed chat.
+Those commands point at the smallest mock-model first-agent example, the no-secret
+transcript, and the support app before you add provider-backed chat.
 
 ### Output
 

--- a/cmd/micro/cli/cli.go
+++ b/cmd/micro/cli/cli.go
@@ -46,6 +46,33 @@ Full local contract:
 
 Guide: https://go-micro.dev/docs/guides/zero-to-hero.html`
 
+const examplesWayfinding = `First-agent examples (no provider key required)
+
+Run these from a go-micro repository checkout in this order:
+
+  1. Smallest service-backed agent
+       go run ./examples/first-agent
+     Proves an agent can call a service tool with the deterministic mock model.
+
+  2. No-secret support-agent transcript
+       go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1
+     Exercises service tools, mock-model chat, and inspectable run history.
+
+  3. Full services → agents → workflows reference app
+       go run ./examples/support
+     Shows the support desk service, agent, workflow, and approval gate together.
+
+Then continue the same path with the installed CLI:
+  micro agent demo
+  micro docs
+  micro zero-to-hero
+
+Guides:
+  https://go-micro.dev/docs/guides/no-secret-first-agent.html
+  https://go-micro.dev/docs/guides/your-first-agent.html
+  https://go-micro.dev/docs/guides/debugging-agents.html
+  https://go-micro.dev/docs/guides/zero-to-hero.html`
+
 const docsWayfinding = `First-agent and 0→hero docs:
 
   1. Start with the no-secret CLI demo
@@ -147,6 +174,17 @@ func init() {
 				for _, service := range services {
 					fmt.Println(service.Name)
 				}
+				return nil
+			},
+		},
+
+		{
+			Name:  "examples",
+			Usage: "Show provider-free first-agent example paths",
+			Description: `Print the maintained no-secret examples for the services → agents →
+workflows on-ramp: first-agent, transcript, support app, and matching guides.`,
+			Action: func(ctx *cli.Context) error {
+				fmt.Fprintln(ctx.App.Writer, examplesWayfinding)
 				return nil
 			},
 		},

--- a/cmd/micro/first_agent_walkthrough_test.go
+++ b/cmd/micro/first_agent_walkthrough_test.go
@@ -22,7 +22,7 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 		}
 	}
 
-	for _, want := range []string{"new", "run", "chat", "inspect", "agent", "docs"} {
+	for _, want := range []string{"new", "run", "chat", "inspect", "agent", "docs", "examples"} {
 		if !commands[want] {
 			t.Fatalf("first-agent walkthrough missing %q command", want)
 		}
@@ -77,6 +77,32 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "micro runs") {
 		t.Fatalf("micro docs output should use the first-agent inspect command, not the legacy runs shortcut:\n%s", out.String())
+	}
+
+	examples := commandByName(t, "examples")
+	if !strings.Contains(examples.Usage, "first-agent") {
+		t.Fatalf("micro examples should advertise the first-agent examples path; usage was %q", examples.Usage)
+	}
+	out.Reset()
+	if err := examples.Action(cli.NewContext(app, nil, nil)); err != nil {
+		t.Fatalf("micro examples failed: %v", err)
+	}
+	for _, want := range []string{
+		"First-agent examples",
+		"go run ./examples/first-agent",
+		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1",
+		"go run ./examples/support",
+		"micro agent demo",
+		"micro docs",
+		"micro zero-to-hero",
+		"no-secret-first-agent.html",
+		"your-first-agent.html",
+		"debugging-agents.html",
+		"zero-to-hero.html",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("micro examples output missing %q:\n%s", want, out.String())
+		}
 	}
 
 	agent := commandByName(t, "agent")

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -57,12 +57,13 @@ After this quick start, follow the agent path in order:
 
 1. [Install troubleshooting](guides/install-troubleshooting.html) — verify the CLI install before agent work.
 2. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
-3. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
-4. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent) — run one service-backed agent with a mock model and no provider key.
-5. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — run a useful support agent with a mock model before setting up a provider key.
-6. [Your First Agent](guides/your-first-agent.html) — build a service-backed agent and talk to it with `micro chat`.
-7. [Debugging your agent](guides/debugging-agents.html) — inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
-8. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
+3. `micro examples` — print the maintained provider-free runnable examples in copy/paste order.
+4. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
+5. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent) — run one service-backed agent with a mock model and no provider key.
+6. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — run a useful support agent with a mock model before setting up a provider key.
+7. [Your First Agent](guides/your-first-agent.html) — build a service-backed agent and talk to it with `micro chat`.
+8. [Debugging your agent](guides/debugging-agents.html) — inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
+9. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
 
 ## Write a Service
 

--- a/internal/website/docs/index.md
+++ b/internal/website/docs/index.md
@@ -16,7 +16,7 @@ It's built on a pluggable architecture of Go interfaces: service discovery, clie
 
 ## Learn More
 
-Start with [Getting Started](getting-started.html) for install and the first local service. Then follow the first-agent on-ramp: `micro agent demo` for the installed no-secret CLI affordance, [No-secret first-agent transcript](guides/no-secret-first-agent.html) to run a mock-model support agent, [Your First Agent](guides/your-first-agent.html) to build and chat with a service-backed agent, [Debugging your agent](guides/debugging-agents.html) to inspect runs and memory, and the [0→hero reference path](guides/zero-to-hero.html) to walk the full scaffold → run → chat → inspect → deploy dry-run lifecycle covered by CI.
+Start with [Getting Started](getting-started.html) for install and the first local service. Then follow the first-agent on-ramp: `micro agent demo` for the installed no-secret CLI affordance, `micro examples` for copy/pasteable runnable examples, [No-secret first-agent transcript](guides/no-secret-first-agent.html) to run a mock-model support agent, [Your First Agent](guides/your-first-agent.html) to build and chat with a service-backed agent, [Debugging your agent](guides/debugging-agents.html) to inspect runs and memory, and the [0→hero reference path](guides/zero-to-hero.html) to walk the full scaffold → run → chat → inspect → deploy dry-run lifecycle covered by CI.
 
 Otherwise continue to read the docs for more information about the framework.
 
@@ -25,6 +25,7 @@ Otherwise continue to read the docs for more information about the framework.
 - [Getting Started](getting-started.html)
 - [0→hero Reference](guides/zero-to-hero.html) - Walk scaffold → run → chat → inspect → deploy dry-run with CI-backed commands
 - `micro agent demo` - Show the provider-free first-agent demo command and next docs steps
+- `micro examples` - Show provider-free first-agent examples in copy/paste order
 - [No-secret first-agent transcript](guides/no-secret-first-agent.html) - Run the first useful agent path without a provider key
 - [Your First Agent](guides/your-first-agent.html) - Build a service-backed agent end to end
 - [MCP & AI Agents](mcp.html) - Turn services into AI-callable tools with the Model Context Protocol

--- a/internal/website/docs/quickstart.md
+++ b/internal/website/docs/quickstart.md
@@ -43,11 +43,12 @@ You now have the service half of the services → agents → workflows lifecycle
 
 1. **[Install troubleshooting](guides/install-troubleshooting.html)** - verify the binary installer or `go install`, `PATH`, `micro --version`, and the no-secret smoke path.
 2. `micro agent demo` - print the provider-free first-agent demo command and the next docs steps from the installed CLI.
-3. `micro zero-to-hero` - print the maintained one-command no-secret lifecycle harness and runnable examples.
-4. **[Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent)** - run a mock-model, no-secret agent before adding provider keys.
-5. **[No-secret first-agent transcript](guides/no-secret-first-agent.html)** - run a useful support agent with a mock model before setting up a provider key.
-6. **[Your First Agent](guides/your-first-agent.html)** - turn this service into an agent-callable tool, chat with it, and learn the `micro agent preflight` → `micro run` → `micro chat` loop.
-7. **[Debugging your agent](guides/debugging-agents.html)** - inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent does something surprising.
+3. `micro examples` - print the maintained provider-free runnable examples in copy/paste order.
+4. `micro zero-to-hero` - print the maintained one-command no-secret lifecycle harness and runnable examples.
+5. **[Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent)** - run a mock-model, no-secret agent before adding provider keys.
+6. **[No-secret first-agent transcript](guides/no-secret-first-agent.html)** - run a useful support agent with a mock model before setting up a provider key.
+7. **[Your First Agent](guides/your-first-agent.html)** - turn this service into an agent-callable tool, chat with it, and learn the `micro agent preflight` → `micro run` → `micro chat` loop.
+8. **[Debugging your agent](guides/debugging-agents.html)** - inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent does something surprising.
 8. **[0→hero Reference](guides/zero-to-hero.html)** - walk the maintained scaffold → run → chat → inspect → deploy dry-run path that proves services, agents, and workflows together.
 
 After that first-agent path, branch out to:


### PR DESCRIPTION
## Summary
- Add a provider-free `micro examples` command that prints the maintained first-agent examples in copy/paste order.
- Extend first-agent CLI coverage to verify the new examples wayfinding output and links.
- Align README and website on-ramp docs with the new CLI examples step.

## Testing
- `go build ./...`
- `go test ./cmd/micro/...`
- `go test ./...` (fails in this sandbox because loopback gRPC targets are blocked by the environment)
- `golangci-lint run ./...`

Closes #4115
Closes #4123