### PR TITLE
Handle AtlasCloud Minimax service tool 400 fallback

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -96,6 +96,7 @@ func (p *Provider) String() string      { return "atlascloud" }
 func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (*ai.Response, error) {
 	tools := atlascloudTools(req.Tools)
 	compatTools, compatPrompt := atlascloudMinimaxCompatTools(p.opts.Model, req.Tools)
+	textToolPrompt := atlascloudMinimaxTextToolPrompt(p.opts.Model, req.Tools)
 
 	messages := []map[string]any{
 		{"role": "system", "content": req.SystemPrompt},
@@ -127,6 +128,11 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		if atlascloudShouldRetryMinimaxCompat(err, compatTools) {
 			apiReq["tools"] = compatTools
 			resp, rawMessage, err = p.callAPI(ctx, "chat-minimax-compat", apiReq)
+		}
+		if atlascloudShouldRetryMinimaxTextTools(err, textToolPrompt) {
+			delete(apiReq, "tools")
+			apiReq["messages"] = append(messages, map[string]any{"role": "system", "content": textToolPrompt})
+			resp, rawMessage, err = p.callAPI(ctx, "chat-minimax-text-tools", apiReq)
 		}
 		if err != nil {
 			return nil, err
@@ -447,6 +453,32 @@ func atlascloudMinimaxCompatTools(model string, input []ai.Tool) ([]map[string]a
 		"For built-in agent tools that are not listed natively (" + strings.Join(builtins, ", ") +
 		"), emit exactly <tool_call name=\"tool_name\">{...}</tool_call> so the agent runtime can execute them. Do not describe those built-in tool calls in prose instead of emitting the tag."
 	return atlascloudTools(native), prompt
+}
+
+func atlascloudMinimaxTextToolPrompt(model string, input []ai.Tool) string {
+	if !atlascloudIsMinimaxModel(model) || len(input) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(input))
+	for _, tool := range input {
+		if tool.Name != "" {
+			names = append(names, tool.Name)
+		}
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	return "AtlasCloud/minimax text-tool compatibility: the native tools payload was rejected. " +
+		"Call exactly one needed tool from this list by emitting exactly <tool_call name=\"tool_name\">{...}</tool_call>: " +
+		strings.Join(names, ", ") + ". Do not answer in prose instead of emitting the tag."
+}
+
+func atlascloudShouldRetryMinimaxTextTools(err error, prompt string) bool {
+	if prompt == "" {
+		return false
+	}
+	var apiErr *atlascloudAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode() == http.StatusBadRequest
 }
 
 func atlascloudIsMinimaxModel(model string) bool {

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -578,6 +578,60 @@ func TestProvider_GenerateRetriesMinimaxBuiltInsAsTextTools(t *testing.T) {
 	}
 }
 
+func TestProvider_GenerateRetriesMinimaxServiceToolsAsTextTools(t *testing.T) {
+	var bodies []map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		bodies = append(bodies, body)
+		w.Header().Set("Content-Type", "application/json")
+		switch len(bodies) {
+		case 1:
+			http.Error(w, `{"code":400,"msg":"bad request"}`, http.StatusBadRequest)
+		case 2:
+			if _, ok := body["tools"]; ok {
+				t.Fatalf("text-tool retry included native tools: %#v", body["tools"])
+			}
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"<tool_call name=\"conformance_echo\">{\"value\":\"agent-conformance\"}</tool_call>"}}]}`))
+		default:
+			t.Fatalf("unexpected API call %d", len(bodies))
+		}
+	}))
+	defer ts.Close()
+
+	p := NewProvider(ai.WithAPIKey("test-key"), ai.WithBaseURL(ts.URL), ai.WithModel("minimaxai/minimax-m3"))
+	resp, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "call a tool",
+		Tools: []ai.Tool{{
+			Name:        "conformance_echo",
+			Description: "echo conformance marker",
+			Properties:  map[string]any{"value": map[string]any{"type": "string"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if !strings.Contains(resp.Reply, `<tool_call name="conformance_echo">`) {
+		t.Fatalf("Reply = %q, want text service-tool fallback", resp.Reply)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("requests = %d, want initial plus text-tool retry", len(bodies))
+	}
+	if _, ok := bodies[0]["tools"].([]any); !ok {
+		t.Fatalf("initial request did not include native tools: %#v", bodies[0])
+	}
+	msgs := bodies[1]["messages"].([]any)
+	compat := msgs[len(msgs)-1].(map[string]any)
+	content := compat["content"].(string)
+	for _, want := range []string{"native tools payload was rejected", `<tool_call name="tool_name">`, "conformance_echo"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("text-tool instruction %q missing %q", content, want)
+		}
+	}
+}
+
 func TestProvider_GenerateFollowUpRetriesWithoutToolsOnBadRequest(t *testing.T) {
 	var bodies []map[string]any
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -643,7 +697,7 @@ func TestProvider_GenerateToolCallHTTPErrorIncludesRequestContext(t *testing.T) 
 	p := NewProvider(
 		ai.WithAPIKey("test-key"),
 		ai.WithBaseURL(ts.URL),
-		ai.WithModel("minimaxai/minimax-m3"),
+		ai.WithModel("deepseek-ai/DeepSeek-V3-0324"),
 	)
 	_, err := p.Generate(context.Background(), &ai.Request{
 		Prompt: "call a tool",
@@ -657,7 +711,7 @@ func TestProvider_GenerateToolCallHTTPErrorIncludesRequestContext(t *testing.T) 
 		t.Fatal("Generate error = nil, want 400")
 	}
 	msg := err.Error()
-	for _, want := range []string{"400 Bad Request", "atlascloud chat request", "model=minimaxai/minimax-m3", "tools=1", "tool_names=conformance_echo"} {
+	for _, want := range []string{"400 Bad Request", "atlascloud chat request", "model=deepseek-ai/DeepSeek-V3-0324", "tools=1", "tool_names=conformance_echo"} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("error %q missing %q", msg, want)
 		}


### PR DESCRIPTION
Summary:
- Add an AtlasCloud/minimax text-tool retry when native tool payloads are rejected with HTTP 400.
- Cover service-tool-only fallback behavior with provider tests.

Testing:
- go build ./...
- go test ./ai/atlascloud
- golangci-lint run ./...
- go test ./... (fails locally because the environment blocks loopback gRPC targets and the AtlasCloud stream skip test sees a live 400 without usable credentials.)

Closes #4354
Closes #4360