### PR TITLE
Fix AtlasCloud built-in tool schemas

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -93,20 +93,7 @@ func (p *Provider) Options() ai.Options { return p.opts }
 func (p *Provider) String() string      { return "atlascloud" }
 
 func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (*ai.Response, error) {
-	var tools []map[string]any
-	for _, t := range req.Tools {
-		tools = append(tools, map[string]any{
-			"type": "function",
-			"function": map[string]any{
-				"name":        t.Name,
-				"description": t.Description,
-				"parameters": map[string]any{
-					"type":       "object",
-					"properties": t.Properties,
-				},
-			},
-		})
-	}
+	tools := atlascloudTools(req.Tools)
 
 	messages := []map[string]any{
 		{"role": "system", "content": req.SystemPrompt},
@@ -377,6 +364,59 @@ func (p *Provider) callAPI(ctx context.Context, phase string, req map[string]any
 	}
 
 	return response, rawMessage, nil
+}
+
+func atlascloudTools(input []ai.Tool) []map[string]any {
+	tools := make([]map[string]any, 0, len(input))
+	for _, t := range input {
+		tools = append(tools, map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        t.Name,
+				"description": t.Description,
+				"parameters": map[string]any{
+					"type":       "object",
+					"properties": normalizeAtlasCloudSchema(t.Properties),
+				},
+			},
+		})
+	}
+	return tools
+}
+
+func normalizeAtlasCloudSchema(schema map[string]any) map[string]any {
+	if schema == nil {
+		return nil
+	}
+	out := make(map[string]any, len(schema))
+	for k, v := range schema {
+		out[k] = normalizeAtlasCloudSchemaValue(v)
+	}
+	return out
+}
+
+func normalizeAtlasCloudSchemaValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val)+1)
+		for k, nested := range val {
+			out[k] = normalizeAtlasCloudSchemaValue(nested)
+		}
+		if typ, _ := out["type"].(string); typ == "array" {
+			if _, ok := out["items"]; !ok {
+				out["items"] = map[string]any{}
+			}
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, nested := range val {
+			out[i] = normalizeAtlasCloudSchemaValue(nested)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 func normalizeAtlasCloudToolCalls(toolCalls []atlasToolCall) []map[string]any {

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -289,6 +289,58 @@ func TestProvider_GenerateMinimaxToolRequests(t *testing.T) {
 	}
 }
 
+func TestProvider_GenerateNormalizesBuiltInToolSchemas(t *testing.T) {
+	var body map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer ts.Close()
+
+	planProperties := map[string]any{
+		"steps": map[string]any{
+			"type":        "array",
+			"description": "ordered plan steps",
+		},
+	}
+	p := NewProvider(
+		ai.WithAPIKey("test-key"),
+		ai.WithBaseURL(ts.URL),
+		ai.WithModel("minimaxai/minimax-m3"),
+	)
+	_, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "plan and delegate",
+		Tools: []ai.Tool{
+			{Name: "task_TaskService_Add", Description: "add task", Properties: map[string]any{"title": map[string]any{"type": "string"}}},
+			{Name: "plan", Description: "record a plan", Properties: planProperties},
+			{Name: "request_input", Description: "request input", Properties: map[string]any{"prompt": map[string]any{"type": "string"}}},
+			{Name: "delegate", Description: "delegate work", Properties: map[string]any{"task": map[string]any{"type": "string"}, "to": map[string]any{"type": "string"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	tools := body["tools"].([]any)
+	if len(tools) != 4 {
+		t.Fatalf("tools = %d, want custom tool plus built-ins", len(tools))
+	}
+	planTool := tools[1].(map[string]any)
+	fn := planTool["function"].(map[string]any)
+	params := fn["parameters"].(map[string]any)
+	props := params["properties"].(map[string]any)
+	steps := props["steps"].(map[string]any)
+	if _, ok := steps["items"].(map[string]any); !ok {
+		t.Fatalf("plan steps schema = %#v, want array items for AtlasCloud/minimax", steps)
+	}
+	if _, mutated := planProperties["steps"].(map[string]any)["items"]; mutated {
+		t.Fatalf("Generate mutated caller tool schema: %#v", planProperties)
+	}
+}
+
 func TestProvider_GenerateExecutesFollowUpToolCall(t *testing.T) {
 	var bodies []map[string]any
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Normalize AtlasCloud tool schemas before sending them to OpenAI-compatible chat completions.
- Add a regression test for custom tools plus built-in plan/request_input/delegate under minimaxai/minimax-m3.

Closes #4151
Closes #4158

## Testing
- go build ./...
- go test ./ai/atlascloud
- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...