### PR TITLE
Fix AtlasCloud minimax tool follow-up retry

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -187,6 +187,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 			if err != nil {
 				if atlascloudShouldRetryWithoutTools(err, followUpReq) {
 					delete(followUpReq, "tools")
+					followUpReq["messages"] = atlascloudFollowUpMessagesWithoutTools(p.opts.Model, followUpMessages)
 					followUpResp, followUpRawMessage, err = p.callAPI(ctx, "tool-follow-up-no-tools", followUpReq)
 				}
 				if err != nil {
@@ -430,6 +431,52 @@ func (p *Provider) callAPI(ctx context.Context, phase string, req map[string]any
 	}
 
 	return response, rawMessage, nil
+}
+
+func atlascloudFollowUpMessagesWithoutTools(model string, messages []map[string]any) []map[string]any {
+	if !atlascloudIsMinimaxModel(model) {
+		return messages
+	}
+	out := make([]map[string]any, 0, len(messages)+1)
+	for _, msg := range messages {
+		role, _ := msg["role"].(string)
+		switch role {
+		case "assistant":
+			converted := map[string]any{"role": "assistant"}
+			if content, _ := msg["content"].(string); content != "" {
+				converted["content"] = content
+			} else if calls, ok := msg["tool_calls"]; ok {
+				converted["content"] = "Tool call requested: " + atlascloudToolCallsText(calls)
+			} else {
+				converted["content"] = ""
+			}
+			out = append(out, converted)
+		case "tool":
+			toolID, _ := msg["tool_call_id"].(string)
+			content, _ := msg["content"].(string)
+			if toolID != "" {
+				content = "Tool result for " + toolID + ": " + content
+			} else {
+				content = "Tool result: " + content
+			}
+			out = append(out, map[string]any{"role": "user", "content": content})
+		default:
+			copyMsg := make(map[string]any, len(msg))
+			for k, v := range msg {
+				copyMsg[k] = v
+			}
+			out = append(out, copyMsg)
+		}
+	}
+	return out
+}
+
+func atlascloudToolCallsText(calls any) string {
+	b, err := json.Marshal(calls)
+	if err != nil {
+		return fmt.Sprint(calls)
+	}
+	return string(b)
 }
 
 func atlascloudMinimaxCompatTools(model string, input []ai.Tool) ([]map[string]any, string) {

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -650,6 +650,19 @@ func TestProvider_GenerateFollowUpRetriesWithoutToolsOnBadRequest(t *testing.T) 
 			if _, ok := body["tools"]; ok {
 				t.Fatalf("no-tools retry still included tools: %#v", body["tools"])
 			}
+			messages := body["messages"].([]any)
+			last := messages[len(messages)-1].(map[string]any)
+			if last["role"] == "tool" {
+				http.Error(w, `{"code":400,"msg":"trailing tool message rejected"}`, http.StatusBadRequest)
+				return
+			}
+			if last["role"] != "user" || !strings.Contains(last["content"].(string), "Tool result for call-1") {
+				t.Fatalf("no-tools retry last message = %#v, want user-visible tool result", last)
+			}
+			assistant := messages[len(messages)-2].(map[string]any)
+			if _, ok := assistant["tool_calls"]; ok {
+				t.Fatalf("no-tools retry assistant still included tool_calls: %#v", assistant)
+			}
 			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"done"}}]}`))
 		default:
 			t.Fatalf("unexpected API call %d", len(bodies))


### PR DESCRIPTION
Summary:
- Convert AtlasCloud/minimax no-tools follow-up retries to a text-compatible transcript by stripping assistant tool_calls and turning tool-role results into user-visible tool result messages.
- Extend the provider test to reject trailing tool-role no-tools retries and verify the compatible transcript avoids duplicate side effects.

Testing:
- go build ./...
- go test ./ai/atlascloud
- go test ./... (fails in this sandbox: configured AtlasCloud stream test reaches a 400 without credentials, and loopback gRPC tests are blocked by the environment)
- golangci-lint run ./...

Closes #4355
Closes #4365