### PR TITLE
Preserve checkpointed tool calls on agent resume

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -432,9 +432,13 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		reply += resp.Answer
 	}
 
+	completedToolCalls := checkpointToolCalls(run.Steps)
+	if a.currentRun != nil {
+		completedToolCalls = checkpointToolCalls(a.currentRun.Steps)
+	}
 	res := &Response{
 		Reply:     reply,
-		ToolCalls: resp.ToolCalls,
+		ToolCalls: mergeCheckpointToolCalls(completedToolCalls, resp.ToolCalls),
 		Agent:     a.opts.Name,
 		RunID:     a.runID,
 		ParentID:  parentRunID,

--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"go-micro.dev/v6/ai"
@@ -287,4 +288,57 @@ func upsertStep(steps *[]flow.StepRecord, rec flow.StepRecord) int {
 	}
 	*steps = append(*steps, rec)
 	return len(*steps) - 1
+}
+
+func checkpointToolCalls(steps []flow.StepRecord) []ai.ToolCall {
+	calls := make([]ai.ToolCall, 0, len(steps))
+	for _, step := range steps {
+		call, ok := checkpointToolCall(step)
+		if !ok {
+			continue
+		}
+		calls = append(calls, call)
+	}
+	return calls
+}
+
+func checkpointToolCall(step flow.StepRecord) (ai.ToolCall, bool) {
+	if step.Status != "done" || !strings.HasPrefix(step.Name, "tool:") {
+		return ai.ToolCall{}, false
+	}
+	parts := strings.SplitN(strings.TrimPrefix(step.Name, "tool:"), ":", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		return ai.ToolCall{}, false
+	}
+	input := map[string]any{}
+	if parts[1] != "null" && parts[1] != "" {
+		if err := json.Unmarshal([]byte(parts[1]), &input); err != nil {
+			return ai.ToolCall{}, false
+		}
+	}
+	return ai.ToolCall{Name: parts[0], Input: input, Result: step.Result}, true
+}
+
+func mergeCheckpointToolCalls(checkpointed, current []ai.ToolCall) []ai.ToolCall {
+	if len(checkpointed) == 0 {
+		return current
+	}
+	seen := make(map[string]struct{}, len(current))
+	for _, call := range current {
+		seen[toolCallKey(call.Name, call.Input)] = struct{}{}
+	}
+	merged := make([]ai.ToolCall, 0, len(checkpointed)+len(current))
+	for _, call := range checkpointed {
+		if _, ok := seen[toolCallKey(call.Name, call.Input)]; ok {
+			continue
+		}
+		merged = append(merged, call)
+	}
+	merged = append(merged, current...)
+	return merged
+}
+
+func toolCallKey(name string, input map[string]any) string {
+	b, _ := json.Marshal(input)
+	return name + ":" + string(b)
 }

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -104,6 +104,12 @@ func TestResumeFailedCheckpointDoesNotReplayCompletedTool(t *testing.T) {
 	if resp.Reply != "finished from checkpoint" {
 		t.Fatalf("Resume reply = %q", resp.Reply)
 	}
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].Name != "external.charge" || resp.ToolCalls[0].Result != "charged" {
+		t.Fatalf("resumed tool calls = %#v, want preserved completed charge call", resp.ToolCalls)
+	}
+	if got := resp.ToolCalls[0].Input["order"]; got != "42" {
+		t.Fatalf("resumed tool input order = %#v, want 42", got)
+	}
 	if toolRuns != 1 {
 		t.Fatalf("tool executions after Resume = %d, want completed tool was not replayed", toolRuns)
 	}


### PR DESCRIPTION
Summary:
- Preserve completed checkpointed tool call records in resumed agent responses so durable runs keep their execution history after a restart.
- Add coverage that a failed checkpoint resume returns the completed tool call and input without re-executing the side effect.

Testing:
- go build ./...
- go test ./... (fails in this environment: atlascloud conformance returned 400 without credentials; loopback GRPC tests are blocked by envoy)
- golangci-lint run ./...

Closes #4368
Closes #4405