### PR TITLE
agent: cancel StreamAsk on close

### DIFF
--- a/agent/stream.go
+++ b/agent/stream.go
@@ -71,14 +71,15 @@ func ResumeStreamAsk(ctx context.Context, ag Agent, runID string) (AgentStream, 
 // StreamAsk runs tools like Ask, emits ToolStart/ToolEnd events as they execute,
 // then emits chunks of the final answer followed by a Done event.
 func (a *agentImpl) StreamAsk(ctx context.Context, message string) (AgentStream, error) {
+	streamCtx, cancel := context.WithCancel(ctx)
 	events := make(chan *StreamEvent, 16)
 	done := make(chan struct{})
-	s := &agentStream{events: events, done: done}
+	s := &agentStream{events: events, done: done, cancel: cancel}
 
 	go func() {
 		defer close(events)
 		defer close(done)
-		resp, err := a.askWithStreamEvents(ctx, message, events)
+		resp, err := a.askWithStreamEvents(streamCtx, message, events)
 		if err != nil {
 			s.setErr(err)
 			return
@@ -94,14 +95,15 @@ func (a *agentImpl) StreamAsk(ctx context.Context, message string) (AgentStream,
 }
 
 func (a *agentImpl) resumeStreamAsk(ctx context.Context, runID string) (AgentStream, error) {
+	streamCtx, cancel := context.WithCancel(ctx)
 	events := make(chan *StreamEvent, 16)
 	done := make(chan struct{})
-	s := &agentStream{events: events, done: done}
+	s := &agentStream{events: events, done: done, cancel: cancel}
 
 	go func() {
 		defer close(events)
 		defer close(done)
-		resp, err := a.resumeWithStreamEvents(ctx, runID, events)
+		resp, err := a.resumeWithStreamEvents(streamCtx, runID, events)
 		if err != nil {
 			s.setErr(err)
 			return
@@ -260,6 +262,7 @@ func (a *agentImpl) streamAskAI(ctx context.Context, message string) (ai.Stream,
 type agentStream struct {
 	events <-chan *StreamEvent
 	done   <-chan struct{}
+	cancel context.CancelFunc
 	mu     sync.Mutex
 	err    error
 }
@@ -278,6 +281,9 @@ func (s *agentStream) Recv() (*StreamEvent, error) {
 }
 
 func (s *agentStream) Close() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
 	<-s.done
 	return nil
 }

--- a/agent/stream_test.go
+++ b/agent/stream_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/flow"
@@ -72,6 +73,39 @@ func TestStreamAskEmitsToolEventsAndFinalTokens(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("Generate calls = %d, want 1", calls)
+	}
+}
+
+func TestStreamAskCloseCancelsInFlightModelCall(t *testing.T) {
+	started := make(chan struct{})
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("stream-cancel"))
+	stream, err := a.StreamAsk(context.Background(), "cancel me")
+	if err != nil {
+		t.Fatalf("StreamAsk: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("model call did not start")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- stream.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close did not cancel the in-flight stream")
 	}
 }
 


### PR DESCRIPTION
Summary:
- Cancel StreamAsk and ResumeStreamAsk contexts when callers close the stream so in-flight model calls can stop promptly.
- Add coverage proving Close cancels an in-flight streaming model call.

Testing:
- go build ./...
- go test ./... (fails in this environment: atlascloud fixture reached provider endpoint and loopback gRPC tests are blocked by envoy)
- golangci-lint run ./... --timeout=10m

Closes #4217
Closes #4225