### PR TITLE
Wire universe harness to the shared broker

### DIFF
--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -414,7 +414,7 @@ func runUniverse(provider string) int {
 	// Services.
 	inv, pay, ord, ntf := new(Inventory), new(Payment), new(Orders), new(Notify)
 	for name, h := range map[string]any{"inventory": inv, "payment": pay, "orders": ord, "notify": ntf} {
-		svc := service.New(service.Name(name), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
+		svc := service.New(service.Name(name), service.Address("127.0.0.1:0"), service.Registry(reg), service.Broker(br), service.Client(cl))
 		svc.Handle(h)
 		go svc.Run()
 	}
@@ -429,6 +429,7 @@ func runUniverse(provider string) int {
 		agent.Address("127.0.0.1:0"),
 		agent.Provider(provider), agent.APIKey(apiKey),
 		agent.MaxSteps(5),
+		agent.WithBroker(br),
 		agent.WrapTool(func(next ai.ToolHandler) ai.ToolHandler {
 			return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
 				atomic.AddInt64(&wrapped, 1)


### PR DESCRIPTION
## Summary
- Wire universe harness RPC services to the same in-memory broker used by the flow trigger.
- Wire the concierge agent endpoint to that broker too, keeping the no-secret end-to-end harness on one shared in-process transport plane.

Closes #4283
Closes #4288

## Testing
- go test -v -timeout 90s ./internal/harness/universe
- go build ./...
- go test ./... (fails in this environment: AtlasCloud configured-provider stream returned 400, and grpc loopback tests are blocked by local envoy: Loopback targets forbidden)
- golangci-lint run ./...
