### PR TITLE
Parse OpenAI-compatible text tool calls

### DIFF
--- a/agent/text_tool_calls.go
+++ b/agent/text_tool_calls.go
@@ -19,7 +19,8 @@ type textToolCall struct {
 	Name      string         `json:"name"`
 	Tool      string         `json:"tool"`
 	Input     map[string]any `json:"input"`
-	Arguments map[string]any `json:"arguments"`
+	Arguments any            `json:"arguments"`
+	Function  *textToolCall  `json:"function"`
 }
 
 // executeTextToolCalls is a compatibility fallback for providers that return a
@@ -176,14 +177,7 @@ func collectTextToolCalls(v any, allowed map[string]string) []ai.ToolCall {
 			return collectTextToolCalls(nested, allowed)
 		}
 		call := mapToTextToolCall(x)
-		name := call.Name
-		if name == "" {
-			name = call.Tool
-		}
-		input := call.Input
-		if input == nil {
-			input = call.Arguments
-		}
+		name, input := textToolCallNameAndInput(call)
 		if name == "" || allowed[name] == "" || input == nil {
 			return nil
 		}
@@ -195,6 +189,40 @@ func collectTextToolCalls(v any, allowed map[string]string) []ai.ToolCall {
 	default:
 		return nil
 	}
+}
+
+func textToolCallNameAndInput(call textToolCall) (string, map[string]any) {
+	name := call.Name
+	if name == "" {
+		name = call.Tool
+	}
+	input := call.Input
+	if input == nil {
+		input = textToolArguments(call.Arguments)
+	}
+	if call.Function != nil {
+		fnName, fnInput := textToolCallNameAndInput(*call.Function)
+		if name == "" {
+			name = fnName
+		}
+		if input == nil {
+			input = fnInput
+		}
+	}
+	return name, input
+}
+
+func textToolArguments(raw any) map[string]any {
+	switch args := raw.(type) {
+	case map[string]any:
+		return args
+	case string:
+		var input map[string]any
+		if err := json.Unmarshal([]byte(args), &input); err == nil {
+			return input
+		}
+	}
+	return nil
 }
 
 func decodeTaggedTextToolCalls(text string, allowed map[string]string) []ai.ToolCall {

--- a/agent/text_tool_calls_test.go
+++ b/agent/text_tool_calls_test.go
@@ -56,3 +56,22 @@ func TestParseTextToolCallsCreateAliasForAddTool(t *testing.T) {
 		t.Fatalf("title = %v, want Design", got)
 	}
 }
+
+func TestParseTextToolCallsOpenAICompatibleFunctionArgumentsString(t *testing.T) {
+	tools := []ai.Tool{{Name: "delegate"}}
+	reply := `<tool_call>{"id":"call-2","type":"function","function":{"name":"delegate","arguments":"{\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}"}}</tool_call>`
+
+	calls := parseTextToolCalls(reply, tools)
+	if len(calls) != 1 {
+		t.Fatalf("parseTextToolCalls returned %d calls, want 1: %+v", len(calls), calls)
+	}
+	if calls[0].Name != "delegate" {
+		t.Fatalf("call name = %q, want delegate", calls[0].Name)
+	}
+	if got := calls[0].Input["task"]; got != "summarize the conformance marker" {
+		t.Fatalf("task = %v, want summarize the conformance marker", got)
+	}
+	if got := calls[0].Input["to"]; got != "blocked-reviewer" {
+		t.Fatalf("to = %v, want blocked-reviewer", got)
+	}
+}


### PR DESCRIPTION
Summary:
- Extend text tool-call fallback parsing to understand OpenAI-compatible function envelopes with JSON-string arguments.
- Add coverage for tagged delegate calls emitted in that shape so AtlasCloud/minimax can satisfy guarded-delegation conformance.

Testing:
- go test ./agent -run 'TestParseTextToolCalls|TestAgentExecutesTextToolCallFallbackAfterStructuredToolCall' -count=1\n- go build ./...\n- go test ./... (fails in this environment: AtlasCloud live stream 400 with configured credentials; loopback targets forbidden for grpc client/transport tests)\n- golangci-lint run ./...\n\nCloses #4244\nCloses #4256