### PR TITLE
Fix plan delegate harness cleanup

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -106,6 +106,11 @@ type agentImpl struct {
 	// durable delegate-result cache is written.
 	delegateMu    sync.Mutex
 	delegateCalls map[string]*delegateCall
+
+	// stopCh lets Stop unblock Run. Without this, tests and harnesses that
+	// start agents in goroutines can leave Run parked forever after the RPC
+	// server has been stopped.
+	stopCh chan struct{}
 }
 
 // New creates a new Agent.
@@ -540,6 +545,11 @@ func (a *agentImpl) Run() error {
 		return fmt.Errorf("failed to start agent: %w", err)
 	}
 
+	stopCh := make(chan struct{})
+	a.mu.Lock()
+	a.stopCh = stopCh
+	a.mu.Unlock()
+
 	fmt.Printf("Agent %s registered (manages: %s)\n", a.opts.Name, strings.Join(a.opts.Services, ", "))
 
 	// Optionally serve the agent directly over the A2A protocol, calling
@@ -561,12 +571,17 @@ func (a *agentImpl) Run() error {
 		fmt.Printf("Agent %s serving A2A on %s\n", a.opts.Name, a.opts.A2AAddress)
 	}
 
-	ch := make(chan struct{})
-	<-ch
+	<-stopCh
 	return nil
 }
 
 func (a *agentImpl) Stop() error {
+	a.mu.Lock()
+	if a.stopCh != nil {
+		close(a.stopCh)
+		a.stopCh = nil
+	}
+	a.mu.Unlock()
 	if a.server != nil {
 		return a.server.Stop()
 	}

--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -433,14 +433,20 @@ func runPlanDelegate(provider string) error {
 	if err := task.Handle(taskSvc); err != nil {
 		return fmt.Errorf("task handle: %w", err)
 	}
-	go task.Run()
+	if err := task.Start(); err != nil {
+		return fmt.Errorf("task start: %w", err)
+	}
+	defer task.Stop()
 
 	notifySvc := new(NotifyService)
 	notify := service.New(service.Name("notify"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	if err := notify.Handle(notifySvc); err != nil {
 		return fmt.Errorf("notify handle: %w", err)
 	}
-	go notify.Run()
+	if err := notify.Start(); err != nil {
+		return fmt.Errorf("notify start: %w", err)
+	}
+	defer notify.Stop()
 
 	// Real comms agent (owns notify), registered so delegate reaches it over RPC.
 	commsOpts := []agent.Option{

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -53,14 +53,20 @@ func TestPlanDelegateEndToEnd(t *testing.T) {
 	if err := task.Handle(taskSvc); err != nil {
 		t.Fatalf("handle task: %v", err)
 	}
-	go task.Run()
+	if err := task.Start(); err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+	defer task.Stop()
 
 	notifySvc := new(NotifyService)
 	notify := service.New(service.Name("notify"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	if err := notify.Handle(notifySvc); err != nil {
 		t.Fatalf("handle notify: %v", err)
 	}
-	go notify.Run()
+	if err := notify.Start(); err != nil {
+		t.Fatalf("start notify: %v", err)
+	}
+	defer notify.Stop()
 
 	// Real comms agent (owns notify), registered so delegate reaches it over RPC.
 	comms := agent.New(
@@ -136,14 +142,20 @@ func TestFlowDispatchesToAgentEndToEnd(t *testing.T) {
 	if err := task.Handle(taskSvc); err != nil {
 		t.Fatalf("handle task: %v", err)
 	}
-	go task.Run()
+	if err := task.Start(); err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+	defer task.Stop()
 
 	notifySvc := new(NotifyService)
 	notify := service.New(service.Name("notify"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl))
 	if err := notify.Handle(notifySvc); err != nil {
 		t.Fatalf("handle notify: %v", err)
 	}
-	go notify.Run()
+	if err := notify.Start(); err != nil {
+		t.Fatalf("start notify: %v", err)
+	}
+	defer notify.Stop()
 
 	comms := agent.New(
 		agent.Name("comms"),


### PR DESCRIPTION
Summary:
- Let agent Stop unblock Run so plan/delegate test agents terminate cleanly.
- Start plan/delegate harness services non-blockingly and stop them explicitly after each run.

Testing:
- go build ./...
- go test ./... (fails here because the environment routes loopback gRPC through an envoy that forbids loopback targets, and atlascloud stream credentials return 400)
- golangci-lint run ./...
- go test -v -race -cover ./internal/harness/plan-delegate -count=1 -timeout=60s

Closes #4527
Closes #4536