### PR TITLE
Handle incomplete AtlasCloud plan repairs

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -158,7 +158,11 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 			return nil, fmt.Errorf("atlascloud partial text tool-call repair failed for %q: %w", toolName, err)
 		}
 		if atlascloudPartialTextToolCallName(resp.Reply, req.Tools) != "" && len(resp.ToolCalls) == 0 {
-			return nil, fmt.Errorf("atlascloud returned incomplete text tool call for %q after repair", toolName)
+			if toolName == "plan" {
+				resp.Reply = atlascloudPlanFallbackTextToolCall(req.Prompt)
+			} else {
+				return nil, fmt.Errorf("atlascloud returned incomplete text tool call for %q after repair", toolName)
+			}
 		}
 	}
 
@@ -520,6 +524,23 @@ func atlascloudPartialTextToolCallName(text string, tools []ai.Tool) string {
 		}
 	}
 	return ""
+}
+
+func atlascloudPlanFallbackTextToolCall(prompt string) string {
+	task := strings.TrimSpace(prompt)
+	if task == "" {
+		task = "continue the requested work"
+	}
+	args, err := json.Marshal(map[string]any{
+		"steps": []map[string]string{{
+			"task":   task,
+			"status": "pending",
+		}},
+	})
+	if err != nil {
+		return `<tool_call name="plan">{"steps":[{"task":"continue the requested work","status":"pending"}]}</tool_call>`
+	}
+	return `<tool_call name="plan">` + string(args) + `</tool_call>`
 }
 
 func atlascloudMinimaxCompatTools(model string, input []ai.Tool) ([]map[string]any, string) {

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -571,7 +571,7 @@ func TestProvider_GenerateRepairsInitialPartialTextToolCall(t *testing.T) {
 	}
 }
 
-func TestProvider_GenerateErrorsAfterRepeatedPartialTextToolCall(t *testing.T) {
+func TestProvider_GenerateFallsBackAfterRepeatedPartialPlanTextToolCall(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"<tool_call name=\"plan\">"}}]}`))
@@ -583,9 +583,36 @@ func TestProvider_GenerateErrorsAfterRepeatedPartialTextToolCall(t *testing.T) {
 		ai.WithBaseURL(ts.URL),
 		ai.WithModel("minimaxai/minimax-m3"),
 	)
-	_, err := p.Generate(context.Background(), &ai.Request{
+	resp, err := p.Generate(context.Background(), &ai.Request{
 		Prompt: "plan and delegate",
 		Tools:  []ai.Tool{{Name: "plan", Description: "record a plan"}},
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if !strings.Contains(resp.Reply, `<tool_call name="plan">`) || !strings.Contains(resp.Reply, `</tool_call>`) {
+		t.Fatalf("Reply = %q, want completed fallback plan text tool call", resp.Reply)
+	}
+	if !strings.Contains(resp.Reply, "plan and delegate") {
+		t.Fatalf("Reply = %q, want fallback plan seeded from prompt", resp.Reply)
+	}
+}
+
+func TestProvider_GenerateErrorsAfterRepeatedPartialNonPlanTextToolCall(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"<tool_call name=\"delegate\">"}}]}`))
+	}))
+	defer ts.Close()
+
+	p := NewProvider(
+		ai.WithAPIKey("test-key"),
+		ai.WithBaseURL(ts.URL),
+		ai.WithModel("minimaxai/minimax-m3"),
+	)
+	_, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "plan and delegate",
+		Tools:  []ai.Tool{{Name: "delegate", Description: "delegate work"}},
 	})
 	if err == nil || !strings.Contains(err.Error(), "incomplete text tool call") {
 		t.Fatalf("Generate error = %v, want incomplete text tool call error", err)


### PR DESCRIPTION
## Summary
- Fall back to a complete text-form plan tool call when AtlasCloud repeats an incomplete repaired plan call.
- Preserve hard failures for repeated incomplete non-plan tool calls so genuine tool-call defects remain visible.

## Testing
- go test ./ai/atlascloud
- go build ./...
- go test ./... (fails in this environment: AtlasCloud configured-provider stream 400, loopback gRPC tests blocked by envoy)
- golangci-lint run ./...

Closes #4455
Closes #4465