### PR TITLE
Repair partial text tool-call recovery

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -414,6 +414,15 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 				continue
 			}
 		}
+		if toolName := partialTextToolCallName(resp.Reply, toolList); len(resp.ToolCalls) == 0 && toolName != "" && planCompletionTurn < maxPlanCompletionTurns {
+			if resp.Reply != "" {
+				a.mem.Add("assistant", resp.Reply)
+			}
+			message = fmt.Sprintf("Your previous response started a %q tool call but did not finish valid tool-call markup or JSON arguments, so no tool was executed. Retry the same step now by emitting one complete valid tool call for %q. Do not describe the action in prose, and do not claim completion until the tool call succeeds.", toolName, toolName)
+			a.mem.Add("user", message)
+			messages = a.mem.Messages()
+			continue
+		}
 		break
 	}
 

--- a/agent/conformance_test.go
+++ b/agent/conformance_test.go
@@ -742,6 +742,61 @@ func TestAgentExecutesProviderTextToolCallFallback(t *testing.T) {
 	}
 }
 
+func TestAgentRepairsPartialTextToolCallFallback(t *testing.T) {
+	attempts := 0
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		if opts.ToolHandler == nil {
+			return nil, errors.New("missing tool handler")
+		}
+		attempts++
+		if attempts == 1 {
+			return &ai.Response{Reply: `<tool_call name="conformance_echo">`}, nil
+		}
+		if !strings.Contains(req.Prompt, "did not finish valid tool-call markup") {
+			return nil, fmt.Errorf("repair prompt = %q, want partial tool-call repair guidance", req.Prompt)
+		}
+		return &ai.Response{
+			Reply: `<tool_call name="conformance_echo">{"value":"agent-conformance"}</tool_call>`,
+		}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	var sawTool bool
+	a := New(
+		Name("conformance-partial-text-tool"),
+		Provider("fake"),
+		WithRegistry(registry.NewMemoryRegistry()),
+		WithStore(store.NewMemoryStore()),
+		WithMemory(NewInMemory(4)),
+		WithTool("conformance_echo", "Echo a conformance value.", map[string]any{
+			"value": map[string]any{"type": "string"},
+		}, func(ctx context.Context, input map[string]any) (string, error) {
+			sawTool = true
+			if input["value"] != "agent-conformance" {
+				return "", fmt.Errorf("unexpected value %v", input["value"])
+			}
+			return `{"marker":"agent-conformance-ok"}`, nil
+		}),
+	)
+
+	resp, err := a.Ask(context.Background(), "Run the partial text tool call fallback.")
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want repair retry", attempts)
+	}
+	if !sawTool {
+		t.Fatal("repaired text tool call fallback did not execute the tool")
+	}
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].Name != "conformance_echo" {
+		t.Fatalf("ToolCalls = %+v, want conformance_echo", resp.ToolCalls)
+	}
+	if !strings.Contains(resp.Reply, "agent-conformance-ok") {
+		t.Fatalf("Reply = %q, want tool result marker", resp.Reply)
+	}
+}
+
 func TestAgentExecutesTextToolCallFallbackAfterStructuredToolCall(t *testing.T) {
 	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
 		if opts.ToolHandler == nil {

--- a/agent/text_tool_calls.go
+++ b/agent/text_tool_calls.go
@@ -15,6 +15,7 @@ var fencedJSONBlock = regexp.MustCompile("(?s)```(?:json)?\\s*(.*?)\\s*```")
 var taggedToolCallBlock = regexp.MustCompile(`(?s)<[^<>]*(?:tool_call|tool_calls|function=)[^<>]*>(.*?)</[^<>]*>`)
 var singleTaggedToolCall = regexp.MustCompile(`(?s)<(tool_call\b[^<>]*|[^<>]*function\s*=[^<>]*)>(.*?)</[^<>]*>`)
 var taggedToolNameAttr = regexp.MustCompile(`(?i)(?:function|name|tool)\s*=\s*["\']?([^"\'\s>]+)`)
+var openingTaggedToolCall = regexp.MustCompile(`(?i)<(tool_call\b[^<>]*|[^<>]*function\s*=[^<>]*)>`)
 
 type textToolCall struct {
 	ID        string         `json:"id"`
@@ -111,6 +112,37 @@ func parseTextToolCalls(text string, tools []ai.Tool) []ai.ToolCall {
 		}
 	}
 	return nil
+}
+
+func partialTextToolCallName(text string, tools []ai.Tool) string {
+	text = html.UnescapeString(text)
+	allowed := textToolNames(tools)
+	if len(allowed) == 0 {
+		return ""
+	}
+	openMatches := openingTaggedToolCall.FindAllStringSubmatchIndex(text, -1)
+	if len(openMatches) == 0 {
+		return ""
+	}
+	closedMatches := singleTaggedToolCall.FindAllStringSubmatchIndex(text, -1)
+	for _, open := range openMatches {
+		closed := false
+		for _, match := range closedMatches {
+			if match[0] == open[0] {
+				closed = true
+				break
+			}
+		}
+		if closed {
+			continue
+		}
+		tag := text[open[2]:open[3]]
+		name := taggedToolName(tag)
+		if canonical := allowed[name]; canonical != "" {
+			return canonical
+		}
+	}
+	return ""
 }
 
 func textToolNames(tools []ai.Tool) map[string]string {


### PR DESCRIPTION
Summary:
- Detect incomplete XML-style text tool-call markup and retry with scoped repair guidance instead of treating the turn as complete.
- Add regression coverage for a provider response that stops at an opening <tool_call> tag before succeeding on retry.

Testing:
- go build ./...
- go test ./agent -run 'TestAgentRepairsPartialTextToolCallFallback|TestAgentExecutesProviderTextToolCallFallback' -count=1\n- go test ./... (fails in this environment because loopback gRPC targets are forbidden and an AtlasCloud stream skip test reaches the live API without credentials)\n- golangci-lint run ./...\n\nCloses #4431\nCloses #4444