### PR TITLE
Fix AtlasCloud multi-step tool followups

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -138,76 +138,77 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 	}
 
 	if p.opts.ToolHandler != nil {
-		allToolCalls := append([]ai.ToolCall(nil), resp.ToolCalls...)
+		var allToolCalls []ai.ToolCall
 		var toolResults []string
+		pendingToolCalls := append([]ai.ToolCall(nil), resp.ToolCalls...)
 		followUpMessages := append(messages, map[string]any{
 			"role":       "assistant",
 			"content":    rawMessage["content"],
 			"tool_calls": rawMessage["tool_calls"],
 		})
 
-		for _, tc := range resp.ToolCalls {
-			content := p.opts.ToolHandler(ctx, tc).Content
-			if content != "" {
-				toolResults = append(toolResults, content)
-			}
-			followUpMessages = append(followUpMessages, map[string]any{
-				"role":         "tool",
-				"tool_call_id": tc.ID,
-				"content":      content,
-			})
-		}
-
-		followUpReq := map[string]any{
-			"model":    p.opts.Model,
-			"messages": followUpMessages,
-		}
-		if len(tools) > 0 {
-			// Keep the tool schema available during the follow-up turn. Minimax
-			// models behind Atlas Cloud sometimes call one required tool, inspect
-			// that result, and then issue a second tool call (for example a guarded
-			// delegate conformance check) instead of completing immediately.
-			followUpReq["tools"] = tools
-		}
-
-		followUpResp, _, err := p.callAPI(ctx, "tool-follow-up", followUpReq)
-		if err != nil {
-			if atlascloudShouldRetryWithoutTools(err, followUpReq) {
-				delete(followUpReq, "tools")
-				followUpResp, _, err = p.callAPI(ctx, "tool-follow-up-no-tools", followUpReq)
-			}
-			if err != nil {
-				return nil, err
-			}
-		}
-		if len(followUpResp.ToolCalls) > 0 {
-			for i := range followUpResp.ToolCalls {
-				result := p.opts.ToolHandler(ctx, followUpResp.ToolCalls[i])
+		for attempt := 0; len(pendingToolCalls) > 0 && attempt < 4; attempt++ {
+			for _, tc := range pendingToolCalls {
+				result := p.opts.ToolHandler(ctx, tc)
 				if result.Refused != "" {
-					followUpResp.ToolCalls[i].Error = result.Refused
+					tc.Error = result.Refused
 				}
 				if result.Content != "" {
-					followUpResp.ToolCalls[i].Result = result.Content
+					tc.Result = result.Content
 					toolResults = append(toolResults, result.Content)
 				}
+				allToolCalls = append(allToolCalls, tc)
+				resp.ToolCalls = allToolCalls
+				followUpMessages = append(followUpMessages, map[string]any{
+					"role":         "tool",
+					"tool_call_id": tc.ID,
+					"content":      result.Content,
+				})
 			}
-			allToolCalls = append(allToolCalls, followUpResp.ToolCalls...)
-			resp.ToolCalls = allToolCalls
-		}
-		if followUpResp.Reply != "" {
-			if strings.Contains(followUpResp.Reply, "<tool_call") || strings.Contains(followUpResp.Reply, "function=") {
-				// Preserve follow-up assistant content as Reply, not Answer, when
-				// it may contain a text-encoded tool call. The agent harness
-				// inspects Reply for text fallback calls after Generate returns,
-				// which covers AtlasCloud/minimax turns that emit a second
-				// required call (for example guarded delegate) as markup instead
-				// of native tool_calls.
-				resp.Reply = followUpResp.Reply
-			} else {
-				resp.Answer = followUpResp.Reply
+
+			followUpReq := map[string]any{
+				"model":    p.opts.Model,
+				"messages": followUpMessages,
 			}
-		} else if len(toolResults) > 0 {
-			resp.Answer = strings.Join(toolResults, "\n")
+			if len(tools) > 0 {
+				// Keep the tool schema available during follow-up turns. Minimax
+				// models behind Atlas Cloud sometimes complete a multi-tool task
+				// one call at a time (plan, then service tools, then delegate).
+				followUpReq["tools"] = tools
+			}
+
+			followUpResp, followUpRawMessage, err := p.callAPI(ctx, "tool-follow-up", followUpReq)
+			if err != nil {
+				if atlascloudShouldRetryWithoutTools(err, followUpReq) {
+					delete(followUpReq, "tools")
+					followUpResp, followUpRawMessage, err = p.callAPI(ctx, "tool-follow-up-no-tools", followUpReq)
+				}
+				if err != nil {
+					return nil, err
+				}
+			}
+			if len(followUpResp.ToolCalls) == 0 {
+				if followUpResp.Reply != "" {
+					if strings.Contains(followUpResp.Reply, "<tool_call") || strings.Contains(followUpResp.Reply, "function=") {
+						// Preserve follow-up assistant content as Reply, not Answer, when
+						// it may contain a text-encoded tool call. The agent harness
+						// inspects Reply for text fallback calls after Generate returns.
+						resp.Reply = followUpResp.Reply
+					} else {
+						resp.Answer = followUpResp.Reply
+					}
+				} else if len(toolResults) > 0 {
+					resp.Answer = strings.Join(toolResults, "\n")
+				}
+				break
+			}
+
+			followUpMessages = append(followUpMessages, map[string]any{
+				"role":       "assistant",
+				"content":    followUpRawMessage["content"],
+				"tool_calls": followUpRawMessage["tool_calls"],
+			})
+			pendingToolCalls = followUpResp.ToolCalls
 		}
 	}
 

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -355,6 +355,8 @@ func TestProvider_GenerateExecutesFollowUpToolCall(t *testing.T) {
 			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"","tool_calls":[{"id":"call-1","function":{"name":"conformance_echo","arguments":"{\"value\":\"agent-conformance\"}"}}]}}]}`))
 		case 2:
 			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"","tool_calls":[{"id":"call-2","function":{"name":"delegate","arguments":"{\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}"}}]}}]}`))
+		case 3:
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"blocked by policy"}}]}`))
 		default:
 			t.Fatalf("unexpected API call %d", len(bodies))
 		}
@@ -403,6 +405,70 @@ func TestProvider_GenerateExecutesFollowUpToolCall(t *testing.T) {
 	}
 	if _, ok := bodies[1]["tools"].([]any); !ok {
 		t.Fatalf("follow-up request did not include tools: %#v", bodies[1])
+	}
+}
+
+func TestProvider_GenerateExecutesMultiStepFollowUpToolCalls(t *testing.T) {
+	var bodies []map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		bodies = append(bodies, body)
+		w.Header().Set("Content-Type", "application/json")
+		switch len(bodies) {
+		case 1:
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"","tool_calls":[{"id":"call-plan","function":{"name":"plan","arguments":"{\"steps\":[{\"task\":\"create tasks\"},{\"task\":\"notify owner\"}]}"}}]}}]}`))
+		case 2:
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"","tool_calls":[{"id":"call-add","function":{"name":"task_TaskService_Add","arguments":"{\"title\":\"Design\"}"}}]}}]}`))
+		case 3:
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"","tool_calls":[{"id":"call-delegate","function":{"name":"delegate","arguments":"{\"task\":\"notify owner@acme.com\",\"to\":\"comms\"}"}}]}}]}`))
+		case 4:
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"done"}}]}`))
+		default:
+			t.Fatalf("unexpected API call %d", len(bodies))
+		}
+	}))
+	defer ts.Close()
+
+	var calls []string
+	p := NewProvider(
+		ai.WithAPIKey("test-key"),
+		ai.WithBaseURL(ts.URL),
+		ai.WithToolHandler(func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+			calls = append(calls, call.Name)
+			return ai.ToolResult{ID: call.ID, Content: `{"ok":true}`}
+		}),
+	)
+	resp, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "plan, create tasks, and delegate notification",
+		Tools: []ai.Tool{
+			{Name: "plan", Description: "record a plan", Properties: map[string]any{"steps": map[string]any{"type": "array"}}},
+			{Name: "task_TaskService_Add", Description: "add task", Properties: map[string]any{"title": map[string]any{"type": "string"}}},
+			{Name: "delegate", Description: "delegate work", Properties: map[string]any{"task": map[string]any{"type": "string"}, "to": map[string]any{"type": "string"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	wantCalls := []string{"plan", "task_TaskService_Add", "delegate"}
+	if strings.Join(calls, ",") != strings.Join(wantCalls, ",") {
+		t.Fatalf("tool calls = %v, want %v", calls, wantCalls)
+	}
+	if len(resp.ToolCalls) != 3 {
+		t.Fatalf("ToolCalls = %+v, want all multi-step calls", resp.ToolCalls)
+	}
+	if resp.Answer != "done" {
+		t.Fatalf("Answer = %q, want final follow-up reply", resp.Answer)
+	}
+	if len(bodies) != 4 {
+		t.Fatalf("requests = %d, want initial plus three follow-ups", len(bodies))
+	}
+	for i := 1; i < 4; i++ {
+		if _, ok := bodies[i]["tools"].([]any); !ok {
+			t.Fatalf("follow-up request %d did not include tools: %#v", i+1, bodies[i])
+		}
 	}
 }
 


### PR DESCRIPTION
Summary:
- Execute AtlasCloud follow-up tool calls iteratively so models that emit plan, service tool, and delegate calls across separate turns complete the full plan-delegate lifecycle.
- Add coverage for chained follow-up tool calls and update existing follow-up behavior expectations.

Testing:
- go build ./...
- go test ./... (environment warning: loopback restrictions caused unrelated ai/client/grpc/transport/grpc failures)
- golangci-lint run ./...

Closes #4255
Closes #4261