### PR TITLE
Add agent resume breadcrumbs

### DIFF
--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -224,12 +224,42 @@ func writeRunIndex(w io.Writer, name string, runs []goagent.RunSummary, asJSON b
 		if run.TraceID != "" {
 			line += "  trace=" + shortTraceID(run.TraceID)
 		}
+		if run.Checkpoint != "" {
+			line += "  checkpoint=" + run.Checkpoint
+		}
+		if run.Stage != "" {
+			line += "  stage=" + run.Stage
+		}
 		if run.LastError != "" {
 			line += "  error=" + run.LastError
 		}
 		fmt.Fprintln(w, line)
+		writeRunIndexBreadcrumbs(w, name, run)
 	}
 	return nil
+}
+
+func writeRunIndexBreadcrumbs(w io.Writer, name string, run goagent.RunSummary) {
+	if run.Stage == "input-required" {
+		fmt.Fprintf(w, "      inspect: micro agent history %s %s\n", name, run.RunID)
+		fmt.Fprintf(w, "      input:   call micro.AgentResumeInput(ctx, agent, %q, input) to continue the input-required run\n", run.RunID)
+		return
+	}
+	if !isResumableRunSummary(run) {
+		return
+	}
+	fmt.Fprintf(w, "      inspect: micro agent history %s %s\n", name, run.RunID)
+	fmt.Fprintf(w, "      resume:  call micro.AgentResume(ctx, agent, %q) after recreating the agent with the same checkpoint store\n", run.RunID)
+	fmt.Fprintf(w, "      stream:  call micro.ResumeStreamAsk(ctx, agent, %q) to resume with streaming events\n", run.RunID)
+}
+
+func isResumableRunSummary(run goagent.RunSummary) bool {
+	switch run.Status {
+	case "running", "error", "failed", "refused":
+		return run.Checkpoint != "done" || run.Stage != ""
+	default:
+		return false
+	}
 }
 
 func printRunHistory(name, runID string, asJSON bool) error {

--- a/cmd/micro/cli/agent/agent_test.go
+++ b/cmd/micro/cli/agent/agent_test.go
@@ -59,6 +59,46 @@ func TestWriteRunIndexHumanIncludesStatusAndDuration(t *testing.T) {
 	}
 }
 
+func TestWriteRunIndexIncludesResumeBreadcrumbs(t *testing.T) {
+	runs := []goagent.RunSummary{{
+		RunID:      "run-failed",
+		Agent:      "runner",
+		UpdatedAt:  time.Date(2026, 6, 25, 12, 34, 56, 0, time.UTC),
+		Events:     3,
+		Status:     "error",
+		LastKind:   "tool",
+		Checkpoint: "failed",
+		Stage:      "ask",
+	}}
+	var out bytes.Buffer
+	if err := writeRunIndex(&out, "runner", runs, false); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{"checkpoint=failed", "stage=ask", `micro agent history runner run-failed`, `micro.AgentResume(ctx, agent, "run-failed")`, `micro.ResumeStreamAsk(ctx, agent, "run-failed")`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteRunIndexInputRequiredUsesResumeInput(t *testing.T) {
+	runs := []goagent.RunSummary{{RunID: "run-input", Agent: "runner", Status: "running", LastKind: "checkpoint", Checkpoint: "paused", Stage: "input-required"}}
+	var out bytes.Buffer
+	if err := writeRunIndex(&out, "runner", runs, false); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{`micro agent history runner run-input`, `micro.AgentResumeInput(ctx, agent, "run-input", input)`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, `micro.AgentResume(ctx, agent, "run-input")`) || strings.Contains(got, "ResumeStreamAsk") {
+		t.Fatalf("input-required run should point at ResumeInput only, got:\n%s", got)
+	}
+}
+
 func TestWriteRunHistoryHumanAndJSON(t *testing.T) {
 	events := []goagent.RunEvent{{
 		Time:      time.Date(2026, 6, 25, 12, 34, 56, 7_000_000, time.UTC),

--- a/cmd/micro/inspect/inspect.go
+++ b/cmd/micro/inspect/inspect.go
@@ -98,14 +98,23 @@ func writeAgentInspection(w io.Writer, name string, runs []goagent.RunSummary, a
 			fmt.Fprintf(w, "  trace=%s", shortID(run.TraceID))
 		}
 		fmt.Fprintln(w)
-		if isResumableAgentRun(run) {
-			fmt.Fprintf(w, "    resume: call micro.AgentResume(ctx, agent, %q) after recreating the agent with the same checkpoint store\n", run.RunID)
-		}
-		if run.Stage == "input-required" {
-			fmt.Fprintf(w, "    input:  call micro.AgentResumeInput(ctx, agent, %q, input) to continue the paused run\n", run.RunID)
-		}
+		writeAgentRunBreadcrumbs(w, name, run)
 	}
 	return nil
+}
+
+func writeAgentRunBreadcrumbs(w io.Writer, name string, run goagent.RunSummary) {
+	if run.Stage == "input-required" {
+		fmt.Fprintf(w, "    inspect: micro agent history %s %s\n", name, run.RunID)
+		fmt.Fprintf(w, "    input:   call micro.AgentResumeInput(ctx, agent, %q, input) to continue the input-required run\n", run.RunID)
+		return
+	}
+	if !isResumableAgentRun(run) {
+		return
+	}
+	fmt.Fprintf(w, "    inspect: micro agent history %s %s\n", name, run.RunID)
+	fmt.Fprintf(w, "    resume:  call micro.AgentResume(ctx, agent, %q) after recreating the agent with the same checkpoint store\n", run.RunID)
+	fmt.Fprintf(w, "    stream:  call micro.ResumeStreamAsk(ctx, agent, %q) to resume with streaming events\n", run.RunID)
 }
 
 func isResumableAgentRun(run goagent.RunSummary) bool {

--- a/cmd/micro/inspect/inspect_test.go
+++ b/cmd/micro/inspect/inspect_test.go
@@ -17,7 +17,7 @@ func TestWriteAgentInspectionIncludesActionableBreadcrumbs(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := out.String()
-	for _, want := range []string{"Agent \"support\" runs", "run-1", "status=error", "events=4", "last=tool", "checkpoint=failed", "stage=ask", `error="boom"`, "trace=1234567890ab", `micro.AgentResume(ctx, agent, "run-1")`} {
+	for _, want := range []string{"Agent \"support\" runs", "run-1", "status=error", "events=4", "last=tool", "checkpoint=failed", "stage=ask", `error="boom"`, "trace=1234567890ab", `micro agent history support run-1`, `micro.AgentResume(ctx, agent, "run-1")`, `micro.ResumeStreamAsk(ctx, agent, "run-1")`} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q:\n%s", want, got)
 		}
@@ -31,10 +31,13 @@ func TestWriteAgentInspectionIncludesInputResumeBreadcrumb(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := out.String()
-	for _, want := range []string{"checkpoint=paused", "stage=input-required", `micro.AgentResumeInput(ctx, agent, "run-input", input)`} {
+	for _, want := range []string{"checkpoint=paused", "stage=input-required", `micro agent history support run-input`, `micro.AgentResumeInput(ctx, agent, "run-input", input)`} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q:\n%s", want, got)
 		}
+	}
+	if strings.Contains(got, `micro.AgentResume(ctx, agent, "run-input")`) || strings.Contains(got, "ResumeStreamAsk") {
+		t.Fatalf("input-required run should point at ResumeInput only, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
Adds clearer next-step breadcrumbs for agent run inspection on top of the existing durable run history work.

Summary:
- Show inspect/history commands next to resumable agent runs.
- Distinguish input-required pauses with ResumeInput-only guidance.
- Surface streaming resume guidance for normal resumable runs.

Testing:
- go build ./...
- go test ./cmd/micro/inspect ./cmd/micro/cli/agent
- go test ./... (fails in this environment: AtlasCloud configured-provider test returns 400; grpc loopback tests are blocked by envoy loopback policy)
- golangci-lint run ./... (system binary cannot load Go 1.25.12 config; freshly installed v2.12.2 reports existing issues outside this change)

Closes #4569
Closes #4588