### PR TITLE
Tighten agent provider conformance coverage

### DIFF
--- a/agent/conformance_test.go
+++ b/agent/conformance_test.go
@@ -22,17 +22,20 @@ type conformanceProvider struct {
 	live  bool
 }
 
+var agentConformanceProviders = []conformanceProvider{
+	{name: "fake"},
+	{name: "openai", key: "OPENAI_API_KEY", model: "GO_MICRO_CONFORMANCE_OPENAI_MODEL", live: true},
+	{name: "anthropic", key: "ANTHROPIC_API_KEY", model: "GO_MICRO_CONFORMANCE_ANTHROPIC_MODEL", live: true},
+	{name: "atlascloud", key: "ATLASCLOUD_API_KEY", model: "GO_MICRO_CONFORMANCE_ATLASCLOUD_MODEL", live: true},
+	{name: "gemini", key: "GEMINI_API_KEY", model: "GO_MICRO_CONFORMANCE_GEMINI_MODEL", live: true},
+	{name: "groq", key: "GROQ_API_KEY", model: "GO_MICRO_CONFORMANCE_GROQ_MODEL", live: true},
+	{name: "minimax", key: "MINIMAX_API_KEY", model: "GO_MICRO_CONFORMANCE_MINIMAX_MODEL", live: true},
+	{name: "mistral", key: "MISTRAL_API_KEY", model: "GO_MICRO_CONFORMANCE_MISTRAL_MODEL", live: true},
+	{name: "together", key: "TOGETHER_API_KEY", model: "GO_MICRO_CONFORMANCE_TOGETHER_MODEL", live: true},
+}
+
 func TestAgentProviderConformanceMatrix(t *testing.T) {
-	providers := []conformanceProvider{
-		{name: "fake"},
-		{name: "openai", key: "OPENAI_API_KEY", model: "GO_MICRO_CONFORMANCE_OPENAI_MODEL", live: true},
-		{name: "anthropic", key: "ANTHROPIC_API_KEY", model: "GO_MICRO_CONFORMANCE_ANTHROPIC_MODEL", live: true},
-		{name: "atlascloud", key: "ATLASCLOUD_API_KEY", model: "GO_MICRO_CONFORMANCE_ATLASCLOUD_MODEL", live: true},
-		{name: "gemini", key: "GEMINI_API_KEY", model: "GO_MICRO_CONFORMANCE_GEMINI_MODEL", live: true},
-		{name: "groq", key: "GROQ_API_KEY", model: "GO_MICRO_CONFORMANCE_GROQ_MODEL", live: true},
-		{name: "mistral", key: "MISTRAL_API_KEY", model: "GO_MICRO_CONFORMANCE_MISTRAL_MODEL", live: true},
-		{name: "together", key: "TOGETHER_API_KEY", model: "GO_MICRO_CONFORMANCE_TOGETHER_MODEL", live: true},
-	}
+	providers := agentConformanceProviders
 
 	selected := selectedConformanceProviders(os.Getenv("GO_MICRO_AGENT_CONFORMANCE_PROVIDERS"))
 	for _, provider := range providers {
@@ -47,16 +50,7 @@ func TestAgentProviderConformanceMatrix(t *testing.T) {
 }
 
 func TestAgentProviderStreamConformanceMatrix(t *testing.T) {
-	providers := []conformanceProvider{
-		{name: "fake"},
-		{name: "openai", key: "OPENAI_API_KEY", model: "GO_MICRO_CONFORMANCE_OPENAI_MODEL", live: true},
-		{name: "anthropic", key: "ANTHROPIC_API_KEY", model: "GO_MICRO_CONFORMANCE_ANTHROPIC_MODEL", live: true},
-		{name: "atlascloud", key: "ATLASCLOUD_API_KEY", model: "GO_MICRO_CONFORMANCE_ATLASCLOUD_MODEL", live: true},
-		{name: "groq", key: "GROQ_API_KEY", model: "GO_MICRO_CONFORMANCE_GROQ_MODEL", live: true},
-		{name: "minimax", key: "MINIMAX_API_KEY", model: "GO_MICRO_CONFORMANCE_MINIMAX_MODEL", live: true},
-		{name: "mistral", key: "MISTRAL_API_KEY", model: "GO_MICRO_CONFORMANCE_MISTRAL_MODEL", live: true},
-		{name: "together", key: "TOGETHER_API_KEY", model: "GO_MICRO_CONFORMANCE_TOGETHER_MODEL", live: true},
-	}
+	providers := streamConformanceProviders()
 
 	selected := selectedConformanceProviders(os.Getenv("GO_MICRO_AGENT_CONFORMANCE_PROVIDERS"))
 	for _, provider := range providers {
@@ -67,6 +61,46 @@ func TestAgentProviderStreamConformanceMatrix(t *testing.T) {
 		t.Run(provider.name, func(t *testing.T) {
 			runAgentStreamConformanceScenario(t, provider)
 		})
+	}
+}
+
+func streamConformanceProviders() []conformanceProvider {
+	providers := make([]conformanceProvider, 0, len(agentConformanceProviders))
+	for _, provider := range agentConformanceProviders {
+		// Gemini is covered by the non-streaming agent/tool matrix, but does not
+		// currently advertise streaming in the provider capability registry.
+		if provider.name == "gemini" {
+			continue
+		}
+		providers = append(providers, provider)
+	}
+	return providers
+}
+
+func TestAgentProviderConformanceMatrixIncludesEveryLiveProvider(t *testing.T) {
+	want := map[string]string{
+		"openai":     "OPENAI_API_KEY",
+		"anthropic":  "ANTHROPIC_API_KEY",
+		"atlascloud": "ATLASCLOUD_API_KEY",
+		"gemini":     "GEMINI_API_KEY",
+		"groq":       "GROQ_API_KEY",
+		"minimax":    "MINIMAX_API_KEY",
+		"mistral":    "MISTRAL_API_KEY",
+		"together":   "TOGETHER_API_KEY",
+	}
+	got := map[string]string{}
+	for _, provider := range agentConformanceProviders {
+		if provider.live {
+			got[provider.name] = provider.key
+		}
+	}
+	for name, key := range want {
+		if got[name] != key {
+			t.Fatalf("agentConformanceProviders[%q] key = %q, want %q", name, got[name], key)
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("agentConformanceProviders live providers = %#v, want exactly %#v", got, want)
 	}
 }
 

--- a/internal/docs/AGENT_CONFORMANCE.md
+++ b/internal/docs/AGENT_CONFORMANCE.md
@@ -3,8 +3,11 @@
 `go test ./...` includes `TestAgentProviderConformanceMatrix`, a shared agent
 scenario that runs against every registered chat provider. The scenario asks an
 agent to call a deterministic local tool, verifies the tool receives `ai.RunInfo`,
-and checks the final response carries the conformance marker. A fake provider path
-runs on every machine without network access so CI always exercises the harness.
+and checks the final response carries the conformance marker. The live matrix
+includes MiniMax in the tool/guardrail path in addition to providers with
+streaming coverage, so every supported chat provider has at least one key-gated
+agent contract. A fake provider path runs on every machine without network
+access so CI always exercises the harness.
 
 Live providers are opt-in to avoid flaky unauthenticated PR checks and accidental
 API spend. To run the live matrix, set `GO_MICRO_AGENT_CONFORMANCE_LIVE=1` plus the


### PR DESCRIPTION
## Summary
- Adds MiniMax to the core agent provider conformance matrix so every supported chat provider has a key-gated tool/guardrail contract.
- Reuses the provider list for stream conformance while keeping Gemini excluded from streaming-only coverage because it does not advertise streaming capability.
- Documents the MiniMax tool/guardrail coverage in the agent conformance guide.

Closes #4568
Closes #4574

## Testing
- go test ./agent -run 'TestAgentProviderConformanceMatrixIncludesEveryLiveProvider|TestAgentProviderConformanceMatrix/fake|TestAgentProviderStreamConformanceMatrix/fake' -count=1\n- go build ./...\n- go test ./... (environment warning: local sandbox proxy rejects loopback gRPC targets; atlascloud stream test hit configured live endpoint)\n- golangci-lint run ./... (environment warning: installed golangci-lint was built with Go 1.24 but repo targets Go 1.25.12)