### PR TITLE
docs(loop): formalize the agent-agnostic mention model

### DIFF
--- a/cmd/micro/README.md
+++ b/cmd/micro/README.md
@@ -684,7 +684,7 @@ micro loop init \
 ```
 
 - `--roles`: which roles to scaffold (`planner,builder,triage`, or `all`)
-- `--agent`: how the workflows summon the agent (an `@mention`)
+- `--agent`: how the workflows summon the agent — any `@mention`-driven coding agent (e.g. `@codex`, `@claude`)
 - `--token-secret`: repo secret holding the driving user PAT
 - `--branch`: base branch for the loop's PRs
 - `--ci-workflow`: `name:` of the CI workflow triage watches

--- a/cmd/micro/loop/loop.go
+++ b/cmd/micro/loop/loop.go
@@ -123,7 +123,7 @@ Examples:
 					&cli.StringFlag{Name: "dir", Usage: "Target repo directory", Value: "."},
 					&cli.StringFlag{Name: "roles", Usage: "Comma-separated roles, or 'all'", Value: "planner,builder,triage"},
 					&cli.StringFlag{Name: "branch", Usage: "Base branch for the loop's PRs (auto-detected if empty)"},
-					&cli.StringFlag{Name: "agent", Usage: "How the workflows summon the agent (an @mention)", Value: "@codex"},
+					&cli.StringFlag{Name: "agent", Usage: "How the workflows summon the agent — any @mention-driven coding agent (e.g. @codex, @claude)", Value: "@codex"},
 					&cli.StringFlag{Name: "token-secret", Usage: "Repo secret holding the user PAT that drives dispatch", Value: "LOOP_TOKEN"},
 					&cli.StringFlag{Name: "ci-workflow", Usage: "CI workflow name(s) triage watches for failures (comma-separated)", Value: "CI"},
 					&cli.StringFlag{Name: "planner-cron", Usage: "Cron schedule for the planner", Value: "0 * * * *"},

--- a/internal/website/docs/guides/micro-loop.md
+++ b/internal/website/docs/guides/micro-loop.md
@@ -50,6 +50,29 @@ branches, create pull requests, and enable auto-merge. Run `gh auth setup-git` i
 the environment that will push branches so `git push` uses the same credentials
 as `gh`.
 
+## Choosing an agent
+
+The loop is **agent-agnostic by design**. Each run opens a fresh tracking issue
+and summons the agent with an `@mention` comment; the prompt file
+(`.github/loop/prompts/<role>.md`) is the instruction. Any coding agent that
+(a) responds to an `@mention` on an issue and (b) can open a PR with `gh` works —
+you select it with `--agent`.
+
+- **Codex** (`--agent @codex`, the default). Point `--token-secret` at a PAT for
+  the user account Codex follows, and make sure the Codex environment installs
+  `gh` and runs `gh auth setup-git`. This is the path Go Micro itself runs on.
+- **Claude Code** (`--agent @claude`). Install
+  [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action)
+  in the repo so a workflow responds to `@claude` comments and runs Claude with a
+  repo-scoped token; then the loop's dispatch triggers it like any other mention.
+- **Any other mention-driven agent** — pass its handle to `--agent`. The
+  mechanics don't care which agent it is.
+
+Not supported by the mention model: agents triggered by **issue assignment**
+rather than a comment (e.g. GitHub Copilot's coding agent, which you assign an
+issue to). The dispatch would need an "assign" adapter for those; it isn't wired
+yet, so stick to mention-driven agents.
+
 ## 3. Make CI the gate
 
 The loop should not be its own reviewer. Protect the default branch so PRs merge


### PR DESCRIPTION
Step 2 of the queue — the "agent adapter," scoped honestly.

On inspection, the loop's dispatch is **already agent-agnostic**: `--agent` just sets the `@mention` the workflow posts, so any coding agent that responds to an issue mention and opens a PR works. The gap was never mechanics — it was that this wasn't documented, so it read as Codex-only. This makes it explicit.

## Changes (docs + help text only, no behavior change)
- **`micro-loop` guide** — new "Choosing an agent" section:
  - **Codex** (`--agent @codex`, default) — the path go-micro runs on.
  - **Claude Code** (`--agent @claude`) — via `anthropics/claude-code-action` responding to `@claude`.
  - Any other mention-driven agent.
  - An honest caveat: agents triggered by **issue assignment** (e.g. Copilot's coding agent) aren't supported by the mention dispatch — that would need an "assign" adapter, not yet wired.
- `--agent` CLI help + README bullet clarified.

## Why this scope
I deliberately did **not** fabricate a Copilot/assign adapter — I can't verify its trigger mechanics blind (the same discipline that avoided the fictional `gemma4` model earlier). The mention model genuinely covers Codex and Claude today; the one real gap is documented as future work rather than shipped broken.

Docs/help-text only; `go test ./cmd/micro/loop/...` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_