### PR TITLE
Complete plan-delegate after observed notify

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -630,11 +630,11 @@ func waitForPlanDelegateExecution(done <-chan error, taskSvc *TaskService, notif
 			tasks := taskSvc.count()
 			notify := notifySvc.count()
 			if err != nil {
+				if hasCompletedPlanDelegateSideEffects(tasks, notify) {
+					fmt.Printf("\n\033[33mwarning:\033[0m flow execute returned after completed side effects: %v\n", err)
+					return nil
+				}
 				if isClientTimeout(err) {
-					if tasks > 0 && notify == 1 {
-						fmt.Printf("\n\033[33mwarning:\033[0m flow execute returned after completed side effects: %v\n", err)
-						return nil
-					}
 					return classifiedPlanDelegateTimeout(tasks, notify, err)
 				}
 				if isUnfinishedPlanError(err) && tasks > 0 && notify == 0 && recoverMissingNotify != nil {
@@ -676,6 +676,10 @@ func waitForNotifySideEffect(notifySvc *NotifyService, timeout time.Duration) (b
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+}
+
+func hasCompletedPlanDelegateSideEffects(tasks, notify int) bool {
+	return tasks == 3 && notify == 1
 }
 
 func classifiedPlanDelegateTimeout(tasks, notify int, err error) error {

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -600,6 +600,28 @@ func TestPlanDelegateExecutionAcceptsClientTimeoutAfterSideEffects(t *testing.T)
 	}
 }
 
+func TestPlanDelegateExecutionAcceptsApprovalPauseAfterSideEffects(t *testing.T) {
+	taskSvc := new(TaskService)
+	for _, title := range []string{"Design", "Build", "Ship"} {
+		var rsp AddResponse
+		if err := taskSvc.Add(context.Background(), &AddRequest{Title: title}, &rsp); err != nil {
+			t.Fatalf("Add(%q): %v", title, err)
+		}
+	}
+	notifySvc := new(NotifyService)
+	var rsp SendResponse
+	if err := notifySvc.Send(context.Background(), &SendRequest{To: "owner@acme.com", Message: "The launch plan is ready"}, &rsp); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	done := make(chan error, 1)
+	done <- errors.New("agent run abc paused for approval: The comms agent is repeatedly timing out (408 errors) while retrying the launch-readiness notification")
+
+	if err := waitForPlanDelegateExecution(done, taskSvc, notifySvc, nil); err != nil {
+		t.Fatalf("waitForPlanDelegateExecution returned %v, want completed side effects to satisfy approval pause", err)
+	}
+}
+
 func TestPlanDelegateExecutionClassifiesClientTimeoutBeforeSideEffects(t *testing.T) {
 	done := make(chan error, 1)
 	done <- errors.New(`{"id":"go.micro.client","code":408,"detail":"<nil>","status":"Request Timeout"}`)


### PR DESCRIPTION
## Summary
- Treat completed plan-delegate side effects (exactly three launch tasks and one owner notification) as sufficient even if the provider reports a late approval pause/error while retrying.
- Add a regression for AtlasCloud-style approval pauses after the notify side effect has already landed.

Closes #4573
Closes #4579

## Testing
- go test ./internal/harness/plan-delegate -run 'TestPlanDelegateExecutionAcceptsApprovalPauseAfterSideEffects|TestPlanDelegateExecutionAcceptsClientTimeoutAfterSideEffects|TestPlanDelegateExecutionClassifiesPartialClientTimeout' -count=1\n- go build ./...\n- go test ./... (fails in this sandbox: atlascloud stream credentials/proxy behavior and loopback targets forbidden for grpc tests)\n- golangci-lint run ./... (fails because installed golangci-lint was built with Go 1.24 while repo targets Go 1.25.12)