### PR TITLE
Verify zero-to-hero deploy dry-run

### DIFF
--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -62,6 +62,62 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 	}
 }
 
+func TestZeroToHeroDeployDryRunCommandSmoke(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	bin := filepath.Join(t.TempDir(), "micro")
+	build := exec.Command("go", "build", "-o", bin, "./cmd/micro")
+	build.Dir = absRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build micro CLI for deploy dry-run smoke: %v\n%s", err, out)
+	}
+
+	workspace := t.TempDir()
+	writeFile(t, filepath.Join(workspace, "micro.mu"), `service api
+    path ./api
+
+deploy prod
+    ssh deploy@prod.example.com
+    path /srv/micro
+`)
+	if err := os.Mkdir(filepath.Join(workspace, "api"), 0o755); err != nil {
+		t.Fatalf("create service dir: %v", err)
+	}
+
+	cmd := exec.Command(bin, "deploy", "--dry-run", "prod")
+	cmd.Dir = workspace
+	cmd.Env = append(os.Environ(), "MICRO_CONFIG_FILE="+filepath.Join(workspace, "micro.mu"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("documented deploy dry-run command failed: %v\n%s", err, out)
+	}
+
+	got := string(out)
+	for _, want := range []string{
+		"micro deploy --dry-run",
+		"Target",
+		"deploy@prod.example.com",
+		"Remote path",
+		"/srv/micro",
+		"Services",
+		"api",
+		"No SSH, rsync, systemd, or remote deployment was performed.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("deploy dry-run output missing %q:\n%s", want, got)
+		}
+	}
+
+	guide := readFile(t, filepath.Join(absRoot, "internal", "website", "docs", "guides", "zero-to-hero.md"))
+	if !strings.Contains(guide, "micro deploy --dry-run prod") {
+		t.Fatal("0→hero guide must document the same deploy dry-run command covered by CI")
+	}
+}
+
 func TestGuidesNavigationLeadsWithDoing(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", "..", ".."))
 	nav := readFile(t, filepath.Join(root, "internal", "website", "_data", "navigation.yml"))

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -9,7 +9,7 @@ cd "$ROOT"
 go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
 go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestZeroToHeroCLIBoundaries' -count=1
 go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
-go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscript|TestNoSecretFirstAgentDebuggingSmoke|TestZeroToHeroReferenceDocs|TestYourFirstAgentTutorialSmoke' -count=1
+go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscript|TestNoSecretFirstAgentDebuggingSmoke|TestZeroToHeroReferenceDocs|TestZeroToHeroDeployDryRunCommandSmoke|TestYourFirstAgentTutorialSmoke' -count=1
 
 # Deterministic no-secret reference scenarios. These use the real Go Micro
 # runtime and mock only the LLM provider. The support example is the maintained

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -23,7 +23,7 @@ cloud credentials?"
 | Run | `micro run` remains the local development entry point. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
 | Chat | `micro chat` remains the interactive agent entry point. | `go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1` |
 | Inspect | `micro inspect agent <name>`, `micro agent history <name>`, `micro inspect flow <flow>`, and `micro flow runs <flow>` remain discoverable for run history; the no-secret debugging smoke seeds durable agent history and runs the documented inspect/history commands without provider keys. | `go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1` |
-| Deploy | `micro deploy --dry-run` resolves deploy targets without touching remote infrastructure. | `go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1` |
+| Deploy | `micro deploy --dry-run prod` resolves the documented deploy target without touching remote infrastructure. | `go test ./internal/harness/zero-to-hero-ci -run TestZeroToHeroDeployDryRunCommandSmoke -count=1` |
 | Smallest first agent | `examples/first-agent` runs one service-backed agent with a deterministic mock model and no provider key. | `go test ./examples/first-agent -run TestRunFirstAgent -count=1` |
 | Runtime reference app | `examples/support` runs typed services, an agent using those services as tools, an event-driven flow handoff, and an approval gate with only the model mocked. | `go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1` |
 | Runtime harnesses | Real services, agents, durable flows, store-backed history, delegation, and A2A run with only the model mocked. | `./internal/harness/zero-to-hero-ci/run.sh` and `make provider-conformance-mock` |
@@ -84,6 +84,7 @@ go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1
 # CLI inner-loop commands: run, chat, inspect, flow runs, deploy --dry-run.
 go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1
 go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
+go test ./internal/harness/zero-to-hero-ci -run TestZeroToHeroDeployDryRunCommandSmoke -count=1
 
 # Smallest no-secret service-backed first agent.
 go test ./examples/first-agent -run TestRunFirstAgent -count=1


### PR DESCRIPTION
Summary:
- Add a CI smoke test that builds the micro CLI and runs the documented `micro deploy --dry-run prod` command against a hermetic deploy target.
- Wire the new check into the zero-to-hero harness and document the focused command in the 0→hero guide.

Testing:
- PASS: go build ./...
- PASS: go test ./internal/harness/zero-to-hero-ci -run TestZeroToHeroDeployDryRunCommandSmoke -count=1
- WARN: go test ./... (environment blocks loopback grpc targets; atlascloud live provider env returned 400)
- PASS: golangci-lint run ./...

Closes #4309
Closes #4329