### PR TITLE
Make micro new contract offline

### DIFF
--- a/cmd/micro/cli/new/contract_test.go
+++ b/cmd/micro/cli/new/contract_test.go
@@ -31,7 +31,7 @@ func TestZeroToOneContract(t *testing.T) {
 		}
 	}
 
-	generated.replaceModule(t)
+	generated.assertLocalModule(t)
 	generated.build(t)
 	generated.run(t)
 	generated.call(t, "Alice", "Hello Alice")
@@ -52,7 +52,7 @@ func TestZeroToOneNoMCPContract(t *testing.T) {
 		t.Fatalf("--no-mcp generated main.go with MCP wiring:\n%s", main)
 	}
 
-	generated.replaceModule(t)
+	generated.assertLocalModule(t)
 	generated.build(t)
 	generated.run(t)
 	generated.call(t, "Bob", "Hello Bob")
@@ -112,6 +112,7 @@ func generateService(t *testing.T, name string, args ...string) generatedService
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("MICRO_NEW_GO_MICRO_REPLACE", repoRoot)
 
 	tmp := t.TempDir()
 	oldwd, err := os.Getwd()
@@ -142,7 +143,7 @@ func generateService(t *testing.T, name string, args ...string) generatedService
 	return generatedService{dir: filepath.Join(tmp, name), repoRoot: repoRoot}
 }
 
-func (g generatedService) replaceModule(t *testing.T) {
+func (g generatedService) assertLocalModule(t *testing.T) {
 	t.Helper()
 
 	modPath := filepath.Join(g.dir, "go.mod")
@@ -150,10 +151,9 @@ func (g generatedService) replaceModule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	modText := strings.Replace(string(mod), "go-micro.dev/v6 latest", "go-micro.dev/v6 v6.0.0", 1)
-	modText += "\nreplace go-micro.dev/v6 => " + filepath.ToSlash(g.repoRoot) + "\n"
-	if err := os.WriteFile(modPath, []byte(modText), 0644); err != nil {
-		t.Fatal(err)
+	want := "replace go-micro.dev/v6 => " + filepath.ToSlash(g.repoRoot)
+	if !strings.Contains(string(mod), want) {
+		t.Fatalf("generated go.mod missing local replace %q:\n%s", want, mod)
 	}
 }
 

--- a/cmd/micro/cli/new/new.go
+++ b/cmd/micro/cli/new/new.go
@@ -39,6 +39,8 @@ type config struct {
 	UseGoPath bool
 	// MicroVersion is the go-micro version to require in go.mod
 	MicroVersion string
+	// MicroReplace optionally points generated services at a local go-micro checkout.
+	MicroReplace string
 	// Files
 	Files []file
 	// Comments
@@ -67,6 +69,10 @@ func microVersion() string {
 		}
 	}
 	return "latest"
+}
+
+func microReplace() string {
+	return filepath.ToSlash(os.Getenv("MICRO_NEW_GO_MICRO_REPLACE"))
 }
 
 type file struct {
@@ -215,6 +221,7 @@ func Run(ctx *cli.Context) error {
 		GoPath:       goPath,
 		UseGoPath:    false,
 		MicroVersion: microVersion(),
+		MicroReplace: microReplace(),
 	}
 
 	if useProto {

--- a/cmd/micro/cli/new/template/module.go
+++ b/cmd/micro/cli/new/template/module.go
@@ -10,7 +10,9 @@ require (
 	github.com/golang/protobuf latest
 	google.golang.org/protobuf latest
 )
-`
+{{if .MicroReplace}}
+replace go-micro.dev/v6 => {{.MicroReplace}}
+{{end}}`
 
 	// ModuleNoProto is the default go.mod: no protobuf dependencies.
 	// MicroVersion is the version this CLI was built from (or "latest"), so a
@@ -20,5 +22,7 @@ require (
 go 1.23
 
 require go-micro.dev/v6 {{.MicroVersion}}
-`
+{{if .MicroReplace}}
+replace go-micro.dev/v6 => {{.MicroReplace}}
+{{end}}`
 )


### PR DESCRIPTION
Summary:
- Add an internal local-module replacement hook for generated go.mod files when MICRO_NEW_GO_MICRO_REPLACE is set.
- Update the zero-to-one micro new contract tests to inject the current checkout before micro new runs go mod tidy, then assert the generated go.mod already contains the local replace.

Testing:
- go build ./...
- go test ./... (fails in this sandbox: existing AtlasCloud configured-provider stream error and loopback-forbidden grpc tests)
- golangci-lint run ./...
- go test ./cmd/micro/cli/new -run TestZeroToOne -count=1

Closes #4463
Closes #4471