### PR TITLE
Stabilize plan-delegate notify recovery

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -482,7 +482,7 @@ func runPlanDelegate(provider string) error {
 
 	f := flow.New("zero-to-hero",
 		flow.Steps(
-			flow.Step{Name: "conductor", Run: planDelegateConductorStep(conductor)},
+			flow.Step{Name: "conductor", Run: planDelegateConductorStep(conductor, taskSvc, notifySvc)},
 			flow.Step{Name: "require-notify", Run: requireDelegatedNotifyStep(taskSvc, notifySvc, func(ctx context.Context) error {
 				_, err := comms.Ask(ctx, "Send exactly one owner readiness notification now with this exact task: "+delegatedNotifyTask+" Use the notify service and do not answer until the notification has been sent.")
 				return err
@@ -521,11 +521,15 @@ func runPlanDelegate(provider string) error {
 	return nil
 }
 
-func planDelegateConductorStep(conductor agent.Agent) flow.StepFunc {
+func planDelegateConductorStep(conductor agent.Agent, taskSvc *TaskService, notifySvc *NotifyService) flow.StepFunc {
 	return func(ctx context.Context, in flow.State) (flow.State, error) {
 		prompt := "Create three launch tasks (Design, Build, Ship), then make sure owner@acme.com is notified: " + in.String()
 		rsp, err := conductor.Ask(ctx, prompt)
 		if err != nil {
+			if isUnfinishedPlanError(err) && taskSvc != nil && notifySvc != nil && taskSvc.count() == 3 && notifySvc.count() == 0 {
+				fmt.Printf("\n\033[33mwarning:\033[0m conductor stopped with unfinished delegation after creating tasks; continuing to require-notify recovery: %v\n", err)
+				return in, nil
+			}
 			return in, err
 		}
 		if rsp != nil && rsp.Reply != "" {
@@ -533,6 +537,13 @@ func planDelegateConductorStep(conductor agent.Agent) flow.StepFunc {
 		}
 		return in, nil
 	}
+}
+
+func isUnfinishedPlanError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "unfinished plan steps")
 }
 
 func requireDelegatedNotifyStep(taskSvc *TaskService, notifySvc *NotifyService, recoverMissingNotify func(context.Context) error) flow.StepFunc {

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -301,6 +301,45 @@ func TestPlanDelegateExecutionRejectsClaimedCompletionWithoutNotify(t *testing.T
 	}
 }
 
+type failingAgent struct {
+	err error
+}
+
+func (a failingAgent) Name() string                                         { return "failing" }
+func (a failingAgent) Init(...agent.Option)                                 {}
+func (a failingAgent) Options() agent.Options                               { return agent.Options{} }
+func (a failingAgent) Ask(context.Context, string) (*agent.Response, error) { return nil, a.err }
+func (a failingAgent) Stream(context.Context, string) (ai.Stream, error)    { return nil, a.err }
+func (a failingAgent) Run() error                                           { return nil }
+func (a failingAgent) Stop() error                                          { return nil }
+func (a failingAgent) String() string                                       { return "failing" }
+
+func TestPlanDelegateConductorAllowsNotifyRecoveryAfterUnfinishedDelegation(t *testing.T) {
+	taskSvc := new(TaskService)
+	for _, title := range []string{"Design", "Build", "Ship"} {
+		var rsp AddResponse
+		if err := taskSvc.Add(context.Background(), &AddRequest{Title: title}, &rsp); err != nil {
+			t.Fatalf("Add(%q): %v", title, err)
+		}
+	}
+	notifySvc := new(NotifyService)
+	step := planDelegateConductorStep(failingAgent{err: errors.New("agent run abc has unfinished plan steps: Delegate readiness notification to comms agent")}, taskSvc, notifySvc)
+	if _, err := step(context.Background(), flow.State{}); err != nil {
+		t.Fatalf("planDelegateConductorStep returned %v, want require-notify recovery to run", err)
+	}
+}
+
+func TestPlanDelegateConductorKeepsUnfinishedTaskFailureActionable(t *testing.T) {
+	step := planDelegateConductorStep(failingAgent{err: errors.New("agent run abc has unfinished plan steps: Create Build task")}, new(TaskService), new(NotifyService))
+	err := func() error { _, err := step(context.Background(), flow.State{}); return err }()
+	if err == nil {
+		t.Fatal("planDelegateConductorStep returned nil, want unfinished task error")
+	}
+	if got := err.Error(); !strings.Contains(got, "Create Build task") {
+		t.Fatalf("error = %q, want original unfinished task detail", got)
+	}
+}
+
 func TestPlanDelegateExecutionRecoversMissingNotifyOnce(t *testing.T) {
 	taskSvc := new(TaskService)
 	for _, title := range []string{"Design", "Build", "Ship"} {


### PR DESCRIPTION
## Summary
- Allow the plan-delegate flow to continue into require-notify recovery when the conductor has already created all three tasks but reports an unfinished delegated notification plan step.
- Add focused tests for the unfinished-delegation recovery path while preserving actionable failures for unfinished task creation.

Closes #4322
Closes #4338

## Testing
- go build ./...
- go test ./... (fails in this environment: atlascloud credential/config path returns 400; loopback gRPC targets are forbidden by envoy)
- golangci-lint run ./...
