### PR TITLE
Fix AtlasCloud tool streaming capability

### DIFF
--- a/agent/conformance_test.go
+++ b/agent/conformance_test.go
@@ -79,8 +79,12 @@ func runAgentStreamConformanceScenario(t *testing.T, provider conformanceProvide
 		if os.Getenv("GO_MICRO_AGENT_CONFORMANCE_LIVE") == "" {
 			t.Skipf("GO_MICRO_AGENT_CONFORMANCE_LIVE not set; skipping live %s stream conformance", provider.name)
 		}
-		if caps := ai.ProviderCapabilities(provider.name); !caps.Stream {
+		caps := ai.ProviderCapabilities(provider.name)
+		if !caps.Stream {
 			t.Fatalf("ProviderCapabilities(%q).Stream = false, want true for stream conformance", provider.name)
+		}
+		if !caps.ToolStream {
+			t.Skipf("ProviderCapabilities(%q).ToolStream = false; skipping live tool stream conformance", provider.name)
 		}
 	} else {
 		var sawToolSchema bool

--- a/agent/integration_test.go
+++ b/agent/integration_test.go
@@ -68,6 +68,8 @@ func init() {
 		_ = m.Init(opts...)
 		return m
 	})
+	ai.RegisterStream("fake")
+	ai.RegisterToolStream("fake")
 }
 
 // fakeClient embeds the default client (so NewRequest works) and

--- a/ai/anthropic/anthropic.go
+++ b/ai/anthropic/anthropic.go
@@ -19,6 +19,7 @@ func init() {
 		return NewProvider(opts...)
 	})
 	ai.RegisterStream("anthropic")
+	ai.RegisterToolStream("anthropic")
 }
 
 // Provider implements the ai.Model interface for Anthropic Claude

--- a/ai/capabilities.go
+++ b/ai/capabilities.go
@@ -23,6 +23,10 @@ type Capabilities struct {
 	// Providers that only satisfy the Model interface with ErrStreamingUnsupported
 	// leave this false until their Stream implementation is usable.
 	Stream bool `json:"stream"`
+	// ToolStream reports whether the provider supports agent Stream requests that
+	// include tool schemas. Providers may support plain token streaming while
+	// leaving this false when their streaming API cannot accept tools.
+	ToolStream bool `json:"tool_stream"`
 }
 
 // ProviderCapabilities reports the capabilities registered for provider.
@@ -31,12 +35,14 @@ func ProviderCapabilities(provider string) Capabilities {
 	_, hasImage := imageProviders[provider]
 	_, hasVideo := videoProviders[provider]
 	_, hasStream := streamProviders[provider]
+	_, hasToolStream := toolStreamProviders[provider]
 
 	return Capabilities{
-		Model:  hasModel,
-		Image:  hasImage,
-		Video:  hasVideo,
-		Stream: hasStream,
+		Model:      hasModel,
+		Image:      hasImage,
+		Video:      hasVideo,
+		Stream:     hasStream,
+		ToolStream: hasToolStream,
 	}
 }
 
@@ -56,6 +62,9 @@ func CapabilityMatrix() map[string]Capabilities {
 		names[name] = struct{}{}
 	}
 	for name := range streamProviders {
+		names[name] = struct{}{}
+	}
+	for name := range toolStreamProviders {
 		names[name] = struct{}{}
 	}
 
@@ -88,10 +97,18 @@ func RegisterStream(provider string) {
 	streamProviders[provider] = struct{}{}
 }
 
+// RegisterToolStream records that provider can accept tool schemas in Stream
+// requests. This is intentionally separate from RegisterStream because some
+// providers can stream tokens but cannot expose tools while streaming.
+func RegisterToolStream(provider string) {
+	toolStreamProviders[provider] = struct{}{}
+}
+
 var streamProviders = make(map[string]struct{})
+var toolStreamProviders = make(map[string]struct{})
 
 // RegisteredProviders returns the registered provider names in sorted order.
-// kind may be "model", "image", "video", "stream", or empty for the union of all
+// kind may be "model", "image", "video", "stream", "tool_stream", or empty for the union of all
 // provider registries.
 func RegisteredProviders(kind string) []string {
 	names := map[string]struct{}{}
@@ -121,6 +138,8 @@ func RegisteredProviders(kind string) []string {
 		add(providers)
 	case "stream":
 		add(streamProviders)
+	case "tool_stream":
+		add(toolStreamProviders)
 	case "image":
 		add(imageProviders)
 	case "video":

--- a/ai/capabilities_test.go
+++ b/ai/capabilities_test.go
@@ -44,14 +44,14 @@ func TestRegisteredProviders(t *testing.T) {
 func TestCapabilityRows(t *testing.T) {
 	got := ai.CapabilityRows()
 	want := []ai.CapabilityRow{
-		{Provider: "anthropic", Capabilities: ai.Capabilities{Model: true, Stream: true}},
+		{Provider: "anthropic", Capabilities: ai.Capabilities{Model: true, Stream: true, ToolStream: true}},
 		{Provider: "atlascloud", Capabilities: ai.Capabilities{Model: true, Image: true, Video: true, Stream: true}},
 		{Provider: "gemini", Capabilities: ai.Capabilities{Model: true}},
-		{Provider: "groq", Capabilities: ai.Capabilities{Model: true, Stream: true}},
-		{Provider: "minimax", Capabilities: ai.Capabilities{Model: true, Stream: true}},
-		{Provider: "mistral", Capabilities: ai.Capabilities{Model: true, Stream: true}},
-		{Provider: "openai", Capabilities: ai.Capabilities{Model: true, Image: true, Stream: true}},
-		{Provider: "together", Capabilities: ai.Capabilities{Model: true, Stream: true}},
+		{Provider: "groq", Capabilities: ai.Capabilities{Model: true, Stream: true, ToolStream: true}},
+		{Provider: "minimax", Capabilities: ai.Capabilities{Model: true, Stream: true, ToolStream: true}},
+		{Provider: "mistral", Capabilities: ai.Capabilities{Model: true, Stream: true, ToolStream: true}},
+		{Provider: "openai", Capabilities: ai.Capabilities{Model: true, Image: true, Stream: true, ToolStream: true}},
+		{Provider: "together", Capabilities: ai.Capabilities{Model: true, Stream: true, ToolStream: true}},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("CapabilityRows() = %#v, want %#v", got, want)
@@ -71,7 +71,7 @@ func TestCapabilityMatrix(t *testing.T) {
 		}
 	}
 
-	if caps := ai.ProviderCapabilities("openai"); caps != (ai.Capabilities{Model: true, Image: true, Stream: true}) {
+	if caps := ai.ProviderCapabilities("openai"); caps != (ai.Capabilities{Model: true, Image: true, Stream: true, ToolStream: true}) {
 		t.Fatalf("ProviderCapabilities(openai) = %#v", caps)
 	}
 	if caps := ai.ProviderCapabilities("atlascloud"); caps != (ai.Capabilities{Model: true, Image: true, Video: true, Stream: true}) {
@@ -93,5 +93,19 @@ func TestRegisterStream(t *testing.T) {
 	want := []string{"anthropic", "atlascloud", "groq", "minimax", "mistral", "openai", "test-stream", "together"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RegisteredProviders(stream) = %#v, want %#v", got, want)
+	}
+}
+
+func TestRegisterToolStream(t *testing.T) {
+	ai.RegisterToolStream("test-tool-stream")
+
+	if caps := ai.ProviderCapabilities("test-tool-stream"); caps != (ai.Capabilities{ToolStream: true}) {
+		t.Fatalf("ProviderCapabilities(test-tool-stream) = %#v", caps)
+	}
+
+	got := ai.RegisteredProviders("tool_stream")
+	want := []string{"anthropic", "groq", "minimax", "mistral", "openai", "test-tool-stream", "together"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RegisteredProviders(tool_stream) = %#v, want %#v", got, want)
 	}
 }

--- a/ai/groq/groq.go
+++ b/ai/groq/groq.go
@@ -30,6 +30,7 @@ func init() {
 		return NewProvider(opts...)
 	})
 	ai.RegisterStream("groq")
+	ai.RegisterToolStream("groq")
 }
 
 type Provider struct {

--- a/ai/minimax/minimax.go
+++ b/ai/minimax/minimax.go
@@ -30,6 +30,7 @@ func init() {
 		return NewProvider(opts...)
 	})
 	ai.RegisterStream("minimax")
+	ai.RegisterToolStream("minimax")
 }
 
 type Provider struct {

--- a/ai/mistral/mistral.go
+++ b/ai/mistral/mistral.go
@@ -30,6 +30,7 @@ func init() {
 		return NewProvider(opts...)
 	})
 	ai.RegisterStream("mistral")
+	ai.RegisterToolStream("mistral")
 }
 
 type Provider struct {

--- a/ai/ollama/ollama.go
+++ b/ai/ollama/ollama.go
@@ -45,6 +45,7 @@ func init() {
 		return NewProvider(opts...)
 	})
 	ai.RegisterStream("ollama")
+	ai.RegisterToolStream("ollama")
 }
 
 // Provider implements the ai.Model interface for Ollama.

--- a/ai/openai/openai.go
+++ b/ai/openai/openai.go
@@ -22,6 +22,7 @@ func init() {
 		return NewProvider(opts...)
 	})
 	ai.RegisterStream("openai")
+	ai.RegisterToolStream("openai")
 }
 
 // Provider implements the ai.Model interface for OpenAI

--- a/ai/together/together.go
+++ b/ai/together/together.go
@@ -30,6 +30,7 @@ func init() {
 		return NewProvider(opts...)
 	})
 	ai.RegisterStream("together")
+	ai.RegisterToolStream("together")
 }
 
 type Provider struct {

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -206,10 +206,10 @@ func writeSummaryMarkdown(path string, summary conformanceSummary) error {
 
 func capabilityMarkdown(rows []ai.CapabilityRow) string {
 	var b strings.Builder
-	b.WriteString("| Provider | Model | Image | Video | Streaming |\n")
-	b.WriteString("| --- | --- | --- | --- | --- |\n")
+	b.WriteString("| Provider | Model | Image | Video | Streaming | Tool streaming |\n")
+	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
 	for _, row := range rows {
-		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n", row.Provider, mark(row.Model), mark(row.Image), mark(row.Video), mark(row.Stream))
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s |\n", row.Provider, mark(row.Model), mark(row.Image), mark(row.Video), mark(row.Stream), mark(row.ToolStream))
 	}
 	return b.String()
 }

--- a/internal/harness/provider-conformance/main_test.go
+++ b/internal/harness/provider-conformance/main_test.go
@@ -93,7 +93,7 @@ func TestWriteCapabilityMarkdown(t *testing.T) {
 	}
 	got := string(b)
 	for _, want := range []string{
-		"| Provider | Model | Image | Video | Streaming |",
+		"| Provider | Model | Image | Video | Streaming | Tool streaming |",
 		"| mock | ✅ | — | — | — |",
 		"| vision | — | ✅ | ✅ | — |",
 	} {

--- a/internal/website/docs/guides/ai-provider-guide.md
+++ b/internal/website/docs/guides/ai-provider-guide.md
@@ -30,23 +30,23 @@ imports are linked in:
 
 ```go
 for _, row := range ai.CapabilityRows() {
-    fmt.Printf("%s: chat=%t image=%t video=%t stream=%t\n", row.Provider, row.Model, row.Image, row.Video, row.Stream)
+    fmt.Printf("%s: chat=%t image=%t video=%t stream=%t tool_stream=%t\n", row.Provider, row.Model, row.Image, row.Video, row.Stream, row.ToolStream)
 }
 ```
 
 The built-in providers currently register these capability interfaces:
 
-| Provider | Chat/text (`ai.Model`) | Image (`ai.ImageModel`) | Video (`ai.VideoModel`) | Streaming (`ai.Stream`) |
-| --- | --- | --- | --- | --- |
-| `anthropic` | Yes | No | No | Yes |
-| `atlascloud` | Yes | Yes | Yes | Yes |
-| `gemini` | Yes | No | No | No |
-| `groq` | Yes | No | No | Yes |
-| `minimax` | Yes | No | No | Yes |
-| `mistral` | Yes | No | No | Yes |
-| `ollama` | Yes | No | No | Yes |
-| `openai` | Yes | Yes | No | Yes |
-| `together` | Yes | No | No | Yes |
+| Provider | Chat/text (`ai.Model`) | Image (`ai.ImageModel`) | Video (`ai.VideoModel`) | Streaming (`ai.Stream`) | Tool streaming |
+| --- | --- | --- | --- | --- | --- |
+| `anthropic` | Yes | No | No | Yes | Yes |
+| `atlascloud` | Yes | Yes | Yes | Yes | No |
+| `gemini` | Yes | No | No | No | No |
+| `groq` | Yes | No | No | Yes | Yes |
+| `minimax` | Yes | No | No | Yes | Yes |
+| `mistral` | Yes | No | No | Yes | Yes |
+| `ollama` | Yes | No | No | Yes | Yes |
+| `openai` | Yes | Yes | No | Yes | Yes |
+| `together` | Yes | No | No | Yes | Yes |
 
 ## Step 1: Implement the `ai.Model` Interface
 

--- a/internal/website/docs/guides/provider_capabilities_test.go
+++ b/internal/website/docs/guides/provider_capabilities_test.go
@@ -34,7 +34,7 @@ func TestAIProviderGuideCapabilityMatrixMatchesRegistry(t *testing.T) {
 	guide := string(b)
 
 	for _, row := range ai.CapabilityRows() {
-		want := fmt.Sprintf("| `%s` | %s | %s | %s | %s |", row.Provider, yesNo(row.Model), yesNo(row.Image), yesNo(row.Video), yesNo(row.Stream))
+		want := fmt.Sprintf("| `%s` | %s | %s | %s | %s | %s |", row.Provider, yesNo(row.Model), yesNo(row.Image), yesNo(row.Video), yesNo(row.Stream), yesNo(row.ToolStream))
 		if !strings.Contains(guide, want) {
 			t.Fatalf("AI provider guide capability matrix is stale; missing row %q", want)
 		}


### PR DESCRIPTION
Summary:\n- Split provider token streaming from tool-streaming capability reporting.\n- Leave AtlasCloud registered for plain streaming while marking it unsupported for live agent tool-stream conformance.\n- Update conformance output and provider guide capability tables.\n\nTesting:\n- go build ./...\n- go test ./... (environment failures: local ATLASCLOUD_API_KEY returns AtlasCloud 400; loopback gRPC targets are blocked by sandbox envoy)\n- env -u ATLASCLOUD_API_KEY go test ./ai ./agent ./internal/harness/provider-conformance ./internal/website/docs/guides\n- golangci-lint run ./...\n\nCloses #4438\nCloses #4476