### PR TITLE
Stabilize agent-flow onboarding side effects

### DIFF
--- a/internal/harness/agent-flow/main.go
+++ b/internal/harness/agent-flow/main.go
@@ -49,19 +49,31 @@ type CreateResponse struct {
 }
 
 type WorkspaceService struct {
-	mu sync.Mutex
-	n  int
+	mu      sync.Mutex
+	n       int
+	byOwner map[string]*Workspace
 }
 
 // Create provisions a workspace for a new user.
 // @example {"owner": "alice@acme.com"}
 func (s *WorkspaceService) Create(ctx context.Context, req *CreateRequest, rsp *CreateResponse) error {
 	s.mu.Lock()
+	if s.byOwner == nil {
+		s.byOwner = make(map[string]*Workspace)
+	}
+	if ws, ok := s.byOwner[req.Owner]; ok {
+		s.mu.Unlock()
+		fmt.Printf("    \033[32m[workspace]\033[0m duplicate suppressed %s for %s\n", ws.ID, req.Owner)
+		rsp.Workspace = ws
+		return nil
+	}
 	s.n++
 	id := fmt.Sprintf("ws-%d", s.n)
+	ws := &Workspace{ID: id, Owner: req.Owner}
+	s.byOwner[req.Owner] = ws
 	s.mu.Unlock()
 	fmt.Printf("    \033[32m[workspace]\033[0m created %s for %s\n", id, req.Owner)
-	rsp.Workspace = &Workspace{ID: id, Owner: req.Owner}
+	rsp.Workspace = ws
 	return nil
 }
 
@@ -79,14 +91,26 @@ type SendResponse struct {
 	Sent bool `json:"sent"`
 }
 type NotifyService struct {
-	mu sync.Mutex
-	n  int
+	mu   sync.Mutex
+	n    int
+	sent map[string]bool
 }
 
 // Send delivers a notification message to a recipient.
 // @example {"to": "alice@acme.com", "message": "Welcome"}
 func (s *NotifyService) Send(ctx context.Context, req *SendRequest, rsp *SendResponse) error {
+	key := req.To + "\x00" + req.Message
 	s.mu.Lock()
+	if s.sent == nil {
+		s.sent = make(map[string]bool)
+	}
+	if s.sent[key] {
+		s.mu.Unlock()
+		fmt.Printf("    \033[35m[notify]\033[0m duplicate suppressed to=%s message=%q\n", req.To, req.Message)
+		rsp.Sent = true
+		return nil
+	}
+	s.sent[key] = true
 	s.n++
 	s.mu.Unlock()
 	fmt.Printf("    \033[35m[notify]\033[0m 📨 to=%s message=%q\n", req.To, req.Message)

--- a/internal/harness/agent-flow/main_test.go
+++ b/internal/harness/agent-flow/main_test.go
@@ -135,3 +135,37 @@ func TestWaitForOnboardingSideEffectsPassesWhenComplete(t *testing.T) {
 		t.Fatalf("waitForOnboardingSideEffects returned %v, want nil", err)
 	}
 }
+
+func TestWorkspaceCreateSuppressesDuplicateOwner(t *testing.T) {
+	wsSvc := new(WorkspaceService)
+	first := new(CreateResponse)
+	if err := wsSvc.Create(context.Background(), &CreateRequest{Owner: "alice@acme.com"}, first); err != nil {
+		t.Fatalf("create first workspace: %v", err)
+	}
+	second := new(CreateResponse)
+	if err := wsSvc.Create(context.Background(), &CreateRequest{Owner: "alice@acme.com"}, second); err != nil {
+		t.Fatalf("create duplicate workspace: %v", err)
+	}
+
+	if got := wsSvc.count(); got != 1 {
+		t.Fatalf("workspace creations = %d, want 1 after duplicate owner replay", got)
+	}
+	if first.Workspace == nil || second.Workspace == nil || second.Workspace.ID != first.Workspace.ID {
+		t.Fatalf("duplicate create returned workspace %#v, want original %#v", second.Workspace, first.Workspace)
+	}
+}
+
+func TestNotifySendSuppressesDuplicateMessage(t *testing.T) {
+	ntSvc := new(NotifyService)
+	req := &SendRequest{To: "alice@acme.com", Message: "Welcome — your workspace is ready."}
+	if err := ntSvc.Send(context.Background(), req, &SendResponse{}); err != nil {
+		t.Fatalf("send first notification: %v", err)
+	}
+	if err := ntSvc.Send(context.Background(), req, &SendResponse{}); err != nil {
+		t.Fatalf("send duplicate notification: %v", err)
+	}
+
+	if got := ntSvc.count(); got != 1 {
+		t.Fatalf("notifications sent = %d, want 1 after duplicate message replay", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Make the agent-flow workspace service idempotent per owner so retry/replay paths return the existing workspace instead of provisioning another one.
- Make the agent-flow notify service idempotent per recipient/message pair so duplicate tool-call replays report success without double-counting the notification.
- Add regression coverage for duplicate workspace and notification side-effect suppression.

Closes #4503
Closes #4519

## Testing
- go build ./...
- go test ./internal/harness/agent-flow
- go test ./... (fails in this environment: AtlasCloud configured-provider stream returned 400 not found; grpc loopback targets forbidden)
- golangci-lint run ./...