### PR TITLE
harness: dedupe delegated owner notifications

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -187,10 +187,20 @@ func (s *NotifyService) duplicateAttempts() int {
 func notifyDedupKey(to, message string) string {
 	recipient := strings.ToLower(strings.TrimSpace(to))
 	body := normalizeNotifyText(message)
-	if recipient == "owner@acme.com" && isLaunchReadinessNotify(body) {
+	if isLaunchReadinessNotify(body) {
+		recipient = canonicalLaunchNotifyRecipient(recipient)
 		body = "launch-readiness"
 	}
 	return recipient + "\x00" + body
+}
+
+func canonicalLaunchNotifyRecipient(recipient string) string {
+	switch recipient {
+	case "owner", "launch owner", "plan owner", "owner@acme.com":
+		return "owner@acme.com"
+	default:
+		return recipient
+	}
 }
 
 func normalizeNotifyText(message string) string {

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -429,7 +429,11 @@ func TestNotifyServiceSendIsIdempotentForDuplicateDelivery(t *testing.T) {
 	}
 	for i, message := range messages {
 		var rsp SendResponse
-		if err := svc.Send(context.Background(), &SendRequest{To: "owner@acme.com", Message: message}, &rsp); err != nil {
+		to := "owner@acme.com"
+		if i == len(messages)-1 {
+			to = "owner"
+		}
+		if err := svc.Send(context.Background(), &SendRequest{To: to, Message: message}, &rsp); err != nil {
 			t.Fatalf("Send attempt %d: %v", i+1, err)
 		}
 		if !rsp.Sent {


### PR DESCRIPTION
## Summary
- Canonicalize launch-readiness notification recipient aliases before deriving the plan-delegate notify idempotency key.
- Extend deterministic coverage so owner alias replays collapse to one durable notification side effect.

Closes #4163
Closes #4172

## Testing
- go test ./internal/harness/plan-delegate -run 'TestNotifyServiceSendIsIdempotentForDuplicateDelivery|TestPlanDelegateExecutionAcceptsDuplicateNotifyReplay' -count=1\n- go build ./...\n- go test ./... (fails in this environment because loopback gRPC targets are blocked by envoy: client/grpc and transport/grpc)\n- golangci-lint run ./...