### PR TITLE
Surface first-agent quickcheck in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,18 +98,20 @@ walkable agent path in this order:
 
 1. [Install troubleshooting](internal/website/docs/guides/install-troubleshooting.md) — verify the binary installer or `go install`, `PATH`, `micro --version`, and the no-secret smoke path before agent work.
 2. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
-3. `micro examples` — print the maintained provider-free runnable examples in copy/paste order.
-4. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
-5. [Examples wayfinding index](examples/INDEX.md) — choose the smallest no-secret first-agent, maintained [0→hero support reference](examples/support/), and next interop examples from one map.
-6. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
-7. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
+3. `micro agent quickcheck` (or `micro agent debug`) — when scaffold → run → chat → inspect stalls, print the short recovery map before you dive into the full debugging guide.
+4. `micro examples` — print the maintained provider-free runnable examples in copy/paste order.
+5. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
+6. [Examples wayfinding index](examples/INDEX.md) — choose the smallest no-secret first-agent, maintained [0→hero support reference](examples/support/), and next interop examples from one map.
+7. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
+8. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
    maintained support agent with a mock model and see services → agents → workflows succeed without a key.
-8. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
+9. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
    service-backed agent and talk to it with `micro chat`.
-9. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
-   `micro inspect agent <name>`, run history, memory, and provider checks when the first
-   conversation does something unexpected.
-10. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
+10. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
+   `micro agent preflight` before `micro run`, `micro agent doctor` after `micro run`,
+   then `micro chat` and `micro inspect agent <name>` to recover run history, memory,
+   and provider checks when the first conversation does something unexpected.
+11. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
    services → agents → workflows loop with scaffold, run, chat, inspect, flow
    history, and deploy dry-run commands that match the maintained harness.
 

--- a/cmd/micro/cli/cli.go
+++ b/cmd/micro/cli/cli.go
@@ -82,6 +82,9 @@ const docsWayfinding = `First-agent and 0→hero docs:
      prove service tools, mock-model chat, and inspectable run history without
      configuring a provider key.
 
+     If scaffold → run → chat → inspect stalls, print the short recovery map:
+       micro agent quickcheck
+
   2. No-secret first-agent transcript
      https://go-micro.dev/docs/guides/no-secret-first-agent.html
      Run the maintained support agent without a provider key:

--- a/cmd/micro/first_agent_walkthrough_test.go
+++ b/cmd/micro/first_agent_walkthrough_test.go
@@ -175,6 +175,7 @@ func TestFirstAgentDocsMatchCLIOutput(t *testing.T) {
 	}
 	agent := commandByName(t, "agent")
 	outputs["micro agent demo"] = commandOutput(t, subcommandByName(t, agent, "demo"))
+	outputs["micro agent quickcheck"] = commandOutput(t, subcommandByName(t, agent, "quickcheck"))
 
 	contracts := []struct {
 		name    string
@@ -186,6 +187,10 @@ func TestFirstAgentDocsMatchCLIOutput(t *testing.T) {
 			file: filepath.Join(root, "README.md"),
 			markers: []string{
 				"micro agent demo",
+				"micro agent quickcheck",
+				"micro agent preflight",
+				"micro agent doctor",
+				"micro inspect agent <name>",
 				"micro examples",
 				"micro zero-to-hero",
 				"examples/first-agent/",
@@ -201,6 +206,10 @@ func TestFirstAgentDocsMatchCLIOutput(t *testing.T) {
 			file: filepath.Join(root, "internal", "website", "docs", "getting-started.md"),
 			markers: []string{
 				"micro agent demo",
+				"micro agent quickcheck",
+				"micro agent preflight",
+				"micro agent doctor",
+				"micro inspect agent <name>",
 				"micro examples",
 				"micro zero-to-hero",
 				"github.com/micro/go-micro/tree/master/examples/first-agent",

--- a/internal/website/docs/getting-started.md
+++ b/internal/website/docs/getting-started.md
@@ -57,14 +57,15 @@ After this quick start, follow the agent path in order:
 
 1. [Install troubleshooting](guides/install-troubleshooting.html) — verify the CLI install before agent work.
 2. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
-3. `micro examples` — print the maintained provider-free runnable examples in copy/paste order.
-4. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
-5. [Examples wayfinding index](https://github.com/micro/go-micro/blob/master/examples/INDEX.md) — choose the smallest no-secret first-agent, maintained [0→hero support reference](https://github.com/micro/go-micro/tree/master/examples/support), and next interop examples from one map.
-6. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent) — run one service-backed agent with a mock model and no provider key.
-7. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — run a useful support agent with a mock model before setting up a provider key.
-8. [Your First Agent](guides/your-first-agent.html) — build a service-backed agent and talk to it with `micro chat`.
-9. [Debugging your agent](guides/debugging-agents.html) — use `micro inspect agent <name>` to inspect service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
-10. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
+3. `micro agent quickcheck` (or `micro agent debug`) — when scaffold → run → chat → inspect stalls, print the short recovery map before you dive into the full debugging guide.
+4. `micro examples` — print the maintained provider-free runnable examples in copy/paste order.
+5. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
+6. [Examples wayfinding index](https://github.com/micro/go-micro/blob/master/examples/INDEX.md) — choose the smallest no-secret first-agent, maintained [0→hero support reference](https://github.com/micro/go-micro/tree/master/examples/support), and next interop examples from one map.
+7. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent) — run one service-backed agent with a mock model and no provider key.
+8. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — run a useful support agent with a mock model before setting up a provider key.
+9. [Your First Agent](guides/your-first-agent.html) — build a service-backed agent and talk to it with `micro chat`.
+10. [Debugging your agent](guides/debugging-agents.html) — use `micro agent preflight` before `micro run`, `micro agent doctor` after `micro run`, then `micro chat` and `micro inspect agent <name>` to recover service registration, tool calls, run history, memory, provider failures, and flow handoffs when the agent surprises you.
+11. [0→hero reference path](guides/zero-to-hero.html) — prove the full scaffold → run → chat → inspect → deploy dry-run lifecycle with commands exercised by `make harness`.
 
 ## Write a Service
 

--- a/internal/website/docs/guides/debugging-agents.md
+++ b/internal/website/docs/guides/debugging-agents.md
@@ -24,10 +24,11 @@ Use the recovery command that matches where you are in the first-agent journey:
 | Checkpoint | When to use it | Command |
 | --- | --- | --- |
 | Install troubleshooting | `micro` is not installed, not on `PATH`, or the shell cannot run it. | [Install troubleshooting](install-troubleshooting.html) |
+| Quick recovery map | The first-agent loop stalled and you want the short scaffold → run → chat → inspect checklist before reading this full guide. | `micro agent quickcheck` (alias: `micro agent debug`) |
 | Preflight before `micro run` | You have not started the local runtime yet and want to verify Go, CLI, provider-key, and gateway-port prerequisites. | `micro agent preflight` |
 | Doctor after `micro run` | `micro run` is active, but chat, the `/agent` gateway, agent registration, provider settings, or inspect/run history is not behaving. | `micro agent doctor` |
 
-`micro agent preflight` is read-only and runs before the first local run; failed
+`micro agent quickcheck` is the quickest breadcrumb when you are unsure where the first-agent path failed: it prints the preflight, run, doctor, inspect, and no-secret fallback commands in one place. `micro agent preflight` is read-only and runs before the first local run; failed
 checks include `Fix:` and `Next:` lines for Go, CLI installation, provider-key
 setup, and the local gateway port. Once `micro run` is already up, switch to
 `micro agent doctor` so the recovery output follows the live gateway, chat


### PR DESCRIPTION
Summary:
- Adds micro agent quickcheck/debug to README and website first-agent wayfinding.
- Adds recovery commands around preflight, doctor, chat, and inspect to the debugging path.
- Extends CLI/docs boundary checks so the quickcheck command remains discoverable.

Testing:
- go build ./...
- go test ./cmd/micro -run TestFirstAgentWalkthrough -count=1
- go test ./internal/harness/zero-to-hero-ci -run TestFirstAgentWayfindingDocs -count=1 && go test ./cmd/micro -run TestFirstAgentDocsMatchCLIOutput -count=1
- go test ./... (fails due existing environment/provider/loopback issues)
- golangci-lint run ./... (fails: installed binary built with Go 1.24 vs target Go 1.25.12)
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./... (fails on pre-existing lint issues outside this change)

Closes #4599
Closes #4607