### PR TITLE
Harden provider model call timeouts

### DIFF
--- a/agent/resilience_test.go
+++ b/agent/resilience_test.go
@@ -240,6 +240,55 @@ func TestAskCancellationDuringToolCallFailsRun(t *testing.T) {
 	}
 }
 
+func TestSlowProviderTimeoutPreventsLateToolSideEffects(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		close(started)
+		<-release
+		defer close(done)
+		if opts.ToolHandler == nil {
+			t.Fatal("missing tool handler")
+		}
+		res := opts.ToolHandler(ctx, ai.ToolCall{ID: "late-1", Name: "external.create", Input: map[string]any{"title": "too late"}})
+		if !strings.Contains(res.Content, context.DeadlineExceeded.Error()) {
+			t.Errorf("late tool result = %q, want deadline exceeded", res.Content)
+		}
+		return &ai.Response{Reply: "late", ToolCalls: []ai.ToolCall{{ID: "late-1", Name: "external.create", Input: map[string]any{"title": "too late"}, Result: res.Content}}}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	toolRuns := 0
+	a := newTestAgent(
+		Name("slow-provider-late-tool"),
+		ModelCallTimeout(10*time.Millisecond),
+		WithTool("external.create", "create once", nil, func(context.Context, map[string]any) (string, error) {
+			toolRuns++
+			return "created", nil
+		}),
+	)
+
+	_, err := a.Ask(context.Background(), "provider times out before tool")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Ask error = %v, want deadline exceeded", err)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("provider was not called")
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("late provider call did not finish")
+	}
+	if toolRuns != 0 {
+		t.Fatalf("late tool executions = %d, want 0", toolRuns)
+	}
+}
+
 func TestAskCheckpointRecordsTerminalOperationalFailureStatus(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ai/retry.go
+++ b/ai/retry.go
@@ -157,7 +157,7 @@ func GenerateWithRetry(ctx context.Context, m Model, req *Request, policy Genera
 			info.MaxAttempts = policy.MaxAttempts
 			callCtx = WithRunInfo(callCtx, info)
 		}
-		resp, err := m.Generate(callCtx, req, opts...)
+		resp, err := generateAttempt(callCtx, m, req, opts...)
 		cancel()
 
 		// Caller cancellation/deadline always wins and is not retried, even if
@@ -195,6 +195,27 @@ func GenerateWithRetry(ctx context.Context, m Model, req *Request, policy Genera
 		}
 	}
 	return nil, &RetryError{Attempts: policy.MaxAttempts, Kind: ClassifyError(last), Err: last}
+}
+
+func generateAttempt(ctx context.Context, m Model, req *Request, opts ...GenerateOption) (*Response, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	type result struct {
+		resp *Response
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		resp, err := m.Generate(ctx, req, opts...)
+		done <- result{resp: resp, err: err}
+	}()
+	select {
+	case res := <-done:
+		return res.resp, res.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func retryBackoff(err error, attempt int, base time.Duration) time.Duration {

--- a/ai/retry_test.go
+++ b/ai/retry_test.go
@@ -135,6 +135,34 @@ func TestGenerateWithRetryAddsAttemptMetadataToRunInfo(t *testing.T) {
 	}
 }
 
+func TestGenerateWithRetryReturnsWhenProviderIgnoresTimeout(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	model := retryModel{generate: func(ctx context.Context, req *Request, opts ...GenerateOption) (*Response, error) {
+		close(started)
+		<-release
+		return &Response{Reply: "late"}, nil
+	}}
+	defer close(release)
+
+	start := time.Now()
+	_, err := GenerateWithRetry(context.Background(), model, &Request{Prompt: "hi"}, GeneratePolicy{
+		Timeout:     10 * time.Millisecond,
+		MaxAttempts: 1,
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GenerateWithRetry error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("GenerateWithRetry took %s after deadline, want prompt return", elapsed)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("provider was not called")
+	}
+}
+
 type statusErr int
 
 func (e statusErr) Error() string   { return "provider status" }


### PR DESCRIPTION
## Summary
- Enforce model call deadlines even when a provider ignores context cancellation.
- Keep late provider completions from turning timed-out agent runs into successes or executing late tool side effects.
- Add focused retry and agent resilience coverage for timeout behavior.

Closes #4408
Closes #4410

## Testing
- go build ./...
- go test ./... (environment warning: atlascloud live-stream credential/config path returned 400, and loopback gRPC tests were blocked by sandbox proxy)
- go test ./ai -run 'TestGenerateWithRetryReturnsWhenProviderIgnoresTimeout|TestGenerateWithRetry'\n- go test ./agent -run 'TestSlowProviderTimeoutPreventsLateToolSideEffects|TestAskCancellation'\n- golangci-lint run ./...