### PR TITLE
docs: refresh planner priorities for 4258

### DIFF
--- a/.github/loop/PRIORITIES.md
+++ b/.github/loop/PRIORITIES.md
@@ -21,8 +21,9 @@ changes, architectural rewrites. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **Make AtlasCloud guarded delegation pass reliably** ([#4244](https://github.com/micro/go-micro/issues/4244)) — Now-phase cross-provider conformance is the current red edge after the Minimax request-shape fallback and duplicate delegated-notification replay fixes shipped: AtlasCloud now reaches the guarded-delegation scenario, but the live agent harness still needs to satisfy the required guarded delegate within the retry budget.
-2. **Link examples wayfinding from website getting-started path** ([#4241](https://github.com/micro/go-micro/issues/4241)) — keep adoption weighted with hardening after the examples index shipped: the repo README and CLI now point at the first-agent/0→hero map, but go-micro.dev getting-started and quickstart pages should expose the same path with a CI-guarded docs smoke check.
+1. **Make AtlasCloud plan-delegate complete the required notify side effect** ([#4255](https://github.com/micro/go-micro/issues/4255)) — Now-phase getting-started contract and cross-provider conformance overlap here: the live AtlasCloud 0→hero plan/delegate harness can now parse the initial plan call, but still exits before the required task and notify side effects, so a provider-backed services → agents → workflows path is not yet reliable.
+2. **Link examples wayfinding from website getting-started path** ([#4241](https://github.com/micro/go-micro/issues/4241)) — keep adoption weighted with hardening after the examples index shipped: the repo README and CLI now point at the first-agent/0→hero map, but go-micro.dev getting-started and quickstart pages still skip the examples index/support reference links that make the no-secret on-ramp discoverable.
+3. **Make AtlasCloud guarded delegation pass reliably** ([#4244](https://github.com/micro/go-micro/issues/4244)) — Now-phase cross-provider conformance remains important after the Minimax request-shape fallback, duplicate delegated-notification replay fixes, and OpenAI-compatible text tool-call parsing shipped; keep it in queue until the live agent harness consistently observes the guarded delegate within the retry budget.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:\n- Re-ranked the planner queue after issue #4258's architecture pass.\n- Put #4255 first because AtlasCloud plan/delegate now blocks a provider-backed 0→hero side-effect contract.\n- Kept website examples wayfinding and AtlasCloud guarded delegation in the active queue.\n\nTesting:\n- go build ./... passed as part of the combined verification command before go test ran.\n- go test ./... failed in go-micro.dev/v6/ai: TestConfiguredProviderStreamsSkipWithoutCredentials/atlascloud returned stream API error 400 not found.\n- golangci-lint run ./... passed.\n\nCloses #4258