### PR TITLE
Add focused CLI inner-loop contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -X $(GIT_IMPORT).BuildDate=$(BUILD_DATE) -X $(GIT_IMPORT).GitCommit=$(
 # GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser-cross:v1.25.7
 GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser:latest
 
-.PHONY: test test-race test-coverage harness cli-wayfinding docs-wayfinding install-smoke provider-conformance-mock provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
+.PHONY: test test-race test-coverage harness inner-loop cli-wayfinding docs-wayfinding install-smoke provider-conformance-mock provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
 
 # Default target
 help:
@@ -19,6 +19,7 @@ help:
 	@echo "  make test-coverage - Run tests with coverage"
 	@echo "  make lint          - Run linter"
 	@echo "  make harness       - Run deterministic getting-started and end-to-end harnesses"
+	@echo "  make inner-loop    - Verify scaffold → run/chat/inspect → deploy dry-run contract"
 	@echo "  make cli-wayfinding - Verify installed first-agent CLI wayfinding commands"
 	@echo "  make docs-wayfinding - Verify first-agent docs wayfinding links resolve locally"
 	@echo "  make install-smoke - Verify the local install.sh and first-run CLI smoke path"
@@ -52,10 +53,20 @@ test-coverage:
 # run/chat/inspect, and 0→hero regressions before a PR is opened.
 harness:
 	$(MAKE) cli-wayfinding
-	go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
+	$(MAKE) inner-loop
 	./internal/harness/zero-to-hero-ci/run.sh
 	go run ./internal/harness/agent-flow
 	$(MAKE) provider-conformance-mock
+
+# Focused provider-free CLI inner-loop contract: scaffold a service, keep the
+# run/chat/inspect commands discoverable, and prove deploy dry-run reaches the
+# documented boundary without remote side effects. Use this when README/docs/CLI
+# drift is the concern and the full runtime harness is more than you need.
+inner-loop:
+	go test ./cmd/micro/cli/new -run TestZeroToOne -count=1
+	go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestZeroToHeroCLIBoundaries|TestZeroToHeroCommandPrintsMaintainedNoSecretPath' -count=1
+	go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1
+	go test ./internal/harness/zero-to-hero-ci -run 'TestZeroToHeroDeployDryRunCommandSmoke|TestNoSecretFirstAgentDebuggingSmoke|TestYourFirstAgentTutorialSmoke' -count=1
 
 # Verify the installed CLI keeps the first-agent on-ramp commands discoverable.
 # This guards the no-secret commands README/docs recommend (`micro agent demo`,

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ access or provider keys, use:
 make install-smoke
 ```
 
+To verify the focused CLI inner-loop contract — scaffold → run/chat/inspect → deploy dry-run — use:
+
+```bash
+make inner-loop
+```
+
 To run the broader local contract (including the [0→hero services → agents → workflows path](internal/website/docs/guides/zero-to-hero.md),
 chat/inspect CLI boundaries, and deploy dry-run), use:
 

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -20,6 +20,7 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 	guide := readFile(t, filepath.Join(root, "internal", "website", "docs", "guides", "zero-to-hero.md"))
 	for _, want := range []string{
 		"make harness",
+		"make inner-loop",
 		"go test ./cmd/micro/cli/new -run TestZeroToOne -count=1",
 		"go test ./cmd/micro -run TestFirstAgentWalkthroughCLIBoundaries -count=1",
 		"go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1",
@@ -67,6 +68,9 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 	readme := readFile(t, filepath.Join(root, "README.md"))
 	if !strings.Contains(readme, "internal/website/docs/guides/zero-to-hero.md") {
 		t.Fatal("README does not point to the canonical 0→hero guide")
+	}
+	if !strings.Contains(readme, "make inner-loop") {
+		t.Fatal("README does not expose the focused CLI inner-loop contract")
 	}
 
 	nav := readFile(t, filepath.Join(root, "internal", "website", "_data", "navigation.yml"))

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -69,6 +69,12 @@ SSH access, or remote service is required.
 
 ## Run focused checks while iterating
 
+Use the dedicated inner-loop target when you need the provider-free CLI contract in one focused command:
+
+```sh
+make inner-loop
+```
+
 Use the smaller checks when you are working on one seam:
 
 ```sh


### PR DESCRIPTION
Adds a focused provider-free `make inner-loop` target for the scaffold → run/chat/inspect → deploy dry-run contract, and links it from README plus the 0→hero guide.

Verification:
- `make inner-loop`
- `go build ./...`
- `go test ./...` (fails in this environment due live/loopback limitations: Atlas Cloud stream 400 and loopback gRPC blocked by envoy)
- `golangci-lint run ./...`

Closes #4483
Closes #4488