### PR TITLE
agent: add resume pending helper

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -244,6 +244,31 @@ func Pending(ctx context.Context, ag Agent) ([]flow.Run, error) {
 	return a.pending(ctx)
 }
 
+// ResumePending resumes every checkpointed agent run that has not completed
+// yet, in the same oldest-first order returned by Pending.
+//
+// It is a convenience for service startup and recovery loops: after recreating
+// an agent with the same checkpoint store, call ResumePending to drain the
+// durable backlog without listing and resuming each run manually. If any run
+// fails again, ResumePending stops and returns that run id with the error so
+// callers can log, alert, or retry later without hiding the failing run.
+func ResumePending(ctx context.Context, ag Agent) (string, error) {
+	a, ok := ag.(*agentImpl)
+	if !ok {
+		return "", fmt.Errorf("agent resume pending: unsupported agent implementation %T", ag)
+	}
+	runs, err := a.pending(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, run := range runs {
+		if _, err := a.resume(ctx, run.ID); err != nil {
+			return run.ID, err
+		}
+	}
+	return "", nil
+}
+
 func (a *agentImpl) ask(ctx context.Context, message, parentRunID string) (*Response, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/client"
@@ -460,6 +461,51 @@ func countMemoryContent(messages []ai.Message, needle string) int {
 		}
 	}
 	return count
+}
+
+func TestResumePendingResumesOldestAgentRunsUntilFailure(t *testing.T) {
+	ctx := context.Background()
+	cp := flow.StoreCheckpoint(store.NewMemoryStore(), "resume-pending-agent")
+	base := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	for _, run := range []flow.Run{
+		{ID: "run-ok", Flow: "resume-pending-agent", Status: "failed", State: flow.State{Stage: agentAskStep, Data: []byte("ok")}, Started: base},
+		{ID: "run-blocked", Flow: "resume-pending-agent", Status: "failed", State: flow.State{Stage: agentAskStep, Data: []byte("block")}, Started: base.Add(time.Minute)},
+		{ID: "run-later", Flow: "resume-pending-agent", Status: "failed", State: flow.State{Stage: agentAskStep, Data: []byte("later")}, Started: base.Add(2 * time.Minute)},
+	} {
+		if err := cp.Save(ctx, run); err != nil {
+			t.Fatalf("Save(%s): %v", run.ID, err)
+		}
+	}
+
+	var prompts []string
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		prompts = append(prompts, req.Prompt)
+		if req.Prompt == "block" {
+			return nil, errors.New("still blocked")
+		}
+		return &ai.Response{Reply: req.Prompt + " resumed"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("resume-pending-agent"), WithCheckpoint(cp))
+	failedRun, err := ResumePending(ctx, a)
+	if err == nil {
+		t.Fatal("ResumePending succeeded, want blocked run error")
+	}
+	if failedRun != "run-blocked" {
+		t.Fatalf("failed run = %q, want run-blocked", failedRun)
+	}
+	if got, want := strings.Join(prompts, ","), "ok,block"; got != want {
+		t.Fatalf("prompts = %q, want %q", got, want)
+	}
+	loaded, ok, err := cp.Load(ctx, "run-ok")
+	if err != nil || !ok || loaded.Status != "done" {
+		t.Fatalf("run-ok loaded=%v err=%v status=%q, want done", ok, err, loaded.Status)
+	}
+	loaded, ok, err = cp.Load(ctx, "run-later")
+	if err != nil || !ok || loaded.Status != "failed" {
+		t.Fatalf("run-later loaded=%v err=%v status=%q, want still failed", ok, err, loaded.Status)
+	}
 }
 
 func TestPendingReturnsUnfinishedAgentRuns(t *testing.T) {

--- a/micro.go
+++ b/micro.go
@@ -220,6 +220,13 @@ func AgentResume(ctx context.Context, a Agent, runID string) (*AgentResponse, er
 	return agent.Resume(ctx, a, runID)
 }
 
+// AgentResumePending resumes every incomplete checkpointed agent run, oldest
+// first. It returns the first run id that fails again so startup recovery loops
+// can leave the durable backlog visible instead of swallowing the failure.
+func AgentResumePending(ctx context.Context, a Agent) (string, error) {
+	return agent.ResumePending(ctx, a)
+}
+
 // AgentResumeInput resumes a checkpointed agent run waiting for human input.
 func AgentResumeInput(ctx context.Context, a Agent, runID, input string) (*AgentResponse, error) {
 	return agent.ResumeInput(ctx, a, runID, input)


### PR DESCRIPTION
Summary:
- Add an agent ResumePending helper that drains checkpointed agent runs oldest-first and stops on the first retry failure.
- Re-export the helper as micro.AgentResumePending for startup recovery loops.
- Cover successful drain-until-failure ordering and backlog preservation with a checkpoint test.

Testing:
- go build ./...
- go test ./agent
- go test ./... (fails in this environment due existing/provider and loopback limitations: ai atlascloud stream 400, cache expiration timing, grpc loopback forbidden, transport/grpc loopback forbidden)
- golangci-lint run ./...

Closes #4202
Closes #4220