### PR TITLE
Fix plan-delegate notify recovery

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -484,7 +484,7 @@ func runPlanDelegate(provider string) error {
 		flow.Steps(
 			flow.Step{Name: "conductor", Run: planDelegateConductorStep(conductor)},
 			flow.Step{Name: "require-notify", Run: requireDelegatedNotifyStep(taskSvc, notifySvc, func(ctx context.Context) error {
-				_, err := conductor.Ask(ctx, "The Design, Build, and Ship tasks already exist, but the owner notification is still missing. Delegate exactly one notification to the \"comms\" agent now with this exact subtask: "+delegatedNotifyTask+" Do not create more tasks and do not answer until comms has handled the notification.")
+				_, err := comms.Ask(ctx, "Send exactly one owner readiness notification now with this exact task: "+delegatedNotifyTask+" Use the notify service and do not answer until the notification has been sent.")
 				return err
 			})},
 		),
@@ -553,6 +553,13 @@ func requireDelegatedNotifyStep(taskSvc *TaskService, notifySvc *NotifyService, 
 			fmt.Print("\n\033[33mwarning:\033[0m conductor step completed before delegated notify; retrying the missing comms handoff once before the flow can complete.\n")
 			if err := recoverMissingNotify(ctx); err != nil {
 				return in, fmt.Errorf("delegation completed without required notify side effect and recovery failed: notify=%d, want 1: %w", notify, err)
+			}
+			settled, err = waitForNotifySideEffect(notifySvc, delegatedNotifySettleTimeout)
+			if err != nil {
+				return in, err
+			}
+			if !settled {
+				return in, fmt.Errorf("delegation recovery completed without required notify side effect: notify=%d, want 1", notifySvc.count())
 			}
 		}
 		if notify = notifySvc.count(); notify != 1 {

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -367,6 +367,37 @@ func TestPlanDelegateExecutionWaitsForInFlightNotifyAfterFlowCompletion(t *testi
 	}
 }
 
+func TestPlanDelegateRecoveryWaitsForRecoveredNotifySideEffect(t *testing.T) {
+	taskSvc := new(TaskService)
+	for _, title := range []string{"Design", "Build", "Ship"} {
+		var rsp AddResponse
+		if err := taskSvc.Add(context.Background(), &AddRequest{Title: title}, &rsp); err != nil {
+			t.Fatalf("Add(%q): %v", title, err)
+		}
+	}
+	notifySvc := new(NotifyService)
+
+	recovered := false
+	_, err := requireDelegatedNotifyStep(taskSvc, notifySvc, func(ctx context.Context) error {
+		recovered = true
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			var rsp SendResponse
+			_ = notifySvc.Send(ctx, &SendRequest{To: "owner@acme.com", Message: "The launch plan is ready"}, &rsp)
+		}()
+		return nil
+	})(context.Background(), flow.State{})
+	if err != nil {
+		t.Fatalf("requireDelegatedNotifyStep returned %v, want delayed recovery success", err)
+	}
+	if !recovered {
+		t.Fatal("missing notify recovery did not run")
+	}
+	if got := notifySvc.count(); got != 1 {
+		t.Fatalf("notify count = %d, want recovered notify side effect", got)
+	}
+}
+
 func TestPlanDelegateExecutionAcceptsClientTimeoutAfterSideEffects(t *testing.T) {
 	taskSvc := new(TaskService)
 	for _, title := range []string{"Design", "Build", "Ship"} {


### PR DESCRIPTION
## Summary
- Recover missing plan-delegate notify side effects by retrying through the comms agent that owns notify.
- Wait for recovered notify side effects to settle before failing the harness step.
- Add coverage for delayed recovered notify side effects.

Closes #4277
Closes #4298

## Testing
- go build ./...
- go test ./internal/harness/plan-delegate -run 'TestPlanDelegateExecutionWaitsForInFlightNotifyAfterFlowCompletion|TestPlanDelegateRecoveryWaitsForRecoveredNotifySideEffect|TestPlanDelegateExecutionAcceptsClientTimeoutAfterSideEffects|TestPlanDelegateExecutionClassifiesClientTimeoutBeforeSideEffects|TestPlanDelegateExecutionClassifiesPartialClientTimeout' -count=1\n- go test ./... (fails in this environment: AtlasCloud live stream without usable credentials and loopback targets forbidden for grpc tests)\n- golangci-lint run ./...