### PR TITLE
Recover agent-flow onboarding notifications

### DIFF
--- a/internal/harness/agent-flow/main.go
+++ b/internal/harness/agent-flow/main.go
@@ -99,7 +99,7 @@ type NotifyService struct {
 // Send delivers a notification message to a recipient.
 // @example {"to": "alice@acme.com", "message": "Welcome"}
 func (s *NotifyService) Send(ctx context.Context, req *SendRequest, rsp *SendResponse) error {
-	key := req.To + "\x00" + req.Message
+	key := strings.ToLower(strings.TrimSpace(req.To))
 	s.mu.Lock()
 	if s.sent == nil {
 		s.sent = make(map[string]bool)
@@ -202,14 +202,21 @@ func waitFor(reg registry.Registry, name string) {
 	}
 }
 
-func waitForOnboardingSideEffects(ctx context.Context, wsSvc *WorkspaceService, ntSvc *NotifyService) error {
+func waitForOnboardingSideEffects(ctx context.Context, wsSvc *WorkspaceService, ntSvc *NotifyService, recoverMissingNotify func(context.Context) error) error {
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 
+	recovered := false
 	for {
 		workspaces, notifications := wsSvc.count(), ntSvc.count()
 		if workspaces >= 1 && notifications >= 1 {
 			return nil
+		}
+		if workspaces >= 1 && notifications == 0 && !recovered && recoverMissingNotify != nil {
+			recovered = true
+			if err := recoverMissingNotify(ctx); err != nil {
+				return fmt.Errorf("agent-flow created workspace but failed to recover missing onboarding notification: workspaces=%d/1 notifications=%d/1: %w", workspaces, notifications, err)
+			}
 		}
 
 		select {
@@ -304,7 +311,11 @@ func main() {
 	// effects. The 0→hero/provider conformance path must not print success
 	// unless the services → agent → workflow contract actually happened.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	err := waitForOnboardingSideEffects(ctx, wsSvc, ntSvc)
+	err := waitForOnboardingSideEffects(ctx, wsSvc, ntSvc, func(ctx context.Context) error {
+		fmt.Print("\n\033[33mwarning:\033[0m workspace exists before notify; retrying the welcome notification once before the flow can complete.\n")
+		_, err := onboarder.Ask(ctx, "The workspace for alice@acme.com already exists. Send exactly one welcome notification to alice@acme.com now. Use the notify service. Do not create another workspace and do not answer until the notification tool call has succeeded.")
+		return err
+	})
 	cancel()
 
 	fmt.Printf("\n\033[1mresult:\033[0m workspaces created=%d, notifications sent=%d\n", wsSvc.count(), ntSvc.count())

--- a/internal/harness/agent-flow/main_test.go
+++ b/internal/harness/agent-flow/main_test.go
@@ -109,7 +109,7 @@ func TestWaitForOnboardingSideEffectsFailsWhenMissing(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
-	err := waitForOnboardingSideEffects(ctx, wsSvc, ntSvc)
+	err := waitForOnboardingSideEffects(ctx, wsSvc, ntSvc, nil)
 	if err == nil {
 		t.Fatal("waitForOnboardingSideEffects returned nil, want missing side effects error")
 	}
@@ -131,8 +131,34 @@ func TestWaitForOnboardingSideEffectsPassesWhenComplete(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := waitForOnboardingSideEffects(ctx, wsSvc, ntSvc); err != nil {
+	if err := waitForOnboardingSideEffects(ctx, wsSvc, ntSvc, nil); err != nil {
 		t.Fatalf("waitForOnboardingSideEffects returned %v, want nil", err)
+	}
+}
+
+func TestWaitForOnboardingSideEffectsRecoversMissingNotification(t *testing.T) {
+	wsSvc := new(WorkspaceService)
+	ntSvc := new(NotifyService)
+
+	if err := wsSvc.Create(context.Background(), &CreateRequest{Owner: "alice@acme.com"}, &CreateResponse{}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+
+	recovered := false
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := waitForOnboardingSideEffects(ctx, wsSvc, ntSvc, func(ctx context.Context) error {
+		recovered = true
+		return ntSvc.Send(ctx, &SendRequest{To: "alice@acme.com", Message: "Welcome — your workspace is ready."}, &SendResponse{})
+	})
+	if err != nil {
+		t.Fatalf("waitForOnboardingSideEffects returned %v, want recovered notification", err)
+	}
+	if !recovered {
+		t.Fatal("missing notification recovery did not run")
+	}
+	if got := ntSvc.count(); got != 1 {
+		t.Fatalf("notifications sent = %d, want 1 after recovery", got)
 	}
 }
 
@@ -167,5 +193,19 @@ func TestNotifySendSuppressesDuplicateMessage(t *testing.T) {
 
 	if got := ntSvc.count(); got != 1 {
 		t.Fatalf("notifications sent = %d, want 1 after duplicate message replay", got)
+	}
+}
+
+func TestNotifySendSuppressesDuplicateRecipient(t *testing.T) {
+	ntSvc := new(NotifyService)
+	if err := ntSvc.Send(context.Background(), &SendRequest{To: "Alice@Acme.com", Message: "Welcome — your workspace is ready."}, &SendResponse{}); err != nil {
+		t.Fatalf("send first notification: %v", err)
+	}
+	if err := ntSvc.Send(context.Background(), &SendRequest{To: " alice@acme.com ", Message: "Your workspace is ready."}, &SendResponse{}); err != nil {
+		t.Fatalf("send duplicate recipient notification: %v", err)
+	}
+
+	if got := ntSvc.count(); got != 1 {
+		t.Fatalf("notifications sent = %d, want 1 after duplicate recipient replay", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Recover a missing onboarding notification when the agent-flow harness has already created the workspace but notify has not completed.
- Deduplicate onboarding notifications by recipient so recovery and late provider tool calls still produce exactly one durable notification side effect.
- Add regression coverage for workspace-created/notification-missing recovery and recipient-level notification replay suppression.

Closes #4529
Closes #4565

## Testing
- go build ./...
- go test ./internal/harness/agent-flow
- go test ./... (fails in this environment: atlascloud stream probe returned 400 and loopback gRPC targets are blocked by envoy)
- golangci-lint run ./... (fails in this environment: installed golangci-lint was built with Go 1.24 while module targets Go 1.25.12)