### PR TITLE
Trace workflow run info on agent tool spans

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -374,13 +374,14 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 			return res
 		}
 
-		ctx, span := a.tracer().Start(ctx, spanNameToolCall, trace.WithAttributes(
+		spanAttrs := appendRunInfoAttributes([]attribute.KeyValue{
 			attribute.String(AttrRunID, info.RunID),
 			attribute.String(AttrParentRunID, info.ParentID),
 			attribute.String(AttrAgentName, info.Agent),
 			attribute.String(AttrToolName, call.Name),
 			attribute.Bool(AttrDelegate, call.Name == toolDelegate),
-		))
+		}, info)
+		ctx, span := a.tracer().Start(ctx, spanNameToolCall, trace.WithAttributes(spanAttrs...))
 		res := next(ctx, call)
 		dur := time.Since(start).Milliseconds()
 		attrs := []attribute.KeyValue{attribute.Int64(AttrLatencyMS, dur)}

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -103,8 +103,10 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 				t.Fatalf("model span missing model event: %#v", s.Events())
 			}
 		}
-		if s.Name() == spanNameToolCall && !spanEventHasRunInfo(s.Events(), "agent.tool", runID, "runner") {
-			t.Fatalf("tool span missing tool event: %#v", s.Events())
+		if s.Name() == spanNameToolCall {
+			if !spanEventHasRunInfo(s.Events(), "agent.tool", runID, "runner") {
+				t.Fatalf("tool span missing tool event: %#v", s.Events())
+			}
 		}
 	}
 	keys, err := store.Scope(st, "agent", "runner").List(store.ListPrefix("runs/"))
@@ -140,6 +142,45 @@ func TestAgentOpenTelemetrySpans(t *testing.T) {
 	if len(events) == 0 || events[0].TraceID == "" || events[0].SpanID == "" {
 		t.Fatalf("events missing trace correlation: %#v", events)
 	}
+}
+
+func TestAgentOpenTelemetryToolSpanIncludesWorkflowRunInfo(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exp))
+	st := store.NewMemoryStore()
+	a := New(Name("workflow-tool"), Provider("oteltest"), WithStore(st), TraceProvider(tp)).(*agentImpl)
+	handler := a.traceTool(func(context.Context, ai.ToolCall) ai.ToolResult {
+		return ai.ToolResult{Value: "ok"}
+	})
+	ctx := ai.WithRunInfo(context.Background(), ai.RunInfo{
+		RunID:    "run-workflow-tool",
+		ParentID: "parent-run",
+		Agent:    "workflow-tool",
+		Flow:     "deploy",
+		Step:     "notify",
+		Dispatch: "workflow",
+		Trigger:  "manual",
+	})
+
+	res := handler(ctx, ai.ToolCall{ID: "call-1", Name: "notify", Input: map[string]any{"ok": true}})
+	if resultError(res) != "" {
+		t.Fatalf("tool returned error: %#v", res)
+	}
+
+	for _, span := range exp.GetSpans().Snapshots() {
+		if span.Name() != spanNameToolCall {
+			continue
+		}
+		attrs := spanAttributes(span.Attributes())
+		if attrs[AttrRunID] != "run-workflow-tool" || attrs[AttrParentRunID] != "parent-run" || attrs[AttrAgentName] != "workflow-tool" {
+			t.Fatalf("tool span missing run lineage: %#v", attrs)
+		}
+		if attrs[AttrFlowName] != "deploy" || attrs[AttrFlowStep] != "notify" || attrs[AttrDispatch] != "workflow" || attrs[AttrTrigger] != "manual" {
+			t.Fatalf("tool span missing workflow run info: %#v", attrs)
+		}
+		return
+	}
+	t.Fatalf("tool span not emitted; got %d spans", len(exp.GetSpans().Snapshots()))
 }
 
 func TestAgentOpenTelemetryToolRetryAttempts(t *testing.T) {


### PR DESCRIPTION
Summary:
- Add workflow RunInfo attributes (flow, step, dispatch, trigger) to agent tool OpenTelemetry spans so service → agent → workflow traces keep end-to-end context across tool calls.
- Add a regression test covering tool span lineage plus workflow RunInfo metadata.

Testing:
- go build ./...
- go test ./agent
- go test ./... (fails in this environment due pre-existing external/loopback-sensitive tests: ai atlascloud live API 400, cache expiration flake, grpc loopback forbidden)
- golangci-lint run ./...

Closes #4315
Closes #4390