### PR TITLE
harness: dedupe delegated notify paraphrases

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -185,10 +185,9 @@ func (s *NotifyService) duplicateAttempts() int {
 }
 
 func notifyDedupKey(to, message string) string {
-	recipient := strings.ToLower(strings.TrimSpace(to))
+	recipient := canonicalLaunchNotifyRecipient(normalizeNotifyText(to))
 	body := normalizeNotifyText(message)
 	if isLaunchReadinessNotify(body) {
-		recipient = canonicalLaunchNotifyRecipient(recipient)
 		body = "launch-readiness"
 	}
 	return recipient + "\x00" + body
@@ -196,21 +195,38 @@ func notifyDedupKey(to, message string) string {
 
 func canonicalLaunchNotifyRecipient(recipient string) string {
 	switch recipient {
-	case "owner", "launch owner", "plan owner", "owner@acme.com":
+	case "owner", "launch owner", "plan owner", "owner acme com", "owner@acme com", "owner @ acme com":
 		return "owner@acme.com"
 	default:
+		if strings.Contains(recipient, "owner") && strings.Contains(recipient, "acme") {
+			return "owner@acme.com"
+		}
 		return recipient
 	}
 }
 
 func normalizeNotifyText(message string) string {
-	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(message))), " ")
+	message = strings.ToLower(strings.TrimSpace(message))
+	message = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			return r
+		case r == '@':
+			return r
+		default:
+			return ' '
+		}
+	}, message)
+	return strings.Join(strings.Fields(message), " ")
 }
 
 func isLaunchReadinessNotify(message string) bool {
 	return strings.Contains(message, "launch") &&
 		strings.Contains(message, "plan") &&
-		(strings.Contains(message, "ready") || strings.Contains(message, "readiness"))
+		(strings.Contains(message, "ready") ||
+			strings.Contains(message, "readiness") ||
+			strings.Contains(message, "prepared") ||
+			strings.Contains(message, "complete"))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -447,3 +447,28 @@ func TestNotifyServiceSendIsIdempotentForDuplicateDelivery(t *testing.T) {
 		t.Fatalf("duplicate notify attempts = %d, want %d", got, len(messages)-1)
 	}
 }
+
+func TestNotifyServiceCollapsesProviderReadinessParaphrases(t *testing.T) {
+	svc := new(NotifyService)
+	requests := []SendRequest{
+		{To: "owner@acme.com", Message: "The launch plan is ready"},
+		{To: "owner @ acme.com", Message: "Launch plan ready."},
+		{To: "launch owner", Message: "The launch readiness plan is prepared."},
+		{To: "plan owner", Message: "Launch plan is complete!"},
+	}
+	for i, req := range requests {
+		var rsp SendResponse
+		if err := svc.Send(context.Background(), &req, &rsp); err != nil {
+			t.Fatalf("Send attempt %d: %v", i+1, err)
+		}
+		if !rsp.Sent {
+			t.Fatalf("Send attempt %d reported Sent=false", i+1)
+		}
+	}
+	if got := svc.count(); got != 1 {
+		t.Fatalf("notify count = %d, want 1 after provider paraphrase replays", got)
+	}
+	if got := svc.duplicateAttempts(); got != len(requests)-1 {
+		t.Fatalf("duplicate notify attempts = %d, want %d", got, len(requests)-1)
+	}
+}


### PR DESCRIPTION
## Summary
- Harden plan-delegate notification idempotency for provider paraphrases and recipient formatting variants.
- Add regression coverage for AtlasCloud-style readiness notification replays.

Closes #4163
Closes #4184

## Testing
- go build ./...
- go test ./internal/harness/plan-delegate
- go test ./... (fails in this environment: loopback gRPC targets forbidden; one generated-service tidy fetch hit sum.golang.org 502)
- golangci-lint run ./...