### PR TITLE
Handle AtlasCloud partial text tool calls

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -139,6 +139,29 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		}
 	}
 
+	if toolName := atlascloudPartialTextToolCallName(resp.Reply, req.Tools); toolName != "" {
+		repairReq := map[string]any{
+			"model": p.opts.Model,
+			"messages": append(append([]map[string]any(nil), messages...),
+				map[string]any{"role": "assistant", "content": resp.Reply},
+				map[string]any{"role": "user", "content": fmt.Sprintf("Your previous response started a %q tool call but did not finish valid tool-call markup or JSON arguments, so no tool was executed. Retry the same step now by emitting one complete valid tool call for %q. Do not describe the action in prose, and do not claim completion until the tool call succeeds.", toolName, toolName)},
+			),
+		}
+		if p.opts.MaxTokens > 0 {
+			repairReq["max_tokens"] = p.opts.MaxTokens
+		}
+		if len(tools) > 0 {
+			repairReq["tools"] = tools
+		}
+		resp, rawMessage, err = p.callAPI(ctx, "chat-partial-tool-repair", repairReq)
+		if err != nil {
+			return nil, fmt.Errorf("atlascloud partial text tool-call repair failed for %q: %w", toolName, err)
+		}
+		if atlascloudPartialTextToolCallName(resp.Reply, req.Tools) != "" && len(resp.ToolCalls) == 0 {
+			return nil, fmt.Errorf("atlascloud returned incomplete text tool call for %q after repair", toolName)
+		}
+	}
+
 	if len(resp.ToolCalls) == 0 {
 		return resp, nil
 	}
@@ -477,6 +500,26 @@ func atlascloudToolCallsText(calls any) string {
 		return fmt.Sprint(calls)
 	}
 	return string(b)
+}
+
+func atlascloudPartialTextToolCallName(text string, tools []ai.Tool) string {
+	if !strings.Contains(text, "<tool_call") {
+		return ""
+	}
+	if strings.Contains(text, "</tool_call>") {
+		return ""
+	}
+	for _, tool := range tools {
+		for _, name := range []string{tool.Name, tool.OriginalName} {
+			if name == "" {
+				continue
+			}
+			if strings.Contains(text, `name="`+name+`"`) || strings.Contains(text, `name='`+name+`'`) {
+				return tool.Name
+			}
+		}
+	}
+	return ""
 }
 
 func atlascloudMinimaxCompatTools(model string, input []ai.Tool) ([]map[string]any, string) {

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -520,6 +520,78 @@ func TestProvider_GeneratePreservesFollowUpTextToolCallInReply(t *testing.T) {
 	}
 }
 
+func TestProvider_GenerateRepairsInitialPartialTextToolCall(t *testing.T) {
+	var bodies []map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		bodies = append(bodies, body)
+		w.Header().Set("Content-Type", "application/json")
+		switch len(bodies) {
+		case 1:
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"<tool_call name=\"plan\">"}}]}`))
+		case 2:
+			messages := body["messages"].([]any)
+			last := messages[len(messages)-1].(map[string]any)
+			if last["role"] != "user" || !strings.Contains(last["content"].(string), "did not finish valid tool-call markup") {
+				t.Fatalf("repair prompt = %#v, want partial tool-call guidance", last)
+			}
+			if _, ok := body["tools"]; !ok {
+				t.Fatalf("repair request did not keep tools available: %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"<tool_call name=\"plan\">{\"steps\":[{\"task\":\"create tasks\"}]}</tool_call>"}}]}`))
+		default:
+			t.Fatalf("unexpected API call %d", len(bodies))
+		}
+	}))
+	defer ts.Close()
+
+	p := NewProvider(
+		ai.WithAPIKey("test-key"),
+		ai.WithBaseURL(ts.URL),
+		ai.WithModel("minimaxai/minimax-m3"),
+	)
+	resp, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "plan and delegate",
+		Tools: []ai.Tool{
+			{Name: "plan", Description: "record a plan", Properties: map[string]any{"steps": map[string]any{"type": "array"}}},
+			{Name: "delegate", Description: "delegate work", Properties: map[string]any{"task": map[string]any{"type": "string"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if !strings.Contains(resp.Reply, `<tool_call name="plan">`) || !strings.Contains(resp.Reply, `</tool_call>`) {
+		t.Fatalf("Reply = %q, want completed text tool call", resp.Reply)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("requests = %d, want initial plus repair", len(bodies))
+	}
+}
+
+func TestProvider_GenerateErrorsAfterRepeatedPartialTextToolCall(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"<tool_call name=\"plan\">"}}]}`))
+	}))
+	defer ts.Close()
+
+	p := NewProvider(
+		ai.WithAPIKey("test-key"),
+		ai.WithBaseURL(ts.URL),
+		ai.WithModel("minimaxai/minimax-m3"),
+	)
+	_, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "plan and delegate",
+		Tools:  []ai.Tool{{Name: "plan", Description: "record a plan"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "incomplete text tool call") {
+		t.Fatalf("Generate error = %v, want incomplete text tool call error", err)
+	}
+}
+
 func TestProvider_GenerateRetriesMinimaxBuiltInsAsTextTools(t *testing.T) {
 	var bodies []map[string]any
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Retry AtlasCloud responses that stop after opening text tool-call markup so the model must return a complete tool call before the agent runtime continues.
- Return a scoped error if the repair attempt still leaves an incomplete text tool call.
- Add AtlasCloud provider tests for repair success and deterministic failure.

Closes #4431
Closes #4450

## Testing
- go build ./...
- go test ./ai/atlascloud
- go test ./... (fails in this sandbox because loopback targets are forbidden for existing grpc tests and atlascloud stream test hits the configured live endpoint)
- golangci-lint run ./...