### PR TITLE
Finalize universe notify after agent timeout

### DIFF
--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -269,13 +269,21 @@ func completeNotifyOnObservedSideEffect(ctx context.Context, in flow.State, ntf 
 			in.Data = []byte("Buyer notified.")
 			return in, nil
 		}
+		wait := time.NewTimer(25 * time.Millisecond)
 		select {
 		case <-ctx.Done():
-			if dispatchErr != nil {
-				return in, dispatchErr
+			if !wait.Stop() {
+				<-wait.C
 			}
-			return in, ctx.Err()
-		case <-time.After(25 * time.Millisecond):
+			if dispatchErr == nil {
+				return in, ctx.Err()
+			}
+			// A timed-out Agent.Chat call can report the caller context as done
+			// while the remote agent is still finishing its notify tool call.
+			// Keep watching for the idempotent side effect until the local settle
+			// window expires so a post-side-effect timeout does not strand the
+			// durable checkout run as pending.
+		case <-wait.C:
 		}
 	}
 	if dispatchErr != nil {

--- a/internal/harness/universe/main_test.go
+++ b/internal/harness/universe/main_test.go
@@ -69,6 +69,42 @@ func TestNotifyStepCompletesAfterObservedSideEffectTimeout(t *testing.T) {
 	}
 }
 
+func TestNotifyStepWaitsForObservedSideEffectAfterCanceledDispatchContext(t *testing.T) {
+	ntf := new(Notify)
+	before := atomic.LoadInt64(&ntf.sent)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		var rsp SendResponse
+		if err := ntf.Send(context.Background(), &SendRequest{
+			To:      "buyer@acme.com",
+			Message: "Your order is confirmed.",
+		}, &rsp); err != nil {
+			t.Errorf("send notification: %v", err)
+		}
+	}()
+
+	out, err := completeNotifyOnObservedSideEffect(
+		ctx,
+		flow.State{Data: []byte(`{"order":"order-1"}`)},
+		ntf,
+		before,
+		time.Second,
+		errors.New("client observed timeout"),
+	)
+	if err != nil {
+		t.Fatalf("notify completion returned error: %v", err)
+	}
+	if got := out.String(); got != "Buyer notified." {
+		t.Fatalf("result = %q, want Buyer notified.", got)
+	}
+	if got := atomic.LoadInt64(&ntf.sent); got != 1 {
+		t.Fatalf("notifications sent = %d, want 1", got)
+	}
+}
+
 func TestNotifyStepRejectsClaimedCompletionWithoutSideEffect(t *testing.T) {
 	ntf := new(Notify)
 	before := atomic.LoadInt64(&ntf.sent)


### PR DESCRIPTION
## Summary
- Keep the universe checkout notify step watching for an observed buyer notification after Agent.Chat returns a timeout with a canceled context, so post-side-effect timeouts do not strand the durable flow.
- Add regression coverage for the canceled-dispatch-context path.

## Testing
- go test ./internal/harness/universe -run TestNotifyStep -count=1
- go build ./...
- go test ./... (fails in this environment: atlascloud stream conformance received 400 not found; grpc loopback tests are blocked by envoy Loopback targets forbidden)
- golangci-lint run ./... (fails: installed golangci-lint was built with Go 1.24, below target Go 1.25.12)

Closes #4572
Closes #4584