### PR TITLE
Clarify zero-to-hero harness boundaries

### DIFF
--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -50,6 +50,19 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 			t.Fatalf("0→hero CI run script missing lifecycle command %q", want)
 		}
 	}
+	for _, want := range []string{
+		"scaffold:",
+		"run/chat/inspect:",
+		"deploy dry-run:",
+		"chat/inspect:",
+		"first-agent app:",
+		"0→hero app:",
+		"flow history:",
+	} {
+		if !strings.Contains(runScript, want) {
+			t.Fatalf("0→hero CI run script missing debuggable boundary label %q", want)
+		}
+	}
 
 	readme := readFile(t, filepath.Join(root, "README.md"))
 	if !strings.Contains(readme, "internal/website/docs/guides/zero-to-hero.md") {

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -35,5 +35,5 @@ run_step "first-agent app: runnable provider-free example" \
   go test ./examples/first-agent -run TestRunFirstAgent -count=1
 run_step "0→hero app: support lifecycle smoke" \
   go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1
-run_step "workflows: deterministic services → agents → workflows harnesses" \
+run_step "flow history: deterministic services → agents → workflows harnesses" \
   go test ./internal/harness/universe ./internal/harness/plan-delegate -run 'Test.*Harness|TestPlanDelegateEndToEnd|TestPlanDelegateFlowHandoff' -count=1


### PR DESCRIPTION
## Summary
- Make the no-secret 0→hero harness print an explicit flow-history boundary so CI failures point to the smallest broken lifecycle step.
- Lock the harness script boundary labels in the zero-to-hero docs contract test.

Closes #4428
Closes #4436

## Testing
- go test ./internal/harness/zero-to-hero-ci -run TestZeroToHeroReferenceDocs -count=1
- go build ./...
- go test ./... (fails in this environment: live AtlasCloud stream call returned 400; loopback gRPC targets are blocked by envoy)
- golangci-lint run ./...