### PR TITLE
Add agent debugging quickcheck docs

### DIFF
--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -32,8 +32,10 @@ and A2A with only the LLM mocked.
 
 The default GitHub harness workflow runs this script on every push and pull
 request after the install smoke check and 0→1 scaffold contract. Developers can
-verify the installer seam alone with `make install-smoke`, or run the same
-no-secret contract locally with:
+verify the installer seam alone with `make install-smoke`, run just the documented
+agent debugging quickcheck with
+`go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1`,
+or run the same no-secret contract locally with:
 
 ```sh
 make harness

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -620,6 +620,24 @@ func TestNoSecretFirstAgentTranscript(t *testing.T) {
 		}
 	}
 
+	debuggingGuide := readFile(t, filepath.Join(root, "internal", "website", "docs", "guides", "debugging-agents.md"))
+	for _, want := range []string{
+		"Provider-free quickcheck",
+		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1",
+		"micro inspect agent assistant --limit 1",
+		"micro inspect agent --status done",
+		"micro agent history assistant",
+	} {
+		if !strings.Contains(debuggingGuide, want) {
+			t.Fatalf("debugging guide missing provider-free quickcheck marker %q", want)
+		}
+	}
+
+	harnessReadme := readFile(t, filepath.Join(root, "internal", "harness", "zero-to-hero-ci", "README.md"))
+	if !strings.Contains(harnessReadme, "go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1") {
+		t.Fatal("0→hero harness README does not expose the agent debugging quickcheck command")
+	}
+
 	readme := readFile(t, filepath.Join(root, "README.md"))
 	if !strings.Contains(readme, "internal/website/docs/guides/no-secret-first-agent.md") {
 		t.Fatal("README does not point to the no-secret first-agent transcript")

--- a/internal/website/docs/guides/debugging-agents.md
+++ b/internal/website/docs/guides/debugging-agents.md
@@ -116,6 +116,18 @@ state (`agent/<name>/runs/...`). The persisted timeline is recorded even without
 an OpenTelemetry exporter, so `micro inspect agent` remains useful in local
 no-secret development.
 
+Provider-free quickcheck: if you want to verify the documented inspect path
+before involving a live model, run the same smoke check CI uses:
+
+```sh
+go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1
+```
+
+That test seeds a local `assistant` run history and memory transcript, then runs
+`micro inspect agent assistant --limit 1`, `micro inspect agent --status done
+--json assistant`, and `micro agent history assistant` with provider credentials
+cleared.
+
 ## 4. See tool calls as they happen
 
 When you are embedding an agent in Go and need live tool visibility, use the


### PR DESCRIPTION
Summary:
- Document the provider-free agent debugging quickcheck in the debugging guide.
- Expose the exact quickcheck command from the 0→hero harness README.
- Extend harness docs tests so guide and harness wayfinding stay aligned with the verified inspect/history commands.

Testing:
- go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscript|TestNoSecretFirstAgentDebuggingSmoke' -count=1\n- go build ./...\n- go test ./... (fails in this environment: atlascloud stream 400 and loopback targets forbidden for grpc tests)\n- golangci-lint run ./...\n\nCloses #4274\nCloses #4284