### PR TITLE
Collapse AtlasCloud spoken notify replays

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -194,6 +194,7 @@ func notifyDedupKey(to, message string) string {
 }
 
 func canonicalLaunchNotifyRecipient(recipient string) string {
+	recipient = canonicalSpokenEmailRecipient(recipient)
 	switch recipient {
 	case "owner", "launch owner", "plan owner", "owner acme com", "owner@acme com", "owner @ acme com":
 		return "owner@acme.com"
@@ -203,6 +204,14 @@ func canonicalLaunchNotifyRecipient(recipient string) string {
 		}
 		return recipient
 	}
+}
+
+func canonicalSpokenEmailRecipient(recipient string) string {
+	fields := strings.Fields(recipient)
+	if len(fields) == 5 && fields[1] == "at" && fields[3] == "dot" {
+		return fields[0] + "@" + fields[2] + "." + fields[4]
+	}
+	return recipient
 }
 
 func normalizeNotifyText(message string) string {

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -562,6 +562,7 @@ func TestNotifyServiceCollapsesProviderReadinessParaphrases(t *testing.T) {
 	requests := []SendRequest{
 		{To: "owner@acme.com", Message: "The launch plan is ready"},
 		{To: "owner @ acme.com", Message: "Launch plan ready."},
+		{To: "owner at acme dot com", Message: "The launch plan is ready."},
 		{To: "launch owner", Message: "The launch readiness plan is prepared."},
 		{To: "plan owner", Message: "Launch plan is complete!"},
 	}


### PR DESCRIPTION
Summary:
- Canonicalize provider-spoken owner email recipients before plan-delegate notify dedupe.
- Cover spoken owner-at-acme-dot-com readiness replays in the notify paraphrase regression test.

Testing:
- go test ./internal/harness/plan-delegate -run TestNotifyServiceCollapsesProviderReadinessParaphrases -count=1
- go build ./...
- go test ./... (fails in sandbox: AtlasCloud live stream 400 and loopback targets forbidden for grpc tests)
- golangci-lint run ./...

Closes #4521
Closes #4530