### PR TITLE
agent: document resume checkpoint limits

### DIFF
--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -21,7 +21,7 @@ func TestResumeCompletedCheckpointDoesNotReplayModel(t *testing.T) {
 	calls := 0
 	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
 		calls++
-		return &ai.Response{Reply: "done"}, nil
+		return &ai.Response{Reply: "done", ToolCalls: []ai.ToolCall{{ID: "call-1", Name: "external.lookup", Result: "cached"}}}, nil
 	}
 	defer func() { fakeGen = nil }()
 
@@ -48,6 +48,9 @@ func TestResumeCompletedCheckpointDoesNotReplayModel(t *testing.T) {
 	}
 	if resumed.RunID != resp.RunID {
 		t.Fatalf("resumed run id = %q, want %q", resumed.RunID, resp.RunID)
+	}
+	if len(resumed.ToolCalls) != 1 || resumed.ToolCalls[0].Name != "external.lookup" || resumed.ToolCalls[0].Result != "cached" {
+		t.Fatalf("resumed tool calls = %#v, want persisted completed call", resumed.ToolCalls)
 	}
 	if calls != 1 {
 		t.Fatalf("model calls after Resume = %d, want 1", calls)

--- a/micro.go
+++ b/micro.go
@@ -215,7 +215,10 @@ func AgentWithCheckpoint(c Checkpoint) AgentOption { return agent.WithCheckpoint
 func AgentPending(ctx context.Context, a Agent) ([]FlowRun, error) { return agent.Pending(ctx, a) }
 
 // AgentResume resumes a checkpointed agent run by id. Completed runs return
-// the persisted response without calling the model or replaying tool calls.
+// the persisted response, including completed tool-call metadata, without
+// calling the model or replaying tool calls. Incomplete runs resume from the
+// saved prompt plus completed tool checkpoints; a provider call interrupted
+// mid-stream is retried rather than continued byte-for-byte.
 func AgentResume(ctx context.Context, a Agent, runID string) (*AgentResponse, error) {
 	return agent.Resume(ctx, a, runID)
 }


### PR DESCRIPTION
Summary:
- Tighten the completed checkpoint resume regression to prove persisted tool-call metadata is returned without replaying the model.
- Clarify AgentResume behavior and the current mid-stream retry limitation.

Testing:
- go test ./agent -run 'TestResumeCompletedCheckpointDoesNotReplayModel|TestResumeFailedCheckpointAfterFreshAgentRestart|TestResumePendingAfterFreshAgentRestartDoesNotReplayCompletedTool' -count=1\n- go build ./...\n- go test ./... (fails in this environment due existing provider/loopback/cache flakes)\n- golangci-lint run ./...\n\nCloses #4368\nCloses #4396