### PR TITLE
Harden AtlasCloud text tool-call parsing

### DIFF
--- a/agent/text_tool_calls.go
+++ b/agent/text_tool_calls.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"regexp"
 	"strings"
 
@@ -12,7 +13,8 @@ import (
 
 var fencedJSONBlock = regexp.MustCompile("(?s)```(?:json)?\\s*(.*?)\\s*```")
 var taggedToolCallBlock = regexp.MustCompile(`(?s)<[^<>]*(?:tool_call|tool_calls|function=)[^<>]*>(.*?)</[^<>]*>`)
-var singleTaggedToolCall = regexp.MustCompile(`(?s)<(tool_call\b[^<>]*|[^<>]*function=[^<>]*)>(.*?)</[^<>]*>`)
+var singleTaggedToolCall = regexp.MustCompile(`(?s)<(tool_call\b[^<>]*|[^<>]*function\s*=[^<>]*)>(.*?)</[^<>]*>`)
+var taggedToolNameAttr = regexp.MustCompile(`(?i)(?:function|name|tool)\s*=\s*["\']?([^"\'\s>]+)`)
 
 type textToolCall struct {
 	ID        string         `json:"id"`
@@ -91,6 +93,7 @@ func textToolCallKey(call ai.ToolCall) string {
 }
 
 func parseTextToolCalls(text string, tools []ai.Tool) []ai.ToolCall {
+	text = html.UnescapeString(text)
 	allowed := textToolNames(tools)
 	if len(allowed) == 0 {
 		return nil
@@ -258,17 +261,11 @@ func decodeTaggedTextToolCalls(text string, allowed map[string]string) []ai.Tool
 }
 
 func taggedToolName(tag string) string {
-	for _, marker := range []string{"function=", "name=", "tool="} {
-		if idx := strings.Index(tag, marker); idx >= 0 {
-			name := strings.TrimSpace(tag[idx+len(marker):])
-			name = strings.Trim(name, `"'`)
-			if end := strings.IndexAny(name, " \t\r\n>"); end >= 0 {
-				name = name[:end]
-			}
-			return strings.Trim(name, `"'`)
-		}
+	match := taggedToolNameAttr.FindStringSubmatch(tag)
+	if len(match) < 2 {
+		return ""
 	}
-	return ""
+	return strings.Trim(match[1], `"'`)
 }
 
 func firstNestedToolCalls(m map[string]any) (any, bool) {

--- a/agent/text_tool_calls_test.go
+++ b/agent/text_tool_calls_test.go
@@ -75,3 +75,35 @@ func TestParseTextToolCallsOpenAICompatibleFunctionArgumentsString(t *testing.T)
 		t.Fatalf("to = %v, want blocked-reviewer", got)
 	}
 }
+
+func TestParseTextToolCallsTaggedMarkupWithSpacedNameAttribute(t *testing.T) {
+	tools := []ai.Tool{{Name: "delegate"}}
+	reply := `<tool_call name = "delegate">{"task":"summarize the conformance marker","to":"blocked-reviewer"}</tool_call>`
+
+	calls := parseTextToolCalls(reply, tools)
+	if len(calls) != 1 {
+		t.Fatalf("parseTextToolCalls returned %d calls, want 1: %+v", len(calls), calls)
+	}
+	if calls[0].Name != "delegate" {
+		t.Fatalf("call name = %q, want delegate", calls[0].Name)
+	}
+	if got := calls[0].Input["to"]; got != "blocked-reviewer" {
+		t.Fatalf("to = %v, want blocked-reviewer", got)
+	}
+}
+
+func TestParseTextToolCallsHTMLEscapedTaggedMarkup(t *testing.T) {
+	tools := []ai.Tool{{Name: "delegate"}}
+	reply := `&lt;tool_call name=&quot;delegate&quot;&gt;{"task":"summarize the conformance marker","to":"blocked-reviewer"}&lt;/tool_call&gt;`
+
+	calls := parseTextToolCalls(reply, tools)
+	if len(calls) != 1 {
+		t.Fatalf("parseTextToolCalls returned %d calls, want 1: %+v", len(calls), calls)
+	}
+	if calls[0].Name != "delegate" {
+		t.Fatalf("call name = %q, want delegate", calls[0].Name)
+	}
+	if got := calls[0].Input["task"]; got != "summarize the conformance marker" {
+		t.Fatalf("task = %v, want summarize the conformance marker", got)
+	}
+}


### PR DESCRIPTION
Summary:
- Harden text-encoded tool-call parsing to accept HTML-escaped tagged markup and spaced tool/function/name attributes.
- Add parser coverage for AtlasCloud/minimax delegate fallback formats.

Testing:
- go build ./...
- go test ./... (fails in this sandbox due loopback/network restrictions unrelated to this change: AtlasCloud stream test reached live endpoint without credentials; grpc loopback targets are blocked by the environment)
- golangci-lint run ./...

Closes #4244
Closes #4269