### PR TITLE
Verify first-agent wayfinding in harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ harness:
 # This guards the no-secret commands README/docs recommend (`micro agent demo`,
 # `micro examples`, and `micro zero-to-hero`) as a CI contract.
 cli-wayfinding:
-	go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestExamplesWayfinding' -count=1
+	go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestExamplesWayfindingIndexStaysLinked|TestExamplesCommandPointsAtWayfindingIndex|TestZeroToHeroCommandPrintsMaintainedNoSecretPath' -count=1
 	$(MAKE) docs-wayfinding
 	$(MAKE) install-smoke
 

--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -8,9 +8,9 @@ scripted so CI can run it on every push without external services or model keys.
 
 1. **Scaffold** — the maintained `micro new` 0→1 contract still creates
    runnable services from a clean workspace.
-2. **First agent** — `micro agent preflight`, `micro run`, `micro chat`, and
-   `micro inspect agent <name>` remain available as the documented first-agent
-   walkthrough path.
+2. **First agent** — `micro agent demo`, `micro examples`, `micro agent preflight`,
+   `micro run`, `micro chat`, and `micro inspect agent <name>` remain available
+   as the documented first-agent walkthrough path.
 3. **Run** — `micro run` remains available as the local development entry point.
 4. **Chat** — `micro chat` remains available as the interactive agent entry point.
 5. **Inspect/debugging** — `micro inspect agent <name>`, `micro agent history <name>`,
@@ -33,7 +33,7 @@ and A2A with only the LLM mocked.
 The default GitHub harness workflow runs this script on every push and pull
 request after the install smoke check and 0→1 scaffold contract. Developers can
 verify the first-agent on-ramp links alone with `make docs-wayfinding`, verify
-the installer seam alone with `make install-smoke`, run just the documented
+the installed first-run CLI seam alone with `make install-smoke`, run just the documented
 agent debugging quickcheck with
 `go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1`,
 or run the same no-secret contract locally with:

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -41,7 +41,7 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 	runScript := readFile(t, filepath.Join(root, "internal", "harness", "zero-to-hero-ci", "run.sh"))
 	for _, want := range []string{
 		"go test ./cmd/micro/cli/new -run TestZeroToOne -count=1",
-		"go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestZeroToHeroCLIBoundaries' -count=1",
+		"go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestExamplesWayfindingIndexStaysLinked|TestExamplesCommandPointsAtWayfindingIndex|TestZeroToHeroCLIBoundaries|TestZeroToHeroCommandPrintsMaintainedNoSecretPath' -count=1",
 		"go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1",
 		"go test ./examples/first-agent -run TestRunFirstAgent -count=1",
 		"go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1",

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -7,7 +7,7 @@ cd "$ROOT"
 # Keep the developer inner-loop boundaries executable and discoverable in CI
 # without secrets or long-running daemons.
 go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
-go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestZeroToHeroCLIBoundaries' -count=1
+go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestExamplesWayfindingIndexStaysLinked|TestExamplesCommandPointsAtWayfindingIndex|TestZeroToHeroCLIBoundaries|TestZeroToHeroCommandPrintsMaintainedNoSecretPath' -count=1
 go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
 go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscript|TestNoSecretFirstAgentDebuggingSmoke|TestZeroToHeroReferenceDocs|TestZeroToHeroDeployDryRunCommandSmoke|TestYourFirstAgentTutorialSmoke' -count=1
 


### PR DESCRIPTION
Summary:
- Expand the first-agent CLI wayfinding checks so the harness covers `micro examples` output and the 0→hero command output, not just command registration.
- Update the 0→hero harness README to document that `micro agent demo` and `micro examples` are part of the first-agent CI contract.

Testing:
- go build ./...
- go test ./... (fails in this environment because loopback gRPC targets are blocked and the configured AtlasCloud stream test hits a 400)
- go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestExamplesWayfindingIndexStaysLinked|TestExamplesCommandPointsAtWayfindingIndex|TestZeroToHeroCLIBoundaries|TestZeroToHeroCommandPrintsMaintainedNoSecretPath' -count=1\n- go test ./internal/harness/zero-to-hero-ci -run TestZeroToHeroReferenceDocs -count=1\n- golangci-lint run ./...\n\nCloses #4381\nCloses #4383