### PR TITLE
Verify installed first-agent on-ramp

### DIFF
--- a/internal/harness/install-smoke/run.sh
+++ b/internal/harness/install-smoke/run.sh
@@ -49,6 +49,34 @@ require_output() {
   fi
 }
 
+require_ordered_output() {
+  local description=$1
+  shift
+  local -a expected=()
+  while [[ $# -gt 0 && "$1" != "--" ]]; do
+    expected+=("$1")
+    shift
+  done
+  shift
+
+  local output
+  if ! output=$("$MICRO" "$@" 2>&1); then
+    echo "micro $* failed while checking $description" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+
+  local remainder=$output
+  for text in "${expected[@]}"; do
+    if [[ "$remainder" != *"$text"* ]]; then
+      echo "micro $* missing expected ordered text '$text' for $description" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+    remainder=${remainder#*"$text"}
+  done
+}
+
 require_output "version" "micro version" --version
 require_output "root help" "COMMANDS" --help
 require_output "service scaffold" "micro new" new --help
@@ -57,5 +85,52 @@ require_output "local runtime" "micro run" run --help
 require_output "agent chat" "micro chat" chat --help
 require_output "agent inspection" "micro inspect agent" inspect agent --help
 require_output "flow inspection" "micro inspect flow" inspect flow --help
+
+require_ordered_output "installed first-agent docs wayfinding" \
+  "micro agent demo" \
+  "no-secret-first-agent.html" \
+  "your-first-agent.html" \
+  "micro agent preflight  # before micro run: prerequisites" \
+  "micro run" \
+  "micro chat" \
+  "micro agent doctor     # after micro run: chat/gateway/inspect recovery" \
+  "debugging-agents.html" \
+  "micro inspect agent <name>" \
+  "zero-to-hero.html" \
+  -- docs
+
+require_ordered_output "installed provider-free examples wayfinding" \
+  "go run ./examples/first-agent" \
+  "go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1" \
+  "go run ./examples/support" \
+  "micro agent demo" \
+  "micro docs" \
+  "micro zero-to-hero" \
+  "no-secret-first-agent.html" \
+  "your-first-agent.html" \
+  "debugging-agents.html" \
+  "zero-to-hero.html" \
+  -- examples
+
+require_ordered_output "installed no-secret agent demo" \
+  "provider-free" \
+  "go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1" \
+  "your-first-agent.html" \
+  "debugging-agents.html" \
+  "zero-to-hero.html" \
+  "micro agent preflight  # before micro run: prerequisites" \
+  "micro run" \
+  "micro chat" \
+  "micro agent doctor     # after micro run: chat/gateway/inspect recovery" \
+  "micro inspect agent <name>" \
+  -- agent demo
+
+require_ordered_output "installed zero-to-hero lifecycle wayfinding" \
+  "./internal/harness/zero-to-hero-ci/run.sh" \
+  "go run ./examples/first-agent" \
+  "go run ./examples/support" \
+  "make harness" \
+  "zero-to-hero.html" \
+  -- zero-to-hero
 
 echo "✓ install smoke path verified"


### PR DESCRIPTION
Summary:
- Tightens the install smoke harness to run the installed micro binary through the first-agent docs, examples, no-secret demo, and zero-to-hero wayfinding in deterministic order.
- Ensures provider-free on-ramp commands stay copy/pasteable from the installed CLI.

Testing:
- bash internal/harness/install-smoke/run.sh
- go build ./...
- go test ./cmd/micro ./internal/harness/zero-to-hero-ci
- golangci-lint run ./...

Note:
- go test ./... is blocked in this environment by loopback target restrictions in grpc client/transport tests.

Closes #4197
Closes #4205