### PR TITLE
agent: trace tool retry attempts

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -36,6 +36,8 @@ const (
 	AttrTotalTokens      = "agent.tokens.total"
 	AttrAttempt          = "agent.model.attempt"
 	AttrMaxAttempts      = "agent.model.max_attempts"
+	AttrToolAttempt      = "agent.tool.attempt"
+	AttrToolMaxAttempts  = "agent.tool.max_attempts"
 	AttrToolName         = "agent.tool.name"
 	AttrDelegate         = "agent.delegate"
 	AttrGuardrailBlock   = "agent.guardrail.block"
@@ -364,7 +366,11 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 			res := next(ctx, call)
 			dur := time.Since(start).Milliseconds()
 			resErr := resultError(res)
-			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr)})
+			toolAttempts := res.Attempts
+			if toolAttempts <= 0 {
+				toolAttempts = 1
+			}
+			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, Attempt: toolAttempts, MaxAttempts: a.opts.ToolMaxAttempts, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr)})
 			return res
 		}
 
@@ -378,6 +384,14 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 		res := next(ctx, call)
 		dur := time.Since(start).Milliseconds()
 		attrs := []attribute.KeyValue{attribute.Int64(AttrLatencyMS, dur)}
+		toolAttempts := res.Attempts
+		if toolAttempts <= 0 {
+			toolAttempts = 1
+		}
+		attrs = append(attrs, attribute.Int(AttrToolAttempt, toolAttempts))
+		if a.opts.ToolMaxAttempts > 0 {
+			attrs = append(attrs, attribute.Int(AttrToolMaxAttempts, a.opts.ToolMaxAttempts))
+		}
 		if res.Refused != "" {
 			attrs = append(attrs, attribute.Bool(AttrGuardrailBlock, true), attribute.String(AttrRefusal, res.Refused))
 		}
@@ -393,7 +407,7 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 		} else {
 			span.SetStatus(codes.Ok, "")
 		}
-		a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr)})
+		a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, Attempt: toolAttempts, MaxAttempts: a.opts.ToolMaxAttempts, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr)})
 		span.End()
 		return res
 	}
@@ -461,10 +475,18 @@ func runEventAttributes(e RunEvent) []attribute.KeyValue {
 		attrs = append(attrs, attribute.String(AttrModel, e.Model))
 	}
 	if e.Attempt > 0 {
-		attrs = append(attrs, attribute.Int(AttrAttempt, e.Attempt))
+		if e.Kind == "tool" {
+			attrs = append(attrs, attribute.Int(AttrToolAttempt, e.Attempt))
+		} else {
+			attrs = append(attrs, attribute.Int(AttrAttempt, e.Attempt))
+		}
 	}
 	if e.MaxAttempts > 0 {
-		attrs = append(attrs, attribute.Int(AttrMaxAttempts, e.MaxAttempts))
+		if e.Kind == "tool" {
+			attrs = append(attrs, attribute.Int(AttrToolMaxAttempts, e.MaxAttempts))
+		} else {
+			attrs = append(attrs, attribute.Int(AttrMaxAttempts, e.MaxAttempts))
+		}
 	}
 	if e.LatencyMS > 0 {
 		attrs = append(attrs, attribute.Int64(AttrLatencyMS, e.LatencyMS))

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -142,6 +142,82 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	}
 }
 
+func TestAgentOpenTelemetryToolRetryAttempts(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exp))
+	st := store.NewMemoryStore()
+	calls := 0
+	a := New(
+		Name("tool-retry-otel"),
+		Provider("oteltest"),
+		WithStore(st),
+		TraceProvider(tp),
+		ToolRetry(3, time.Millisecond),
+		WithTool("probe", "probe", nil, func(context.Context, map[string]any) (string, error) {
+			calls++
+			if calls == 1 {
+				return "", errors.New("rate limit exceeded")
+			}
+			return "ok", nil
+		}),
+	)
+	if _, err := a.Ask(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("tool calls = %d, want retry success after 2 attempts", calls)
+	}
+
+	var sawToolSpan bool
+	for _, span := range exp.GetSpans().Snapshots() {
+		if span.Name() != spanNameToolCall {
+			continue
+		}
+		attrs := spanAttributes(span.Attributes())
+		if attrs[AttrToolName] != "probe" {
+			continue
+		}
+		if attrs[AttrToolAttempt] != "2" || attrs[AttrToolMaxAttempts] != "3" {
+			t.Fatalf("tool retry span attempts = %#v", attrs)
+		}
+		if !spanEventHasAttr(span.Events(), "agent.tool", AttrToolAttempt, "2") || !spanEventHasAttr(span.Events(), "agent.tool", AttrToolMaxAttempts, "3") {
+			t.Fatalf("tool retry event missing attempt attributes: %#v", span.Events())
+		}
+		sawToolSpan = true
+	}
+	if !sawToolSpan {
+		t.Fatal("tool retry span not emitted")
+	}
+
+	summaries, err := ListRunSummaries(st, "tool-retry-otel")
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := LoadRunEvents(st, "tool-retry-otel", summaries[0].RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.Kind == "tool" && event.Name == "probe" && event.Attempt == 2 && event.MaxAttempts == 3 {
+			return
+		}
+	}
+	t.Fatalf("persisted tool event missing retry attempts: %#v", events)
+}
+
+func spanEventHasAttr(events []trace.Event, name, key, value string) bool {
+	for _, event := range events {
+		if event.Name != name {
+			continue
+		}
+		attrs := spanAttributes(event.Attributes)
+		if attrs[key] == value {
+			return true
+		}
+	}
+	return false
+}
+
 func TestAgentRunObservabilityRedactsInputByDefault(t *testing.T) {
 	secret := "deploy production with token sk-secret"
 	exp := tracetest.NewInMemoryExporter()


### PR DESCRIPTION
## Summary
- add OpenTelemetry attributes for tool retry attempts and configured tool retry budget
- persist tool attempt counts in agent run history so inspect output and traces tell the same story
- add coverage for a transient tool retry succeeding on the second attempt

Closes #4218
Closes #4231

## Testing
- go build ./...
- go test ./agent
- go test ./... (fails in this environment: atlascloud live stream returned 400; loopback gRPC tests are blocked by envoy "Loopback targets forbidden")
- golangci-lint run ./...