### PR TITLE
CI-verify first-agent scaffold in 0-to-hero harness

### DIFF
--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -4,19 +4,21 @@ This directory owns the no-secret reference scenario for the Go Micro
 services → agents → workflows lifecycle. It is intentionally small and
 scripted so CI can run it on every push without external services or model keys.
 
-`run.sh` verifies five boundaries together:
+`run.sh` verifies the complete first-agent 0→hero contract together:
 
-1. **First agent** — `micro new`, `micro agent preflight`, `micro run`,
-   `micro chat`, and `micro inspect agent <name>` remain available as the
-   documented first-agent walkthrough path.
-2. **Run** — `micro run` remains available as the local development entry point.
-3. **Chat** — `micro chat` remains available as the interactive agent entry point.
-4. **Inspect/debugging** — `micro inspect agent <name>`, `micro agent history <name>`,
+1. **Scaffold** — the maintained `micro new` 0→1 contract still creates
+   runnable services from a clean workspace.
+2. **First agent** — `micro agent preflight`, `micro run`, `micro chat`, and
+   `micro inspect agent <name>` remain available as the documented first-agent
+   walkthrough path.
+3. **Run** — `micro run` remains available as the local development entry point.
+4. **Chat** — `micro chat` remains available as the interactive agent entry point.
+5. **Inspect/debugging** — `micro inspect agent <name>`, `micro agent history <name>`,
    and `micro inspect flow <name>` remain available as the local run-history
    inspection step. The no-secret debugging smoke seeds durable agent run history
    and memory, then runs the documented inspect/history commands without provider
    credentials; `micro flow runs` preserves durable workflow history inspection.
-5. **Deploy** — `micro deploy --dry-run <target>` remains available as the
+6. **Deploy** — `micro deploy --dry-run <target>` remains available as the
    deployment-boundary checkpoint. The dry run resolves configured deploy targets
    and services and prints the remote build/copy/systemd/health plan without
    building binaries, opening SSH connections, running `rsync`, or touching

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -38,6 +38,19 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 		}
 	}
 
+	runScript := readFile(t, filepath.Join(root, "internal", "harness", "zero-to-hero-ci", "run.sh"))
+	for _, want := range []string{
+		"go test ./cmd/micro/cli/new -run TestZeroToOne -count=1",
+		"go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestZeroToHeroCLIBoundaries' -count=1",
+		"go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1",
+		"go test ./examples/first-agent -run TestRunFirstAgent -count=1",
+		"go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1",
+	} {
+		if !strings.Contains(runScript, want) {
+			t.Fatalf("0→hero CI run script missing lifecycle command %q", want)
+		}
+	}
+
 	readme := readFile(t, filepath.Join(root, "README.md"))
 	if !strings.Contains(readme, "internal/website/docs/guides/zero-to-hero.md") {
 		t.Fatal("README does not point to the canonical 0→hero guide")

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -6,6 +6,7 @@ cd "$ROOT"
 
 # Keep the developer inner-loop boundaries executable and discoverable in CI
 # without secrets or long-running daemons.
+go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
 go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestZeroToHeroCLIBoundaries' -count=1
 go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
 go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscript|TestNoSecretFirstAgentDebuggingSmoke|TestZeroToHeroReferenceDocs|TestYourFirstAgentTutorialSmoke' -count=1


### PR DESCRIPTION
Summary:
- Add the maintained micro new 0→1 scaffold contract to the zero-to-hero CI script so scaffold → run/chat → inspect → deploy dry-run is verified from one provider-free entry point.
- Add a docs guard that fails if the zero-to-hero script drops scaffold, CLI, deploy, first-agent, or support-example checks.
- Update the harness README to describe the full first-agent 0→hero contract.

Testing:
- go test ./internal/harness/zero-to-hero-ci -run TestZeroToHeroReferenceDocs -count=1
- ./internal/harness/zero-to-hero-ci/run.sh
- go build ./...
- go test ./... (fails in this environment: atlascloud live stream endpoint returned 400, and loopback gRPC tests were blocked by Envoy)
- golangci-lint run ./...

Closes #4272
Closes #4278