### PR TITLE
docs: add micro loop quickstart wayfinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Running Go Micro in production, or building on it and want help? Paid **support,
 - [Building Agents](#building-agents) — [Plan & Delegate](#plan--delegate), [Pluggable](#batteries-included-pluggable), [Paid tools (x402)](#paid-tools-x402), [A2A](#reachable-by-other-agents-a2a)
 - [Features](#features)
 - [CLI](#cli)
+- [Autonomous improvement loop](#autonomous-improvement-loop)
 - [Multi-Service Projects](#multi-service-projects)
 - [Data Model](#data-model)
 - [AI Providers](#ai-providers)
@@ -104,6 +105,25 @@ walkable agent path in this order:
 9. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
    services → agents → workflows loop with scaffold, run, chat, inspect, flow
    history, and deploy dry-run commands that match the maintained harness.
+
+### Autonomous improvement loop
+
+Want the same services → agents → workflows lifecycle applied to your
+repository? `micro loop` scaffolds the autonomous improvement loop used by Go
+Micro itself: a North Star, ranked issue queue, role prompts, GitHub Actions
+workflows, and verification for CI-gated PRs.
+
+```bash
+micro loop init --roles all
+micro loop verify
+```
+
+Before turning on the schedule, configure a dispatch token such as
+`CODEX_TRIGGER_TOKEN`, protect the default branch with required CI checks
+(`go build ./...`, `go test ./...`, and `golangci-lint run ./...` for this
+repository), and seed `.github/loop/PRIORITIES.md` with one scoped issue per
+increment. See the [`micro loop` quickstart](internal/website/docs/guides/micro-loop.md)
+for the setup checklist and operating model.
 
 ### Generate from a prompt — with an LLM key
 

--- a/internal/website/_data/navigation.yml
+++ b/internal/website/_data/navigation.yml
@@ -42,6 +42,8 @@ examples:
 guides:
   - title: Debugging your agent
     url: /docs/guides/debugging-agents.html
+  - title: micro loop quickstart
+    url: /docs/guides/micro-loop.html
   - title: Plan & Delegate
     url: /docs/guides/plan-delegate.html
   - title: Agent Guardrails
@@ -86,6 +88,7 @@ search_order:
   - /docs/guides/your-first-agent.html
   - /docs/guides/zero-to-hero.html
   - /docs/guides/debugging-agents.html
+  - /docs/guides/micro-loop.html
   - /docs/getting-started.html
   - /docs/mcp.html
   - /docs/architecture.html

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -259,4 +259,5 @@ The flow discovers all services as tools and lets the LLM decide which RPCs to c
 - [Agent Design](https://github.com/micro/go-micro/blob/master/internal/docs/AGENT_DESIGN.md) — the full agent interface specification
 - [MCP & AI Agents](mcp.html) — MCP gateway, tool discovery, and auth
 - [Data Model](model.html) — typed persistence with CRUD and queries
+- [`micro loop` quickstart](guides/micro-loop.html) — scaffold a CI-gated autonomous improvement loop for a repository
 - [Deployment](deployment.html) — deploy via SSH + systemd

--- a/internal/website/docs/guides/micro-loop.md
+++ b/internal/website/docs/guides/micro-loop.md
@@ -1,0 +1,96 @@
+---
+layout: default
+---
+
+# `micro loop` quickstart
+
+`micro loop` scaffolds the autonomous improvement loop that Go Micro uses on
+this repository: GitHub Actions workflows for planning, building, evaluation
+feedback, coherence, security, and release. Use it when you want a repository to
+continuously turn a ranked queue into small PRs while CI remains the merge gate.
+
+## 1. Initialize the loop
+
+Run the default loop from the repository root:
+
+```bash
+micro loop init
+```
+
+For every role used by Go Micro itself, scaffold all workflows:
+
+```bash
+micro loop init --roles all
+```
+
+The command writes:
+
+- `.github/loop/NORTH_STAR.md` — the direction every increment should optimize.
+- `.github/loop/PRIORITIES.md` — the ranked queue; the builder takes the top open issue.
+- `.github/loop/prompts/*.md` — editable policy for planner, builder, triage, coherence, and security roles.
+- `.github/workflows/loop-*.yml` — generated GitHub Actions mechanics.
+
+Edit the files under `.github/loop/` to steer the loop. Re-run
+`micro loop init --roles all --force` only when you want to regenerate workflow
+mechanics from the installed CLI.
+
+## 2. Configure the dispatch token
+
+The scheduled builder needs a repository secret containing a token from a user
+account that the coding agent will answer. Go Micro names that secret
+`CODEX_TRIGGER_TOKEN` by default. If you use another secret name, pass it when
+you initialize the loop:
+
+```bash
+micro loop init --agent @codex --token-secret LOOP_TOKEN --roles all
+```
+
+The token needs enough repository permission to open issues, comment, push
+branches, create pull requests, and enable auto-merge. Run `gh auth setup-git` in
+the environment that will push branches so `git push` uses the same credentials
+as `gh`.
+
+## 3. Make CI the gate
+
+The loop should not be its own reviewer. Protect the default branch so PRs merge
+only after the required checks pass. At minimum, require the same commands the
+Go Micro loop verifies locally and in CI:
+
+```bash
+go build ./...
+go test ./...
+golangci-lint run ./...
+```
+
+If your repository has a harness or end-to-end grader, make that required too.
+Keep human approval requirements out of the autonomous path unless you intend the
+loop to pause for review.
+
+## 4. Verify the wiring
+
+After editing the North Star, queue, prompts, token secret, and branch
+protection, run:
+
+```bash
+micro loop verify
+```
+
+`micro loop verify` checks that the loop direction, queue, prompts, role
+workflows, and non-loop CI gate are present. Fix any reported missing items
+before relying on scheduled increments.
+
+## 5. Operate the queue
+
+Keep one ranked list in `.github/loop/PRIORITIES.md`. Each item should link a
+scoped issue and be small enough for one PR. The builder closes both the priority
+issue and the per-run tracker issue in the PR body, for example:
+
+```text
+Closes #1234
+Closes #5678
+```
+
+Use the North Star to keep the queue honest: favor small improvements that move
+developers through the services → agents → workflows lifecycle, and surface
+breaking API or brand/positioning decisions for humans instead of auto-merging
+them.

--- a/internal/website/docs/index.md
+++ b/internal/website/docs/index.md
@@ -30,6 +30,7 @@ Otherwise continue to read the docs for more information about the framework.
 - [Your First Agent](guides/your-first-agent.html) - Build a service-backed agent end to end
 - [MCP & AI Agents](mcp.html) - Turn services into AI-callable tools with the Model Context Protocol
 - [CLI & Gateway Guide](guides/cli-gateway.html) - Development vs Production modes
+- [`micro loop` quickstart](guides/micro-loop.html) - Scaffold an autonomous CI-gated improvement loop
 - [Quick Start](quickstart.html)
 - [Architecture](architecture.html)
 - [Configuration](config.html)
@@ -64,5 +65,6 @@ Otherwise continue to read the docs for more information about the framework.
 - [Real-World Examples](examples/realworld/)
 - [Migration Guides](guides/migration/)
 - [Observability](observability.html)
+- [`micro loop` quickstart](guides/micro-loop.html)
 - [Contributing](contributing.html)
 - [Roadmap](roadmap.html)


### PR DESCRIPTION
## Summary
- Add README wayfinding for `micro loop init --roles all` and `micro loop verify`.
- Add a website `micro loop` quickstart covering scaffolded files, dispatch token setup, CI-as-gate branch protection, verification, and queue operation.
- Link the guide from website docs index, getting started, navigation, and search order.

Closes #4169
Closes #4178

## Testing
- `go build ./...`
- `go test ./...` (fails in this environment because loopback gRPC targets are blocked by envoy)
- `golangci-lint run ./...`