### PR TITLE
docs: refresh planner priorities for 4473

### DIFF
--- a/.github/loop/PRIORITIES.md
+++ b/.github/loop/PRIORITIES.md
@@ -21,9 +21,8 @@ changes, architectural rewrites. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **Make micro new zero-to-one contract offline** ([#4463](https://github.com/micro/go-micro/issues/4463)) — The current developer-adoption gate can fail before a new user reaches an agent: `micro new` runs `go mod tidy` against the public Go proxy before the contract test rewrites the module to the local checkout. Fix this first because the no-secret scaffold → run → call path is the 0→1 contract and must be deterministic in CI and constrained environments.
-2. **Fix AtlasCloud tool streaming capability mismatch** ([#4438](https://github.com/micro/go-micro/issues/4438)) — The provider matrix still advertises AtlasCloud streaming capability beyond its tool-streaming implementation, causing the live agent streaming conformance path to run an unsupported assertion. Fixing the capability/implementation seam keeps streaming honest without blocking no-secret adoption work.
-3. **Broaden provider streaming conformance** ([#4386](https://github.com/micro/go-micro/issues/4386)) — Once the provider-specific AtlasCloud failures are resolved, expand the broader streaming matrix so chat, agent RPC, and A2A streaming regressions are caught across keyed providers while local CI continues to skip cleanly without secrets.
+1. **Fix AtlasCloud tool streaming capability mismatch** ([#4438](https://github.com/micro/go-micro/issues/4438)) — With the offline `micro new` 0→1 contract shipped, the top open risk is the provider capability/implementation seam: AtlasCloud still advertises streaming capability beyond its tool-streaming implementation, causing live agent streaming conformance to run an unsupported assertion. Fixing this keeps provider-backed chat and agent streaming honest without re-opening the no-secret adoption path.
+2. **Broaden provider streaming conformance** ([#4386](https://github.com/micro/go-micro/issues/4386)) — Once the provider-specific AtlasCloud mismatch is resolved, expand the broader streaming matrix so chat, agent RPC, and A2A streaming regressions are caught across keyed providers while local CI continues to skip cleanly without secrets.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:\n- Remove completed #4463 from the autonomous loop queue after #4472 shipped the offline micro new 0→1 contract.\n- Promote #4438 and keep #4386 ordered behind it so provider streaming conformance follows the AtlasCloud capability fix.\n\nTesting:\n- git diff --check\n- go build ./... (interrupted after >2 minutes with no failures emitted)\n- golangci-lint run ./... (interrupted after >90 seconds with no failures emitted)\n\nCloses #4473