### PR TITLE
Fix A2A fallback artifact text

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -627,6 +627,9 @@ func (d *dispatcher) run(ctx context.Context, params json.RawMessage, invoke Inv
 			reply = err.Error()
 			state = stateInputRequired
 		}
+	} else if strings.TrimSpace(reply) == "" {
+		reply = "error: agent returned an empty response"
+		state = stateFailed
 	}
 	task := d.taskFromReply(p.Message, reply, state)
 	d.store(task)
@@ -750,13 +753,11 @@ func (g *Gateway) callAgent(ctx context.Context, name, message string) (string, 
 	if err := g.opts.Client.Call(ctx, req, &rsp); err != nil {
 		return "", err
 	}
-	var out struct {
-		Reply string `json:"reply"`
-	}
-	if err := json.Unmarshal(rsp.Data, &out); err != nil {
+	reply, err := decodeAgentChatReply(rsp.Data)
+	if err != nil {
 		return "", err
 	}
-	return out.Reply, nil
+	return reply, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -974,6 +975,35 @@ func textArtifact(text string) Artifact {
 		ArtifactID: uuid.New().String(),
 		Parts:      []Part{{Kind: "text", Text: text}},
 	}
+}
+
+func decodeAgentChatReply(data []byte) (string, error) {
+	var out struct {
+		Reply   string `json:"reply"`
+		Answer  string `json:"answer"`
+		Content string `json:"content"`
+		Text    string `json:"text"`
+		Message struct {
+			Content string `json:"content"`
+			Text    string `json:"text"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return "", err
+	}
+	for _, candidate := range []string{
+		out.Reply,
+		out.Answer,
+		out.Content,
+		out.Text,
+		out.Message.Content,
+		out.Message.Text,
+	} {
+		if strings.TrimSpace(candidate) != "" {
+			return candidate, nil
+		}
+	}
+	return "", nil
 }
 
 // requestContext carries request cancellation and deadlines into the downstream

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -523,6 +523,65 @@ func TestMessageStreamChunksFallsBackWhenUnsupported(t *testing.T) {
 	}
 }
 
+func TestMessageStreamFallbackDoesNotCompleteWithEmptyText(t *testing.T) {
+	d := newDispatcher()
+	body := `{"jsonrpc":"2.0","id":1,"method":"message/stream","params":{"message":{"role":"user","parts":[{"kind":"text","text":"ping"}],"kind":"message"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+
+	d.serveWithStream(rr, req, func(context.Context, string) (string, error) {
+		return "", nil
+	}, func(context.Context, string) (ai.Stream, error) {
+		return nil, fmt.Errorf("%w: test provider", ai.ErrStreamingUnsupported)
+	})
+
+	var event struct {
+		Result Task      `json:"result"`
+		Error  *rpcError `json:"error"`
+	}
+	for _, line := range strings.Split(strings.TrimSpace(rr.Body.String()), "\n") {
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "data: "))
+		if line == "" {
+			continue
+		}
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("decode event %q: %v", line, err)
+		}
+	}
+	if event.Error != nil {
+		t.Fatalf("fallback event error: %+v", event.Error)
+	}
+	if event.Result.Status.State != stateFailed {
+		t.Fatalf("fallback state = %q, want failed", event.Result.Status.State)
+	}
+	if got := textOf(event.Result.Artifacts[0].Parts); got == "" {
+		t.Fatalf("fallback artifact text is empty: %+v", event.Result.Artifacts)
+	}
+	if got := textOf(event.Result.History[len(event.Result.History)-1].Parts); got == "" {
+		t.Fatalf("fallback history text is empty: %+v", event.Result.History)
+	}
+}
+
+func TestDecodeAgentChatReplyFallsBackToProviderTextFields(t *testing.T) {
+	for name, body := range map[string]string{
+		"answer":          `{"answer":"answer text"}`,
+		"content":         `{"content":"content text"}`,
+		"text":            `{"text":"text field"}`,
+		"message_content": `{"message":{"content":"message content"}}`,
+		"message_text":    `{"message":{"text":"message text"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := decodeAgentChatReply([]byte(body))
+			if err != nil {
+				t.Fatalf("decodeAgentChatReply error: %v", err)
+			}
+			if strings.TrimSpace(got) == "" {
+				t.Fatalf("decodeAgentChatReply(%s) returned empty text", body)
+			}
+		})
+	}
+}
+
 func TestTasksResubscribeStreamsCurrentAndSubsequentEvents(t *testing.T) {
 	d := newDispatcher()
 	initial := &Task{ID: "task-1", ContextID: "ctx-1", Kind: "task", Status: TaskStatus{State: stateWorking, Timestamp: time.Now().UTC().Format(time.RFC3339)}}


### PR DESCRIPTION
Summary:
- Decode A2A gateway Agent.Chat replies from provider-compatible text fields when `reply` is absent.
- Prevent streaming fallback from completing tasks with empty artifact/history text by returning a failed diagnostic task instead.

Testing:
- go build ./...
- go test ./gateway/a2a
- go test ./... (environment warnings: AtlasCloud configured-provider stream returned 400; loopback gRPC targets are forbidden in this sandbox)
- golangci-lint run ./...

Closes #4522
Closes #4547