### PR TITLE
Harden AtlasCloud conformance delegate retries

### DIFF
--- a/agent/conformance_test.go
+++ b/agent/conformance_test.go
@@ -225,10 +225,16 @@ func missingConformanceRequirements(sawTool, sawBlockedDelegate *bool, hasMarker
 	return missing
 }
 
+const (
+	conformanceEchoInputJSON      = `{"value":"agent-conformance"}`
+	conformanceDelegateInputJSON  = `{"task":"summarize the conformance marker","to":"blocked-reviewer"}`
+	conformanceDelegateTaggedCall = `<tool_call name="delegate">` + conformanceDelegateInputJSON + `</tool_call>`
+)
+
 func conformanceSystemPrompt(provider string) string {
-	prompt := "You are a conformance test agent. Create a short plan, use conformance_echo exactly once with input {\"value\":\"agent-conformance\"}, then attempt to delegate a summary to blocked-reviewer with input {\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}. If the delegate is refused, explain the refusal and answer with the echo result."
+	prompt := "You are a conformance test agent. Create a short plan, use conformance_echo exactly once with input " + conformanceEchoInputJSON + ", then attempt to delegate a summary to blocked-reviewer with input " + conformanceDelegateInputJSON + ". You must complete both tool calls before any final answer; a final answer that only mentions the steps without calling both tools is invalid. If the delegate is refused, explain the refusal and answer with the echo result."
 	if provider == "atlascloud" {
-		prompt += " AtlasCloud/minimax conformance note: the delegate attempt is mandatory after conformance_echo. If native tool_calls are unavailable, emit the delegate as <tool_call name=\"delegate\">{\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}</tool_call> rather than answering in prose."
+		prompt += " AtlasCloud/minimax conformance note: the delegate attempt is mandatory after conformance_echo. If native tool_calls are unavailable, emit the delegate as " + conformanceDelegateTaggedCall + " rather than answering in prose."
 	}
 	return prompt
 }
@@ -237,6 +243,7 @@ func TestAgentProviderConformanceAtlasCloudPromptRequiresTaggedDelegateFallback(
 	prompt := conformanceSystemPrompt("atlascloud")
 	for _, want := range []string{
 		"delegate attempt is mandatory",
+		"You must complete both tool calls before any final answer",
 		"<tool_call name=\"delegate\">",
 		`{"task":"summarize the conformance marker","to":"blocked-reviewer"}`,
 	} {
@@ -250,12 +257,29 @@ func TestAgentProviderConformanceAtlasCloudPromptRequiresTaggedDelegateFallback(
 	}
 }
 
+func TestAgentProviderConformanceRetryPromptsRequireBothTools(t *testing.T) {
+	for name, prompt := range map[string]string{
+		"missing tool":     nextConformanceRetryPrompt(false, false, false),
+		"missing delegate": nextConformanceRetryPrompt(true, false, true),
+	} {
+		for _, want := range []string{
+			"delegate exactly once",
+			conformanceDelegateTaggedCall,
+			"do not",
+		} {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("%s retry prompt %q missing %q", name, prompt, want)
+			}
+		}
+	}
+}
+
 func nextConformanceRetryPrompt(sawTool, sawBlockedDelegate, hasMarker bool) string {
 	switch {
 	case !sawTool:
-		return "The previous response did not call the required conformance_echo tool. Retry the same conformance check now: you must call conformance_echo exactly once with input {\"value\":\"agent-conformance\"} before any final answer, then include the tool result marker in the final answer."
+		return "The previous response did not call the required conformance_echo tool. Retry the same conformance check now: first call conformance_echo exactly once with input " + conformanceEchoInputJSON + ", then call delegate exactly once with input " + conformanceDelegateInputJSON + "; do not provide a final answer until both tool calls have been attempted. If native delegate tool_calls are unavailable after conformance_echo, emit exactly " + conformanceDelegateTaggedCall + ". The delegate is expected to be refused by policy; include that refusal and the agent-conformance marker in the final answer."
 	case !sawBlockedDelegate:
-		return "The previous response called conformance_echo but did not attempt the required guarded delegation. Continue the same conformance check now: call delegate exactly once with input {\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}; do not answer in prose until that delegate call has been attempted. If native tool_calls are unavailable, emit exactly <tool_call name=\"delegate\">{\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}</tool_call>. The delegate is expected to be refused by policy; include that refusal and the agent-conformance marker in the final answer."
+		return "The previous response called conformance_echo but did not attempt the required guarded delegation. Continue the same conformance check now: call delegate exactly once with input " + conformanceDelegateInputJSON + "; do not answer in prose until that delegate call has been attempted. If native tool_calls are unavailable, emit exactly " + conformanceDelegateTaggedCall + ". The delegate is expected to be refused by policy; include that refusal and the agent-conformance marker in the final answer."
 	case !hasMarker:
 		return "The previous response completed the required tool calls but omitted the conformance marker. Continue the same conformance check now: do not call more tools; answer with the prior echo result marker agent-conformance-ok and mention the guarded delegate refusal."
 	default:


### PR DESCRIPTION
## Summary
- Require the agent conformance system prompt to complete both conformance_echo and the guarded delegate before any final answer.
- Reuse canonical echo/delegate JSON in AtlasCloud tagged fallback guidance and retry prompts.
- Add deterministic coverage that retry prompts continue to require the delegate fallback path.

Closes #4183
Closes #4194

## Testing
- go build ./...
- go test ./... (fails in this sandbox because loopback gRPC tests are blocked by the environment: envoy returns 'Loopback targets forbidden')
- go test ./agent -run 'TestAgentProviderConformance(RetryPromptsRequireBothTools|RetriesMissingTool|RetriesMissingDelegate|FailsWhenDelegateStillMissing|AtlasCloudPromptRequiresTaggedDelegateFallback)' -count=1
- golangci-lint run ./...