### PR TITLE
Fix AtlasCloud delegate text fallback

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -158,11 +158,11 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 			return nil, fmt.Errorf("atlascloud partial text tool-call repair failed for %q: %w", toolName, err)
 		}
 		if atlascloudPartialTextToolCallName(resp.Reply, req.Tools) != "" && len(resp.ToolCalls) == 0 {
-			if toolName == "plan" {
-				resp.Reply = atlascloudPlanFallbackTextToolCall(req.Prompt)
-			} else {
+			fallback := atlascloudFallbackTextToolCall(toolName, req)
+			if fallback == "" {
 				return nil, fmt.Errorf("atlascloud returned incomplete text tool call for %q after repair", toolName)
 			}
+			resp.Reply = fallback
 		}
 	}
 
@@ -526,6 +526,17 @@ func atlascloudPartialTextToolCallName(text string, tools []ai.Tool) string {
 	return ""
 }
 
+func atlascloudFallbackTextToolCall(toolName string, req *ai.Request) string {
+	switch toolName {
+	case "plan":
+		return atlascloudPlanFallbackTextToolCall(req.Prompt)
+	case "delegate":
+		return atlascloudDelegateFallbackTextToolCall(req)
+	default:
+		return ""
+	}
+}
+
 func atlascloudPlanFallbackTextToolCall(prompt string) string {
 	task := strings.TrimSpace(prompt)
 	if task == "" {
@@ -541,6 +552,49 @@ func atlascloudPlanFallbackTextToolCall(prompt string) string {
 		return `<tool_call name="plan">{"steps":[{"task":"continue the requested work","status":"pending"}]}</tool_call>`
 	}
 	return `<tool_call name="plan">` + string(args) + `</tool_call>`
+}
+
+func atlascloudDelegateFallbackTextToolCall(req *ai.Request) string {
+	ctxText := atlascloudRequestText(req)
+	task := strings.TrimSpace(req.Prompt)
+	if task == "" {
+		task = strings.TrimSpace(ctxText)
+	}
+	if task == "" {
+		task = "continue the requested delegated work"
+	}
+
+	args := map[string]any{"task": task}
+	if strings.Contains(strings.ToLower(ctxText), "comms") {
+		args["to"] = "comms"
+	}
+	b, err := json.Marshal(args)
+	if err != nil {
+		return `<tool_call name="delegate">{"task":"continue the requested delegated work"}</tool_call>`
+	}
+	return `<tool_call name="delegate">` + string(b) + `</tool_call>`
+}
+
+func atlascloudRequestText(req *ai.Request) string {
+	if req == nil {
+		return ""
+	}
+	var parts []string
+	if req.SystemPrompt != "" {
+		parts = append(parts, req.SystemPrompt)
+	}
+	for _, msg := range req.Messages {
+		switch c := msg.Content.(type) {
+		case string:
+			parts = append(parts, c)
+		default:
+			parts = append(parts, fmt.Sprint(c))
+		}
+	}
+	if req.Prompt != "" {
+		parts = append(parts, req.Prompt)
+	}
+	return strings.Join(parts, "\n")
 }
 
 func atlascloudMinimaxCompatTools(model string, input []ai.Tool) ([]map[string]any, string) {

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -598,7 +598,7 @@ func TestProvider_GenerateFallsBackAfterRepeatedPartialPlanTextToolCall(t *testi
 	}
 }
 
-func TestProvider_GenerateErrorsAfterRepeatedPartialNonPlanTextToolCall(t *testing.T) {
+func TestProvider_GenerateFallsBackAfterRepeatedPartialDelegateTextToolCall(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"<tool_call name=\"delegate\">"}}]}`))
@@ -610,12 +610,18 @@ func TestProvider_GenerateErrorsAfterRepeatedPartialNonPlanTextToolCall(t *testi
 		ai.WithBaseURL(ts.URL),
 		ai.WithModel("minimaxai/minimax-m3"),
 	)
-	_, err := p.Generate(context.Background(), &ai.Request{
-		Prompt: "plan and delegate",
-		Tools:  []ai.Tool{{Name: "delegate", Description: "delegate work"}},
+	resp, err := p.Generate(context.Background(), &ai.Request{
+		SystemPrompt: "You coordinate launch work and delegate readiness notifications to the comms agent.",
+		Prompt:       "delegate the owner readiness notification to comms",
+		Tools:        []ai.Tool{{Name: "delegate", Description: "delegate work"}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "incomplete text tool call") {
-		t.Fatalf("Generate error = %v, want incomplete text tool call error", err)
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{`<tool_call name="delegate">`, `"task":"delegate the owner readiness notification to comms"`, `"to":"comms"`, `</tool_call>`} {
+		if !strings.Contains(resp.Reply, want) {
+			t.Fatalf("Reply = %q, want delegate fallback containing %q", resp.Reply, want)
+		}
 	}
 }
 


### PR DESCRIPTION
Summary:\n- Add an AtlasCloud fallback that synthesizes a complete delegate text tool call when partial text-tool repair still returns incomplete markup.\n- Preserve the existing plan fallback while keeping unsupported tools on the existing error path.\n- Add regression coverage for repeated partial delegate text tool calls.\n\nTesting:\n- go test ./ai/atlascloud\n- go test ./ai/atlascloud ./internal/harness/plan-delegate\n- go build ./...\n- go test ./... (fails in this sandbox because loopback gRPC targets are blocked and an AtlasCloud stream test hit a live 400)\n- golangci-lint run ./...\n\nCloses #4487\nCloses #4492