### PR TITLE
Avoid stale memory on stream fallback

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -227,16 +227,18 @@ func (a *agentImpl) Stream(ctx context.Context, message string) (ai.Stream, erro
 	if err != nil {
 		return nil, fmt.Errorf("discover tools: %w", err)
 	}
-	a.mem.Add("user", message)
+	messages := append([]ai.Message(nil), a.mem.Messages()...)
+	messages = append(messages, ai.Message{Role: "user", Content: message})
 	stream, err := a.model.Stream(ctx, &ai.Request{
 		Prompt:       message,
 		SystemPrompt: a.buildPrompt(),
 		Tools:        toolList,
-		Messages:     a.mem.Messages(),
+		Messages:     messages,
 	})
 	if err != nil {
 		return nil, err
 	}
+	a.mem.Add("user", message)
 	return &memoryRecordingStream{stream: stream, memory: a.mem}, nil
 }
 

--- a/agent/stream_test.go
+++ b/agent/stream_test.go
@@ -243,6 +243,29 @@ func TestResumeStreamAskDoesNotReplayCompletedTool(t *testing.T) {
 	}
 }
 
+func TestAgentStreamDoesNotRecordUserWhenProviderStreamingUnsupported(t *testing.T) {
+	fakeStream = func(ctx context.Context, opts ai.Options, req *ai.Request) (ai.Stream, error) {
+		if len(req.Messages) == 0 || req.Messages[len(req.Messages)-1].Role != "user" || req.Messages[len(req.Messages)-1].Content != "stream fallback" {
+			t.Fatalf("stream request messages = %+v, want pending user message", req.Messages)
+		}
+		return nil, ai.ErrStreamingUnsupported
+	}
+	defer func() { fakeStream = nil }()
+
+	mem := NewInMemory(8)
+	a := newTestAgent(Name("stream-fallback"), WithMemory(mem), WithTool("echo", "echo text", nil, func(context.Context, map[string]any) (string, error) {
+		return "ok", nil
+	}))
+
+	_, err := a.Stream(context.Background(), "stream fallback")
+	if !errors.Is(err, ai.ErrStreamingUnsupported) {
+		t.Fatalf("Stream error = %v, want ErrStreamingUnsupported", err)
+	}
+	if got := mem.Messages(); len(got) != 0 {
+		t.Fatalf("memory after unsupported stream = %+v, want no recorded messages", got)
+	}
+}
+
 type unsupportedAgent struct{}
 
 func (unsupportedAgent) Name() string                                      { return "unsupported" }


### PR DESCRIPTION
## Summary
- Keep provider streaming requests stateless until the stream is successfully opened, so unsupported streaming paths do not leave a duplicate user turn before A2A falls back to Ask.
- Add regression coverage for unsupported provider streams preserving the pending request message without recording failed stream attempts in agent memory.

Closes #4297
Closes #4312

## Testing
- go test ./agent ./gateway/a2a ./ai/atlascloud ./internal/harness/a2a-stream-fallback
- go build ./...
- go test ./... (fails in this sandbox: configured AtlasCloud stream check returns 400 for the available env model/key; local loopback gRPC tests are blocked by the environment proxy)
- golangci-lint run ./...
- go run ./internal/harness/provider-conformance -providers mock -harnesses a2a-stream-fallback