### PR TITLE
Guard checkpointed tool result recording

### DIFF
--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -235,28 +235,32 @@ func agentOperationalError(err error) error {
 
 func (a *agentImpl) checkpointToolWrap(next ai.ToolHandler) ai.ToolHandler {
 	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
-		if a.opts.Checkpoint == nil || a.currentRun == nil {
+		run := a.currentRun
+		if a.opts.Checkpoint == nil || run == nil {
 			return next(ctx, call)
 		}
 		name := toolCheckpointName(call)
-		if rec, ok := findStep(a.currentRun.Steps, name); ok && rec.Status == "done" {
+		if rec, ok := findStep(run.Steps, name); ok && rec.Status == "done" {
 			return ai.ToolResult{ID: call.ID, Value: rec.Result, Content: rec.Result}
 		}
 
-		idx := upsertStep(&a.currentRun.Steps, flow.StepRecord{Name: name, Status: "in_progress"})
-		_ = a.saveRun(ctx, *a.currentRun)
+		idx := upsertStep(&run.Steps, flow.StepRecord{Name: name, Status: "in_progress"})
+		_ = a.saveRun(ctx, *run)
 		res := next(ctx, call)
-		a.currentRun.Steps[idx].Attempts++
+		if idx < 0 || idx >= len(run.Steps) || run.Steps[idx].Name != name {
+			idx = upsertStep(&run.Steps, flow.StepRecord{Name: name, Status: "in_progress"})
+		}
+		run.Steps[idx].Attempts++
 		if res.Refused != "" {
-			a.currentRun.Steps[idx].Status = "failed"
-			a.currentRun.Steps[idx].Error = res.Content
-			_ = a.saveRun(ctx, *a.currentRun)
+			run.Steps[idx].Status = "failed"
+			run.Steps[idx].Error = res.Content
+			_ = a.saveRun(ctx, *run)
 			return res
 		}
-		a.currentRun.Steps[idx].Status = "done"
-		a.currentRun.Steps[idx].Result = res.Content
-		a.currentRun.Steps[idx].Error = ""
-		_ = a.saveRun(ctx, *a.currentRun)
+		run.Steps[idx].Status = "done"
+		run.Steps[idx].Result = res.Content
+		run.Steps[idx].Error = ""
+		_ = a.saveRun(ctx, *run)
 		return res
 	}
 }

--- a/agent/checkpoint_test.go
+++ b/agent/checkpoint_test.go
@@ -154,6 +154,45 @@ func TestCheckpointSkipsDuplicateToolWithinAsk(t *testing.T) {
 	}
 }
 
+func TestCheckpointToolWrapSurvivesClearedCurrentRun(t *testing.T) {
+	ctx := context.Background()
+	cp := flow.StoreCheckpoint(store.NewMemoryStore(), "tool-cleared-run-agent")
+	run := flow.Run{
+		ID:     "run-1",
+		Flow:   "tool-cleared-run-agent",
+		Status: "running",
+		Steps:  []flow.StepRecord{{Name: agentAskStep, Status: "in_progress"}},
+	}
+	a := &agentImpl{
+		opts:       newOptions(Name("tool-cleared-run-agent"), WithCheckpoint(cp)),
+		currentRun: &run,
+	}
+
+	handler := a.checkpointToolWrap(func(context.Context, ai.ToolCall) ai.ToolResult {
+		a.currentRun = nil
+		return ai.ToolResult{ID: "call-1", Content: "created"}
+	})
+	res := handler(ctx, ai.ToolCall{ID: "call-1", Name: "external.create", Input: map[string]any{"title": "Design"}})
+	if res.Content != "created" {
+		t.Fatalf("tool result = %q, want created", res.Content)
+	}
+
+	loaded, ok, err := cp.Load(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("load checkpoint: %v", err)
+	}
+	if !ok {
+		t.Fatal("checkpoint missing")
+	}
+	rec, ok := findStep(loaded.Steps, `tool:external.create:{"title":"Design"}`)
+	if !ok {
+		t.Fatalf("checkpoint steps = %#v, want completed tool step", loaded.Steps)
+	}
+	if rec.Status != "done" || rec.Result != "created" || rec.Attempts != 1 {
+		t.Fatalf("tool checkpoint = %#v, want done result with one attempt", rec)
+	}
+}
+
 func TestCheckpointContinuesRunWithUnfinishedPlanStep(t *testing.T) {
 	ctx := context.Background()
 	cp := flow.StoreCheckpoint(store.NewMemoryStore(), "unfinished-plan-agent")


### PR DESCRIPTION
Summary:
- Keep checkpointed tool result recording attached to the run snapshot captured before tool execution, so tool wrappers/provider paths that clear currentRun do not panic after side effects complete.
- Add deterministic coverage for a checkpointed tool call whose handler clears currentRun before result persistence.

Testing:
- go build ./...
- go test ./agent
- /root/.local/share/mise/installs/go/1.24.3/bin/golangci-lint run ./agent
- go test ./... (fails in this sandbox because loopback gRPC targets are forbidden and an AtlasCloud stream test hit a configured provider endpoint)
- golangci-lint run ./... (system golangci-lint was built with Go 1.24 while this repo targets Go 1.25.12; a locally installed Go 1.25.12-built golangci-lint reports existing unrelated issues outside this change)

Closes #4594
Closes #4601