### PR TITLE
CI-verify first-agent docs wayfinding links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -X $(GIT_IMPORT).BuildDate=$(BUILD_DATE) -X $(GIT_IMPORT).GitCommit=$(
 # GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser-cross:v1.25.7
 GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser:latest
 
-.PHONY: test test-race test-coverage harness install-smoke provider-conformance-mock provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
+.PHONY: test test-race test-coverage harness docs-wayfinding install-smoke provider-conformance-mock provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
 
 # Default target
 help:
@@ -19,6 +19,7 @@ help:
 	@echo "  make test-coverage - Run tests with coverage"
 	@echo "  make lint          - Run linter"
 	@echo "  make harness       - Run deterministic getting-started and end-to-end harnesses"
+	@echo "  make docs-wayfinding - Verify first-agent docs wayfinding links resolve locally"
 	@echo "  make install-smoke - Verify the local install.sh and first-run CLI smoke path"
 	@echo "  make provider-conformance-mock - Run cross-provider harness with deterministic mock provider"
 	@echo "  make provider-conformance - Run harnesses against configured live providers"
@@ -49,11 +50,18 @@ test-coverage:
 # This mirrors the default CI path so local dogfooding catches scaffold,
 # run/chat/inspect, and 0→hero regressions before a PR is opened.
 harness:
+	$(MAKE) docs-wayfinding
 	$(MAKE) install-smoke
 	go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
 	./internal/harness/zero-to-hero-ci/run.sh
 	go run ./internal/harness/agent-flow
 	$(MAKE) provider-conformance-mock
+
+# Verify the README and website first-agent/0→hero wayfinding links resolve to
+# maintained local docs and examples. This is a focused no-network guard for the
+# developer-adoption on-ramp.
+docs-wayfinding:
+	go test ./internal/harness/zero-to-hero-ci -run 'TestFirstAgentWayfindingDocs|TestFirstAgentWayfindingLinkTargetsResolve' -count=1
 
 # Verify the documented install script and first-run CLI command boundaries without
 # provider keys or network access.
@@ -110,4 +118,3 @@ gorelease-dry-run:
 		-w /$(NAME) \
 		$(GORELEASER_DOCKER_IMAGE) \
 		--clean --verbose --skip=publish,validate --snapshot
-

--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -32,7 +32,8 @@ and A2A with only the LLM mocked.
 
 The default GitHub harness workflow runs this script on every push and pull
 request after the install smoke check and 0→1 scaffold contract. Developers can
-verify the installer seam alone with `make install-smoke`, run just the documented
+verify the first-agent on-ramp links alone with `make docs-wayfinding`, verify
+the installer seam alone with `make install-smoke`, run just the documented
 agent debugging quickcheck with
 `go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1`,
 or run the same no-secret contract locally with:
@@ -41,9 +42,9 @@ or run the same no-secret contract locally with:
 make harness
 ```
 
-That target intentionally exercises the install script smoke path, both 0→1
-scaffold variants, the 0→hero scenario, the event-driven agent-flow harness, and
-mock provider conformance, so
+That target intentionally exercises the first-agent docs wayfinding guard, the
+install script smoke path, both 0→1 scaffold variants, the 0→hero scenario, the
+event-driven agent-flow harness, and mock provider conformance, so
 the public scaffold → run/chat → inspect → deploy lifecycle stays executable
 outside CI as well. Live provider checks remain separate and gated by configured
 API keys (`make provider-conformance` or the scheduled/manual CI job).


### PR DESCRIPTION
Summary:
- Add make docs-wayfinding as a focused no-network guard for the first-agent/0→hero docs on-ramp.
- Wire the guard into make harness so the local CI-equivalent path catches README and website link drift.
- Document the focused command in the 0→hero CI harness README.

Testing:
- make docs-wayfinding
- go build ./...
- go test ./... (fails in this sandbox: configured AtlasCloud credentials return 400 and loopback gRPC targets are blocked by the environment)
- golangci-lint run ./...

Closes #4291
Closes #4302