### PR TITLE
Add first-agent docs CLI parity check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help:
 	@echo "  make harness       - Run deterministic getting-started and end-to-end harnesses"
 	@echo "  make inner-loop    - Verify scaffold → run/chat/inspect → deploy dry-run contract"
 	@echo "  make cli-wayfinding - Verify installed first-agent CLI wayfinding commands"
-	@echo "  make docs-wayfinding - Verify first-agent docs wayfinding links resolve locally"
+	@echo "  make docs-wayfinding - Verify first-agent docs/CLI wayfinding stays in sync"
 	@echo "  make install-smoke - Verify the local install.sh and first-run CLI smoke path"
 	@echo "  make provider-conformance-mock - Run cross-provider harness with deterministic mock provider"
 	@echo "  make provider-conformance - Run harnesses against configured live providers"
@@ -81,6 +81,7 @@ cli-wayfinding:
 # developer-adoption on-ramp.
 docs-wayfinding:
 	go test ./internal/harness/zero-to-hero-ci -run 'TestFirstAgentWayfindingDocs|TestFirstAgentWayfindingLinkTargetsResolve' -count=1
+	go test ./cmd/micro -run 'TestFirstAgentDocsMatchCLIOutput|TestFirstAgentWalkthroughCLIBoundaries' -count=1
 
 # Verify the documented install script and first-run CLI command boundaries without
 # provider keys or network access.

--- a/cmd/micro/first_agent_walkthrough_test.go
+++ b/cmd/micro/first_agent_walkthrough_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -137,6 +139,126 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 			t.Fatalf("micro agent demo output missing %q:\n%s", want, out.String())
 		}
 	}
+}
+
+func TestFirstAgentDocsMatchCLIOutput(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	outputs := map[string]string{
+		"micro docs":         commandOutput(t, commandByName(t, "docs")),
+		"micro examples":     commandOutput(t, commandByName(t, "examples")),
+		"micro zero-to-hero": commandOutput(t, commandByName(t, "zero-to-hero")),
+	}
+	agent := commandByName(t, "agent")
+	outputs["micro agent demo"] = commandOutput(t, subcommandByName(t, agent, "demo"))
+
+	contracts := []struct {
+		name    string
+		file    string
+		markers []string
+	}{
+		{
+			name: "README first-agent on-ramp",
+			file: filepath.Join(root, "README.md"),
+			markers: []string{
+				"micro agent demo",
+				"micro examples",
+				"micro zero-to-hero",
+				"examples/first-agent/",
+				"examples/support/",
+				"internal/website/docs/guides/no-secret-first-agent.md",
+				"internal/website/docs/guides/your-first-agent.md",
+				"internal/website/docs/guides/debugging-agents.md",
+				"internal/website/docs/guides/zero-to-hero.md",
+			},
+		},
+		{
+			name: "website getting-started first-agent on-ramp",
+			file: filepath.Join(root, "internal", "website", "docs", "getting-started.md"),
+			markers: []string{
+				"micro agent demo",
+				"micro examples",
+				"micro zero-to-hero",
+				"github.com/micro/go-micro/tree/master/examples/first-agent",
+				"github.com/micro/go-micro/tree/master/examples/support",
+				"guides/no-secret-first-agent.html",
+				"guides/your-first-agent.html",
+				"guides/debugging-agents.html",
+				"guides/zero-to-hero.html",
+			},
+		},
+	}
+
+	for _, contract := range contracts {
+		doc := readTestFile(t, contract.file)
+		for _, marker := range contract.markers {
+			if !strings.Contains(doc, marker) {
+				t.Fatalf("%s missing documented first-agent marker %q", contract.name, marker)
+			}
+			if isCLIContractMarker(marker) && !cliOutputsContain(outputs, marker) {
+				t.Fatalf("%s documents %q, but none of the first-agent CLI outputs mention it; keep README/website breadcrumbs aligned with micro agent demo/examples/zero-to-hero", contract.name, marker)
+			}
+			assertMaintainedFirstAgentPath(t, root, marker)
+		}
+	}
+}
+
+func commandOutput(t *testing.T, command *cli.Command) string {
+	t.Helper()
+	var out bytes.Buffer
+	app := cli.NewApp()
+	app.Writer = &out
+	if err := command.Action(cli.NewContext(app, nil, nil)); err != nil {
+		t.Fatalf("%s failed: %v", command.Name, err)
+	}
+	return out.String()
+}
+
+func cliOutputsContain(outputs map[string]string, marker string) bool {
+	for command, out := range outputs {
+		if command == marker || strings.Contains(out, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCLIContractMarker(marker string) bool {
+	return strings.HasPrefix(marker, "micro ") || strings.HasPrefix(marker, "go run ") || strings.HasPrefix(marker, "go test ") || strings.Contains(marker, ".html")
+}
+
+func assertMaintainedFirstAgentPath(t *testing.T, root, marker string) {
+	t.Helper()
+	pathChecks := map[string]string{
+		"go run ./examples/first-agent":                              "examples/first-agent",
+		"examples/first-agent/":                                      "examples/first-agent",
+		"examples/support/":                                          "examples/support",
+		"internal/website/docs/guides/no-secret-first-agent.md":      "internal/website/docs/guides/no-secret-first-agent.md",
+		"internal/website/docs/guides/your-first-agent.md":           "internal/website/docs/guides/your-first-agent.md",
+		"internal/website/docs/guides/debugging-agents.md":           "internal/website/docs/guides/debugging-agents.md",
+		"internal/website/docs/guides/zero-to-hero.md":               "internal/website/docs/guides/zero-to-hero.md",
+		"guides/no-secret-first-agent.html":                          "internal/website/docs/guides/no-secret-first-agent.md",
+		"guides/your-first-agent.html":                               "internal/website/docs/guides/your-first-agent.md",
+		"guides/debugging-agents.html":                               "internal/website/docs/guides/debugging-agents.md",
+		"guides/zero-to-hero.html":                                   "internal/website/docs/guides/zero-to-hero.md",
+		"github.com/micro/go-micro/tree/master/examples/first-agent": "examples/first-agent",
+		"github.com/micro/go-micro/tree/master/examples/support":     "examples/support",
+	}
+	path, ok := pathChecks[marker]
+	if !ok {
+		return
+	}
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(path))); err != nil {
+		t.Fatalf("documented first-agent path %q from marker %q does not resolve: %v", path, marker, err)
+	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
 }
 
 func commandByName(t *testing.T, name string) *cli.Command {

--- a/internal/harness/zero-to-hero-ci/README.md
+++ b/internal/harness/zero-to-hero-ci/README.md
@@ -32,8 +32,12 @@ and A2A with only the LLM mocked.
 
 The default GitHub harness workflow runs this script on every push and pull
 request after the install smoke check and 0→1 scaffold contract. Developers can
-verify the first-agent on-ramp links alone with `make docs-wayfinding`, verify
-the installed first-run CLI seam alone with `make install-smoke`, run just the documented
+verify the first-agent on-ramp links and CLI command-output parity with
+`make docs-wayfinding` whenever README or website first-agent breadcrumbs,
+`micro agent demo`, `micro examples`, or `micro zero-to-hero` change. That
+check is provider-free and fails if documented command names, guide links, or
+maintained no-secret example paths drift from the CLI outputs. To verify the
+installed first-run CLI seam alone, use `make install-smoke`; to run just the documented
 agent debugging quickcheck with
 `go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1`,
 or run the same no-secret contract locally with:


### PR DESCRIPTION
## Summary
- Add a provider-free test that compares README and website first-agent breadcrumbs against the maintained CLI wayfinding output for micro agent demo, micro examples, and micro zero-to-hero.
- Wire the parity check into make docs-wayfinding and document when to run it.

Closes #4495
Closes #4505

## Testing
- make docs-wayfinding
- go build ./...
- go test ./... (fails in this environment due loopback proxy/provider constraints: ai atlascloud stream 400; client/grpc and transport/grpc loopback targets forbidden)
- golangci-lint run ./...