### PR TITLE
Improve getting-started harness logs

### DIFF
--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -4,17 +4,36 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
 
+run_step() {
+  local name=$1
+  shift
+
+  printf '\n==> %s\n' "$name"
+  printf '+ %q' "$@"
+  printf '\n'
+  "$@"
+}
+
 # Keep the developer inner-loop boundaries executable and discoverable in CI
-# without secrets or long-running daemons.
-go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
-go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestExamplesWayfindingIndexStaysLinked|TestExamplesCommandPointsAtWayfindingIndex|TestZeroToHeroCLIBoundaries|TestZeroToHeroCommandPrintsMaintainedNoSecretPath' -count=1
-go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
-go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscript|TestNoSecretFirstAgentDebuggingSmoke|TestZeroToHeroReferenceDocs|TestZeroToHeroDeployDryRunCommandSmoke|TestYourFirstAgentTutorialSmoke' -count=1
+# without secrets or long-running daemons. Step names mirror the documented
+# install → scaffold → run/chat → inspect → deploy-dry-run seams so failures
+# identify the broken part of the getting-started contract.
+run_step "scaffold: 0→1 service contract" \
+  go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
+run_step "run/chat/inspect: first-agent CLI boundaries" \
+  go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestExamplesWayfindingIndexStaysLinked|TestExamplesCommandPointsAtWayfindingIndex|TestZeroToHeroCLIBoundaries|TestZeroToHeroCommandPrintsMaintainedNoSecretPath' -count=1
+run_step "deploy dry-run: configured target plan" \
+  go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
+run_step "chat/inspect: no-secret first-agent transcript and docs" \
+  go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscript|TestNoSecretFirstAgentDebuggingSmoke|TestZeroToHeroReferenceDocs|TestZeroToHeroDeployDryRunCommandSmoke|TestYourFirstAgentTutorialSmoke' -count=1
 
 # Deterministic no-secret reference scenarios. These use the real Go Micro
 # runtime and mock only the LLM provider. The support example is the maintained
 # runnable 0→hero app; keep it in this CI path so its documented run/chat/inspect
 # journey cannot drift from the framework.
-go test ./examples/first-agent -run TestRunFirstAgent -count=1
-go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1
-go test ./internal/harness/universe ./internal/harness/plan-delegate -run 'Test.*Harness|TestPlanDelegateEndToEnd|TestPlanDelegateFlowHandoff' -count=1
+run_step "first-agent app: runnable provider-free example" \
+  go test ./examples/first-agent -run TestRunFirstAgent -count=1
+run_step "0→hero app: support lifecycle smoke" \
+  go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1
+run_step "workflows: deterministic services → agents → workflows harnesses" \
+  go test ./internal/harness/universe ./internal/harness/plan-delegate -run 'Test.*Harness|TestPlanDelegateEndToEnd|TestPlanDelegateFlowHandoff' -count=1


### PR DESCRIPTION
## Summary
- Add named step logging to the zero-to-hero CI runner so failures identify the install, scaffold, run/chat/inspect, deploy dry-run, example, or workflow seam that broke.
- Keep the no-secret provider-free getting-started contract wired through the existing make harness path.

Closes #4399
Closes #4401

## Testing
- ./internal/harness/zero-to-hero-ci/run.sh
- go build ./...
- go test ./... (fails in this sandbox: atlascloud live stream request reached API and loopback gRPC tests are blocked by the environment)
- golangci-lint run ./...