### PR TITLE
Add first-agent tutorial smoke harness

### DIFF
--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -2,6 +2,7 @@ package zerotoheroci
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -74,6 +75,76 @@ func TestGuidesNavigationLeadsWithDoing(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(root, "internal", "website", "docs", doc)); err != nil {
 			t.Fatalf("navigation links to missing guide %s: %v", guide, err)
 		}
+	}
+}
+
+func TestYourFirstAgentTutorialSmoke(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	guide := readFile(t, filepath.Join(root, "internal", "website", "docs", "guides", "your-first-agent.md"))
+
+	for _, want := range []string{
+		"go test ./internal/harness/zero-to-hero-ci -run TestYourFirstAgentTutorialSmoke -count=1",
+		"micro agent preflight",
+		"mkdir first-agent",
+		"go mod init example.com/first-agent",
+		"go get go-micro.dev/v6@v6",
+		"micro run",
+		"micro call task TaskService.Create",
+		"micro call task TaskService.List",
+		"micro chat assistant",
+		"micro inspect agent assistant",
+	} {
+		if !strings.Contains(guide, want) {
+			t.Fatalf("Your First Agent guide missing copy/paste boundary %q", want)
+		}
+	}
+
+	mainGo := extractFirstAgentMain(t, guide)
+	workspace := t.TempDir()
+	writeFile(t, filepath.Join(workspace, "go.mod"), "module example.com/first-agent\n\ngo 1.24\n\nrequire go-micro.dev/v6 v6.0.0\n\nreplace go-micro.dev/v6 => "+absRoot+"\n")
+	writeFile(t, filepath.Join(workspace, "main.go"), mainGo)
+
+	runInWorkspace(t, workspace, "go", "mod", "tidy")
+	runInWorkspace(t, workspace, "go", "test", "./...")
+}
+
+func extractFirstAgentMain(t *testing.T, guide string) string {
+	t.Helper()
+	start := strings.Index(guide, "Add `main.go`:")
+	if start == -1 {
+		t.Fatal("Your First Agent guide is missing the main.go section")
+	}
+	rest := guide[start:]
+	open := strings.Index(rest, "```go")
+	if open == -1 {
+		t.Fatal("Your First Agent guide is missing a Go code fence for main.go")
+	}
+	rest = rest[open+len("```go"):]
+	close := strings.Index(rest, "```")
+	if close == -1 {
+		t.Fatal("Your First Agent guide main.go code fence is not closed")
+	}
+	return strings.TrimSpace(rest[:close]) + "\n"
+}
+
+func writeFile(t *testing.T, name, contents string) {
+	t.Helper()
+	if err := os.WriteFile(name, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func runInWorkspace(t *testing.T, workspace, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = workspace
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Your First Agent tutorial command %q does not pass from a clean workspace: %v\n%s", strings.Join(append([]string{name}, args...), " "), err, out)
 	}
 }
 

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -8,7 +8,7 @@ cd "$ROOT"
 # without secrets or long-running daemons.
 go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestZeroToHeroCLIBoundaries' -count=1
 go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
-go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscript|TestZeroToHeroReferenceDocs' -count=1
+go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscript|TestZeroToHeroReferenceDocs|TestYourFirstAgentTutorialSmoke' -count=1
 
 # Deterministic no-secret reference scenarios. These use the real Go Micro
 # runtime and mock only the LLM provider. The support example is the maintained

--- a/internal/website/docs/guides/your-first-agent.md
+++ b/internal/website/docs/guides/your-first-agent.md
@@ -47,7 +47,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 Plain service calls work without a model key; the key is only needed when the
 agent reasons over tools.
 
-Run the read-only first-agent preflight before starting the walkthrough. The same CLI boundary is covered by CI with `go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1`, so the documented scaffold → run → chat → inspect path stays visible in the local harness:
+Run the read-only first-agent preflight before starting the walkthrough. The same CLI boundary is covered by CI with `go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1`, and the copy/paste tutorial code is built from a clean temporary workspace with `go test ./internal/harness/zero-to-hero-ci -run TestYourFirstAgentTutorialSmoke -count=1`, so the documented scaffold → run → chat → inspect path stays visible in the local harness:
 
 ```sh
 micro agent preflight
@@ -177,7 +177,14 @@ Create a task called "Review the first-agent walkthrough", then show me all task
 ```
 
 A healthy run shows the agent calling the task service and then summarizing the
-result. If the model refuses to call tools, tighten the prompt so it explicitly
+result. Inspect the recorded run when you want to see the tool calls, memory,
+and timing behind the answer:
+
+```sh
+micro inspect agent assistant
+```
+
+If the model refuses to call tools, tighten the prompt so it explicitly
 uses the `task` service before answering.
 
 ## 4. Know what just happened


### PR DESCRIPTION
## Summary
- Add a zero-to-hero CI smoke test that extracts the Your First Agent guide main.go into a clean temporary module, wires it to the local repository, and verifies it with go mod tidy plus go test.
- Include the smoke test in the maintained zero-to-hero harness script.
- Document the maintained smoke command and add the missing inspect step to the Your First Agent walkthrough.

## Testing
- go build ./...
- go test ./internal/harness/zero-to-hero-ci -run TestYourFirstAgentTutorialSmoke -count=1
- ./internal/harness/zero-to-hero-ci/run.sh
- golangci-lint run ./...
- go test ./... (fails in this environment because loopback gRPC tests are blocked by the sandbox envoy: "Loopback targets forbidden")

Closes #4128
Closes #4139