### PR TITLE
Fix retry timeout test race

### DIFF
--- a/ai/retry_test.go
+++ b/ai/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -69,9 +70,9 @@ func TestGenerateWithRetryDoesNotRetryCallerCancellation(t *testing.T) {
 }
 
 func TestGenerateWithRetryHonorsPerAttemptTimeout(t *testing.T) {
-	attempts := 0
+	var attempts atomic.Int32
 	model := retryModel{generate: func(ctx context.Context, _ *Request, _ ...GenerateOption) (*Response, error) {
-		attempts++
+		attempts.Add(1)
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}}
@@ -91,8 +92,8 @@ func TestGenerateWithRetryHonorsPerAttemptTimeout(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("error = %v, want context.DeadlineExceeded", err)
 	}
-	if attempts != 2 {
-		t.Fatalf("attempts = %d, want 2", attempts)
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace the unsynchronized retry timeout test attempt counter with an atomic counter so the goroutine launched by GenerateWithRetry can be observed safely under the race detector.

## Testing
- go test -race ./ai -run TestGenerateWithRetryHonorsPerAttemptTimeout -count=10
- go build ./...
- go test ./... (fails in this sandbox: atlascloud stream test reaches provider and loopback gRPC tests are blocked by envoy)
- golangci-lint run ./...

Closes #4415
Closes #4420