### PR TITLE
Prevent duplicate delegate replay side effects

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -99,6 +99,12 @@ type agentImpl struct {
 	// holding mu. Tool execution updates it so resumed runs can reuse
 	// completed tool results without replaying side effects.
 	currentRun *flow.Run
+
+	// delegateCalls collapses concurrent equivalent delegate tool calls so a
+	// provider replay cannot fan out duplicate delegated side effects before the
+	// durable delegate-result cache is written.
+	delegateMu    sync.Mutex
+	delegateCalls map[string]*delegateCall
 }
 
 // New creates a new Agent.

--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -27,6 +27,11 @@ const (
 	toolHumanInput = "request_input"
 )
 
+type delegateCall struct {
+	done chan struct{}
+	res  ai.ToolResult
+}
+
 // builtinTools returns the tool definitions exposed to the model in
 // addition to the agent's scoped service tools.
 func builtinTools() []ai.Tool {
@@ -585,7 +590,7 @@ func (a *agentImpl) handleHumanInput(call ai.ToolCall) ai.ToolResult {
 // if 'to' names a registered agent, it is called via RPC. Otherwise an
 // ephemeral sub-agent is created with a fresh, isolated context, asked
 // the subtask, and its reply returned.
-func (a *agentImpl) handleDelegate(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+func (a *agentImpl) handleDelegate(ctx context.Context, call ai.ToolCall) (res ai.ToolResult) {
 	input := call.Input
 	task, _ := input["task"].(string)
 	if task == "" {
@@ -595,6 +600,12 @@ func (a *agentImpl) handleDelegate(ctx context.Context, call ai.ToolCall) ai.Too
 	if cached, ok := a.cachedDelegateResult(call.ID, to, task); ok {
 		return cached
 	}
+
+	key := delegateResultKey(to, task)
+	if cached, ok := a.joinDelegateCall(ctx, call.ID, key); ok {
+		return cached
+	}
+	defer func() { a.finishDelegateCall(key, res) }()
 
 	// An external agent on another framework, addressed by A2A URL.
 	if strings.HasPrefix(to, "http://") || strings.HasPrefix(to, "https://") {
@@ -647,6 +658,38 @@ func (a *agentImpl) handleDelegate(ctx context.Context, call ai.ToolCall) ai.Too
 	return a.storeDelegateResult(call.ID, to, task, map[string]any{"reply": resp.Reply})
 }
 
+func (a *agentImpl) joinDelegateCall(ctx context.Context, id, key string) (ai.ToolResult, bool) {
+	a.delegateMu.Lock()
+	if a.delegateCalls == nil {
+		a.delegateCalls = map[string]*delegateCall{}
+	}
+	if inFlight := a.delegateCalls[key]; inFlight != nil {
+		a.delegateMu.Unlock()
+		select {
+		case <-ctx.Done():
+			return errResult(id, ctx.Err().Error()), true
+		case <-inFlight.done:
+			return withToolResultID(inFlight.res, id), true
+		}
+	}
+	a.delegateCalls[key] = &delegateCall{done: make(chan struct{})}
+	a.delegateMu.Unlock()
+	return ai.ToolResult{}, false
+}
+
+func (a *agentImpl) finishDelegateCall(key string, res ai.ToolResult) {
+	a.delegateMu.Lock()
+	inFlight := a.delegateCalls[key]
+	if inFlight == nil {
+		a.delegateMu.Unlock()
+		return
+	}
+	inFlight.res = res
+	delete(a.delegateCalls, key)
+	close(inFlight.done)
+	a.delegateMu.Unlock()
+}
+
 func (a *agentImpl) cachedDelegateResult(id, to, task string) (ai.ToolResult, bool) {
 	recs, err := a.stateStore().Read(delegateResultKey(to, task))
 	if err != nil || len(recs) == 0 {
@@ -664,6 +707,11 @@ func (a *agentImpl) storeDelegateResult(id, to, task string, out map[string]any)
 	b, _ := json.Marshal(out)
 	_ = a.stateStore().Write(&store.Record{Key: delegateResultKey(to, task), Value: b})
 	return ai.ToolResult{ID: id, Value: out, Content: string(b)}
+}
+
+func withToolResultID(res ai.ToolResult, id string) ai.ToolResult {
+	res.ID = id
+	return res
 }
 
 func delegateResultKey(to, task string) string {

--- a/agent/builtin_test.go
+++ b/agent/builtin_test.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
+	"time"
 
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/registry"
@@ -204,6 +206,44 @@ func TestDelegateResultCacheReusesLaunchReadinessParaphrases(t *testing.T) {
 	}
 	if !containsStr(cached.Content, "Notified owner@acme.com") {
 		t.Fatalf("cached result content = %q, want original delegate reply", cached.Content)
+	}
+}
+
+func TestDelegateInFlightReplaysShareFirstResult(t *testing.T) {
+	a := New(Name("planner"), WithStore(store.NewMemoryStore())).(*agentImpl)
+	key := delegateResultKey("comms", "Notify owner@acme.com that the launch plan is ready")
+	if _, joined := a.joinDelegateCall(context.Background(), "delegate-1", key); joined {
+		t.Fatal("first delegate call unexpectedly joined an existing in-flight call")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	results := make(chan ai.ToolResult, 1)
+	go func() {
+		defer wg.Done()
+		res, joined := a.joinDelegateCall(context.Background(), "delegate-2", key)
+		if !joined {
+			t.Error("replayed delegate call did not join the in-flight call")
+			return
+		}
+		results <- res
+	}()
+
+	select {
+	case res := <-results:
+		t.Fatalf("replayed delegate returned before first call finished: %+v", res)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	first := ai.ToolResult{ID: "delegate-1", Content: `{"reply":"Notified owner@acme.com."}`}
+	a.finishDelegateCall(key, first)
+	wg.Wait()
+	replayed := <-results
+	if replayed.ID != "delegate-2" {
+		t.Fatalf("replayed result ID = %q, want delegate-2", replayed.ID)
+	}
+	if replayed.Content != first.Content {
+		t.Fatalf("replayed content = %q, want %q", replayed.Content, first.Content)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Collapse concurrent equivalent delegate tool calls behind the first in-flight result.
- Add regression coverage for replayed delegate calls sharing the first result.

Testing:
- go build ./...
- go test ./agent ./internal/harness/plan-delegate
- go test ./... (fails in this environment: AtlasCloud stream probe returns 400 without credentials; loopback gRPC tests are blocked by Envoy)
- golangci-lint run ./...

Closes #4245
Closes #4250