### PR TITLE
Propagate provider HTTP retry signals

### DIFF
--- a/ai/anthropic/anthropic.go
+++ b/ai/anthropic/anthropic.go
@@ -297,7 +297,7 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 	// Read response
 	respBody, _ := io.ReadAll(httpResp.Body)
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+		return nil, nil, ai.NewHTTPError(httpResp, respBody)
 	}
 
 	// Parse response

--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -327,15 +327,30 @@ func (s *atlasStream) Close() error {
 }
 
 type atlascloudAPIError struct {
-	Status     string
-	StatusCode int
-	Phase      string
-	Summary    string
-	Body       string
+	Status  string
+	Code    int
+	Retry   time.Duration
+	Phase   string
+	Summary string
+	Body    string
 }
 
 func (e *atlascloudAPIError) Error() string {
 	return fmt.Sprintf("API error (%s) during atlascloud %s request (%s): %s", e.Status, e.Phase, e.Summary, e.Body)
+}
+
+func (e *atlascloudAPIError) StatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.Code
+}
+
+func (e *atlascloudAPIError) RetryAfter() time.Duration {
+	if e == nil {
+		return 0
+	}
+	return e.Retry
 }
 
 func (p *Provider) callAPI(ctx context.Context, phase string, req map[string]any) (*ai.Response, map[string]any, error) {
@@ -361,7 +376,12 @@ func (p *Provider) callAPI(ctx context.Context, phase string, req map[string]any
 
 	respBody, _ := io.ReadAll(httpResp.Body)
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, nil, &atlascloudAPIError{Status: httpResp.Status, StatusCode: httpResp.StatusCode, Phase: phase, Summary: atlascloudRequestSummary(req), Body: string(respBody)}
+		retryAfter := time.Duration(0)
+		var retryErr interface{ RetryAfter() time.Duration }
+		if errors.As(ai.NewHTTPError(httpResp, respBody), &retryErr) {
+			retryAfter = retryErr.RetryAfter()
+		}
+		return nil, nil, &atlascloudAPIError{Status: httpResp.Status, Code: httpResp.StatusCode, Retry: retryAfter, Phase: phase, Summary: atlascloudRequestSummary(req), Body: string(respBody)}
 	}
 
 	var chatResp struct {
@@ -439,7 +459,7 @@ func atlascloudShouldRetryMinimaxCompat(err error, compatTools []map[string]any)
 		return false
 	}
 	var apiErr *atlascloudAPIError
-	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusBadRequest
+	return errors.As(err, &apiErr) && apiErr.StatusCode() == http.StatusBadRequest
 }
 
 func atlascloudShouldRetryWithoutTools(err error, req map[string]any) bool {
@@ -447,7 +467,7 @@ func atlascloudShouldRetryWithoutTools(err error, req map[string]any) bool {
 		return false
 	}
 	var apiErr *atlascloudAPIError
-	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusBadRequest
+	return errors.As(err, &apiErr) && apiErr.StatusCode() == http.StatusBadRequest
 }
 
 func atlascloudTools(input []ai.Tool) []map[string]any {

--- a/ai/gemini/gemini.go
+++ b/ai/gemini/gemini.go
@@ -163,7 +163,7 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 
 	respBody, _ := io.ReadAll(httpResp.Body)
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+		return nil, nil, ai.NewHTTPError(httpResp, respBody)
 	}
 
 	var geminiResp struct {

--- a/ai/groq/groq.go
+++ b/ai/groq/groq.go
@@ -147,7 +147,7 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 
 	respBody, _ := io.ReadAll(httpResp.Body)
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+		return nil, nil, ai.NewHTTPError(httpResp, respBody)
 	}
 
 	var chatResp struct {

--- a/ai/minimax/minimax.go
+++ b/ai/minimax/minimax.go
@@ -147,7 +147,7 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 
 	respBody, _ := io.ReadAll(httpResp.Body)
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+		return nil, nil, ai.NewHTTPError(httpResp, respBody)
 	}
 
 	var chatResp struct {

--- a/ai/mistral/mistral.go
+++ b/ai/mistral/mistral.go
@@ -147,7 +147,7 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 
 	respBody, _ := io.ReadAll(httpResp.Body)
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+		return nil, nil, ai.NewHTTPError(httpResp, respBody)
 	}
 
 	var chatResp struct {

--- a/ai/openai/openai.go
+++ b/ai/openai/openai.go
@@ -285,7 +285,7 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 	// Read response
 	respBody, _ := io.ReadAll(httpResp.Body)
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+		return nil, nil, ai.NewHTTPError(httpResp, respBody)
 	}
 
 	// Parse response

--- a/ai/retry.go
+++ b/ai/retry.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -17,6 +19,64 @@ type StatusCoder interface {
 // supplied retry delay, such as HTTP Retry-After on a 429/503 response.
 type RetryAfterCoder interface {
 	RetryAfter() time.Duration
+}
+
+// HTTPError describes a failed provider HTTP response while preserving the
+// status code and Retry-After signal for retry classifiers.
+type HTTPError struct {
+	Status string
+	Code   int
+	Body   string
+	Header http.Header
+}
+
+func (e *HTTPError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("API error (%s): %s", e.Status, e.Body)
+}
+
+func (e *HTTPError) StatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.Code
+}
+
+func (e *HTTPError) RetryAfter() time.Duration {
+	if e == nil {
+		return 0
+	}
+	return parseRetryAfter(e.Header.Get("Retry-After"), time.Now())
+}
+
+func NewHTTPError(resp *http.Response, body []byte) error {
+	if resp == nil {
+		return errors.New("API error: nil response")
+	}
+	return &HTTPError{Status: resp.Status, Code: resp.StatusCode, Body: string(body), Header: resp.Header.Clone()}
+}
+
+func parseRetryAfter(value string, now time.Time) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0
+	}
+	if delay := when.Sub(now); delay > 0 {
+		return delay
+	}
+	return 0
 }
 
 // ErrorKind classifies provider-boundary failures into stable buckets callers

--- a/ai/retry_test.go
+++ b/ai/retry_test.go
@@ -3,6 +3,7 @@ package ai
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -219,5 +220,25 @@ func TestGenerateWithRetryHonorsRetryAfterWhenLongerThanBackoff(t *testing.T) {
 func TestGenerateWithRetryCapsRetryAfter(t *testing.T) {
 	if got := retryBackoff(retryAfterErr{delay: time.Minute}, 1, time.Millisecond); got != 30*time.Second {
 		t.Fatalf("retryBackoff() = %s, want 30s cap", got)
+	}
+}
+
+func TestHTTPErrorExposesStatusAndRetryAfter(t *testing.T) {
+	resp := &http.Response{
+		Status:     "429 Too Many Requests",
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"2"}},
+	}
+	err := NewHTTPError(resp, []byte("slow down"))
+
+	if got := ClassifyError(err); got != ErrorKindRateLimited {
+		t.Fatalf("ClassifyError() = %q, want %q", got, ErrorKindRateLimited)
+	}
+	var retryAfter RetryAfterCoder
+	if !errors.As(err, &retryAfter) {
+		t.Fatalf("NewHTTPError does not expose RetryAfterCoder")
+	}
+	if got := retryAfter.RetryAfter(); got != 2*time.Second {
+		t.Fatalf("RetryAfter() = %s, want 2s", got)
 	}
 }

--- a/ai/together/together.go
+++ b/ai/together/together.go
@@ -147,7 +147,7 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 
 	respBody, _ := io.ReadAll(httpResp.Body)
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("API error (%s): %s", httpResp.Status, string(respBody))
+		return nil, nil, ai.NewHTTPError(httpResp, respBody)
 	}
 
 	var chatResp struct {


### PR DESCRIPTION
## Summary
- Preserve HTTP status codes and Retry-After headers from provider model-call failures so retry classification and backoff can respond to rate limits and unavailable providers.
- Wire OpenAI-compatible, Anthropic, Gemini, and AtlasCloud chat model calls to return typed provider HTTP errors.
- Add coverage for provider HTTP retry signal classification.

## Testing
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in grpc client/transport tests; AtlasCloud stream conformance hit live 400 with configured credentials)
- golangci-lint run ./...

Closes #4273
Closes #4317