### PR TITLE
Tighten first-agent wayfinding guard

### DIFF
--- a/cmd/micro/README.md
+++ b/cmd/micro/README.md
@@ -67,10 +67,11 @@ provider-free agent path:
 ```
 micro agent demo
 micro examples
+micro zero-to-hero
 ```
 
 Those commands point at the smallest mock-model first-agent example, the no-secret
-transcript, and the support app before you add provider-backed chat.
+transcript, and the 0→hero support app before you add provider-backed chat.
 
 ### Output
 

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -311,6 +311,26 @@ func TestFirstAgentWayfindingDocs(t *testing.T) {
 			},
 		},
 		{
+			name:    "repository examples wayfinding index",
+			file:    filepath.Join(root, "examples", "INDEX.md"),
+			heading: "## Recommended adoption path",
+			links: []string{
+				"./hello-world/",
+				"./first-agent/",
+				"./support/",
+			},
+		},
+		{
+			name:    "micro README first-agent on-ramp",
+			file:    filepath.Join(root, "cmd", "micro", "README.md"),
+			heading: "## First agent on-ramp",
+			links: []string{
+				"micro agent demo",
+				"micro examples",
+				"micro zero-to-hero",
+			},
+		},
+		{
 			name:    "website examples index",
 			file:    filepath.Join(root, "internal", "website", "docs", "examples", "index.md"),
 			heading: "## Start here",
@@ -412,6 +432,11 @@ func TestFirstAgentWayfindingLinkTargetsResolve(t *testing.T) {
 			name:    "repository examples index",
 			file:    filepath.Join(root, "examples", "README.md"),
 			heading: "## Recommended first-agent path",
+		},
+		{
+			name:    "repository examples wayfinding index",
+			file:    filepath.Join(root, "examples", "INDEX.md"),
+			heading: "## Recommended adoption path",
 		},
 		{
 			name:    "website examples index",


### PR DESCRIPTION
Summary:
- Add the CLI README to the first-agent wayfinding contract and document `micro zero-to-hero` alongside `micro agent demo` and `micro examples`.
- Extend docs wayfinding checks to cover the repository examples wayfinding index.

Testing:
- `go build ./...`
- `go test ./internal/harness/zero-to-hero-ci -run 'TestFirstAgentWayfindingDocs|TestFirstAgentWayfindingLinkTargetsResolve' -count=1`\n- `go test ./...` (fails in this environment: AtlasCloud live stream error and loopback gRPC tests are blocked by Envoy)\n- `golangci-lint run ./...`\n\nCloses #4441\nCloses #4456