### PR TITLE
Add first-agent quickcheck breadcrumbs

### DIFF
--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -14,6 +14,32 @@ import (
 	"go-micro.dev/v6/store"
 )
 
+const firstAgentQuickChecksHelp = `First-agent failure-mode quick checks
+
+Use this when scaffold -> run -> chat -> inspect stalls and you want the
+smallest provider-free recovery loop before reading the full docs.
+
+1. Confirm prerequisites before starting the gateway:
+   micro agent preflight
+
+2. Start the project and keep it running in a separate terminal:
+   micro run
+
+3. Check the agent is registered and the chat gateway is reachable:
+   micro agent doctor
+
+4. If chat returns an answer or an error, inspect the latest run state:
+   micro inspect agent <name>
+   micro runs <name>
+
+5. If provider chat is not configured yet, prove the no-secret path still works:
+   micro agent demo
+   go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1
+
+Recovery docs:
+  https://go-micro.dev/docs/guides/debugging-agents.html
+  https://go-micro.dev/docs/guides/no-secret-first-agent.html`
+
 const noSecretDemoHelp = `No-secret first-agent demo
 
 Use this when you want the fastest provider-free agent success path before
@@ -69,6 +95,18 @@ the deterministic mock-model transcript, when to use it, and where to go next
 for live-provider chat and inspect/debugging.`,
 				Action: func(c *cli.Context) error {
 					fmt.Fprintln(c.App.Writer, noSecretDemoHelp)
+					return nil
+				},
+			},
+			{
+				Name:    "quickcheck",
+				Aliases: []string{"debug"},
+				Usage:   "Print first-agent failure-mode quick checks",
+				Description: `Print provider-free recovery breadcrumbs for the scaffold -> run ->
+chat -> inspect loop, including exact commands for registration, gateway, run
+history, and no-secret fallback checks.`,
+				Action: func(c *cli.Context) error {
+					fmt.Fprintln(c.App.Writer, firstAgentQuickChecksHelp)
 					return nil
 				},
 			},

--- a/cmd/micro/cli/agent/doctor_test.go
+++ b/cmd/micro/cli/agent/doctor_test.go
@@ -73,3 +73,24 @@ func TestRunAgentDoctorReportsActionableRecoveryFailures(t *testing.T) {
 		}
 	}
 }
+
+func TestAgentQuickcheckPrintsProviderFreeFailureModeBreadcrumbs(t *testing.T) {
+	got := firstAgentQuickChecksHelp
+	for _, want := range []string{
+		"First-agent failure-mode quick checks",
+		"scaffold -> run -> chat -> inspect",
+		"micro agent preflight",
+		"micro run",
+		"micro agent doctor",
+		"micro inspect agent <name>",
+		"micro runs <name>",
+		"micro agent demo",
+		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1",
+		"debugging-agents.html",
+		"no-secret-first-agent.html",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("quickcheck output missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/cmd/micro/first_agent_walkthrough_test.go
+++ b/cmd/micro/first_agent_walkthrough_test.go
@@ -38,6 +38,9 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 	if !subcommands["agent"]["doctor"] {
 		t.Fatal("first-agent walkthrough missing recovery boundary: agent doctor")
 	}
+	if !subcommands["agent"]["quickcheck"] {
+		t.Fatal("first-agent walkthrough missing failure-mode boundary: agent quickcheck")
+	}
 	if !subcommands["inspect"]["agent"] {
 		t.Fatal("first-agent walkthrough missing inspect boundary: inspect agent")
 	}
@@ -115,6 +118,28 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 	for _, want := range []string{"chat", "gateway", "registration", "provider", "inspect", "after micro run"} {
 		if !strings.Contains(doctor.Usage, want) {
 			t.Fatalf("micro agent doctor usage should advertise after-run recovery for %q; usage was %q", want, doctor.Usage)
+		}
+	}
+
+	quickcheck := subcommandByName(t, agent, "quickcheck")
+	out.Reset()
+	if err := quickcheck.Action(cli.NewContext(app, nil, nil)); err != nil {
+		t.Fatalf("micro agent quickcheck failed: %v", err)
+	}
+	for _, want := range []string{
+		"First-agent failure-mode quick checks",
+		"scaffold -> run -> chat -> inspect",
+		"micro agent preflight",
+		"micro run",
+		"micro agent doctor",
+		"micro inspect agent <name>",
+		"micro runs <name>",
+		"micro agent demo",
+		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1",
+		"debugging-agents.html",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("micro agent quickcheck output missing %q:\n%s", want, out.String())
 		}
 	}
 


### PR DESCRIPTION
Summary:
- Add `micro agent quickcheck` (alias `debug`) with provider-free recovery breadcrumbs for scaffold -> run -> chat -> inspect failures.
- Cover the quickcheck text and CLI registration with provider-free tests.

Testing:
- `go build ./...` passed.
- `go test ./cmd/micro/cli/agent ./cmd/micro -run 'TestAgentQuickcheck|TestFirstAgentWalkthroughCLIBoundaries' -count=1` passed.\n- `go test ./...` failed due environment/live-test limitations unrelated to this change: AtlasCloud stream returned 400, and loopback gRPC tests were blocked by the sandbox proxy (`Loopback targets forbidden`).\n- `golangci-lint run ./...` failed because installed golangci-lint was built with Go 1.24 while the module targets Go 1.25.12.\n\nCloses #4591\nCloses #4596