### PR TITLE
docs: add examples wayfinding index

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,16 @@ walkable agent path in this order:
 2. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
 3. `micro examples` — print the maintained provider-free runnable examples in copy/paste order.
 4. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
-5. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
-6. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
+5. [Examples wayfinding index](examples/INDEX.md) — choose the smallest no-secret first-agent, maintained [0→hero support reference](examples/support/), and next interop examples from one map.
+6. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
+7. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
    maintained support agent with a mock model and see services → agents → workflows succeed without a key.
-7. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
+8. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
    service-backed agent and talk to it with `micro chat`.
-8. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
+9. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
    `micro inspect agent <name>`, run history, memory, and provider checks when the first
    conversation does something unexpected.
-9. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
+10. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
    services → agents → workflows loop with scaffold, run, chat, inspect, flow
    history, and deploy dry-run commands that match the maintained harness.
 

--- a/cmd/micro/cli/cli.go
+++ b/cmd/micro/cli/cli.go
@@ -48,7 +48,8 @@ Guide: https://go-micro.dev/docs/guides/zero-to-hero.html`
 
 const examplesWayfinding = `First-agent examples (no provider key required)
 
-Run these from a go-micro repository checkout in this order:
+Run these from a go-micro repository checkout in this order. For the complete
+examples map, open examples/INDEX.md:
 
   1. Smallest service-backed agent
        go run ./examples/first-agent

--- a/cmd/micro/examples_wayfinding_test.go
+++ b/cmd/micro/examples_wayfinding_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+	microcmd "go-micro.dev/v6/cmd"
+)
+
+func TestExamplesWayfindingIndexStaysLinked(t *testing.T) {
+	root := filepath.Join("..", "..")
+	files := map[string]string{}
+	for _, name := range []string{"README.md", "examples/README.md", "examples/INDEX.md"} {
+		b, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		files[name] = string(b)
+	}
+
+	for _, check := range []struct {
+		file string
+		want []string
+	}{
+		{
+			file: "README.md",
+			want: []string{"examples/INDEX.md", "examples/first-agent/", "examples/support/", "zero-to-hero.md"},
+		},
+		{
+			file: "examples/README.md",
+			want: []string{"./INDEX.md", "./first-agent/", "./support/", "./mcp/hello/", "./mcp/workflow/"},
+		},
+		{
+			file: "examples/INDEX.md",
+			want: []string{"go run ./examples/first-agent", "go run ./examples/support", "mcp/hello", "mcp/workflow", "flow-durable", "micro examples"},
+		},
+	} {
+		for _, want := range check.want {
+			if !strings.Contains(files[check.file], want) {
+				t.Fatalf("%s missing %q", check.file, want)
+			}
+		}
+	}
+}
+
+func TestExamplesCommandPointsAtWayfindingIndex(t *testing.T) {
+	examples := commandByName(t, "examples")
+	var out bytes.Buffer
+	app := cli.NewApp()
+	app.Writer = &out
+	if err := examples.Action(cli.NewContext(app, nil, nil)); err != nil {
+		t.Fatalf("micro examples failed: %v", err)
+	}
+
+	for _, want := range []string{
+		"examples/INDEX.md",
+		"go run ./examples/first-agent",
+		"go run ./examples/support",
+		"micro zero-to-hero",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("micro examples output missing %q:\n%s", want, out.String())
+		}
+	}
+
+	_ = microcmd.DefaultCmd // keep this test coupled to the registered command package.
+}

--- a/examples/INDEX.md
+++ b/examples/INDEX.md
@@ -1,0 +1,46 @@
+# Examples wayfinding
+
+Use this index when you want the shortest path from a first runnable agent to the
+next services, agents, workflows, and interop examples. Every command below is
+provider-free unless the example README says otherwise.
+
+## Pick by goal
+
+| Goal | Start here | Run or verify | Then try |
+|------|------------|---------------|----------|
+| Run the smallest no-secret agent | [`first-agent`](./first-agent/) | `go run ./examples/first-agent` | [`agent-demo`](./agent-demo/) for a larger service-backed agent |
+| Prove the maintained 0→hero path | [`support`](./support/) | `go run ./examples/support` and `go test ./examples/support` | [`zero-to-hero` guide](../internal/website/docs/guides/zero-to-hero.md) |
+| See planning and delegation | [`agent-plan-delegate`](./agent-plan-delegate/) | `go run ./examples/agent-plan-delegate` | [`plan-delegate` guide](../internal/website/docs/guides/plan-delegate.md) |
+| Expose services through MCP | [`mcp/hello`](./mcp/hello/) | follow [`mcp`](./mcp/) setup | [`mcp/crud`](./mcp/crud/) and [`mcp/workflow`](./mcp/workflow/) |
+| Try A2A or gRPC interop next | [`agent-demo`](./agent-demo/) plus gateway docs | run the example, then use the gateway docs | [`grpc-interop`](./grpc-interop/) |
+| Add workflow durability | [`flow-durable`](./flow-durable/) | `go run ./examples/flow-durable` | [`flow-loop`](./flow-loop/) |
+
+## Recommended adoption path
+
+1. **First service:** run [`hello-world`](./hello-world/) to learn service
+   registration, handlers, client calls, and health checks.
+2. **First agent:** run [`first-agent`](./first-agent/) with
+   `go run ./examples/first-agent`; it uses a deterministic mock model and needs
+   no provider key.
+3. **0→hero reference:** run [`support`](./support/) with
+   `go run ./examples/support`; it keeps typed services, an agent chat loop, an
+   event-driven flow, and an approval gate in one maintained example.
+4. **Interop next:** use [`mcp/hello`](./mcp/hello/), [`mcp/crud`](./mcp/crud/),
+   and [`mcp/workflow`](./mcp/workflow/) when you are ready to expose tools to
+   external AI clients.
+5. **Workflow depth:** use [`flow-durable`](./flow-durable/) once the agent path
+   needs checkpointed, resumable deterministic work.
+
+## CLI wayfinding
+
+The installed CLI prints the same path:
+
+```bash
+micro examples
+micro agent demo
+micro zero-to-hero
+```
+
+Keep this file, [`README.md`](../README.md), and the `micro examples` output in
+sync so new developers can find `examples/first-agent` and `examples/support`
+from one documented path.

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,8 @@ coordinate work with workflows.
 ## Quick Start
 
 Each example can be run with `go run .` from its directory unless its README says
-otherwise. If you are new to the repo, follow the first-agent path below instead
-of reading the directories alphabetically.
+otherwise. If you are new to the repo, start with the [examples wayfinding index](./INDEX.md)
+or follow the first-agent path below instead of reading the directories alphabetically.
 
 ## Recommended first-agent path
 


### PR DESCRIPTION
Summary:\n- Add an examples wayfinding index that groups first-agent, 0→hero support, plan/delegate, MCP, interop, and workflow examples by developer goal.\n- Link the new index from the README first-agent on-ramp, examples README, and micro examples CLI output.\n- Add smoke tests that keep the README, examples index, and CLI wayfinding paths from drifting.\n\nTesting:\n- go test ./cmd/micro -run 'TestExamples|TestFirstAgent' -count=1\n- go build ./...\n- go test ./... (fails in this sandbox due existing live/provider and loopback restrictions: ai atlascloud 400, grpc loopback forbidden)\n- golangci-lint run ./...\n\nCloses #4223\nCloses #4238