### PR TITLE
Handle AtlasCloud empty-arg text tool repair

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -554,8 +554,28 @@ func atlascloudFallbackTextToolCall(toolName string, req *ai.Request) string {
 	case "delegate":
 		return atlascloudDelegateFallbackTextToolCall(req)
 	default:
+		if atlascloudToolTakesNoArguments(toolName, req.Tools) {
+			return atlascloudEmptyArgumentFallbackTextToolCall(toolName)
+		}
 		return ""
 	}
+}
+
+func atlascloudToolTakesNoArguments(toolName string, tools []ai.Tool) bool {
+	for _, tool := range tools {
+		if tool.Name != toolName {
+			continue
+		}
+		return len(tool.Properties) == 0
+	}
+	return false
+}
+
+func atlascloudEmptyArgumentFallbackTextToolCall(toolName string) string {
+	if toolName == "" {
+		return ""
+	}
+	return `<tool_call name="` + toolName + `">{}</tool_call>`
 }
 
 func atlascloudPlanFallbackTextToolCall(prompt string) string {

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -628,6 +628,36 @@ func TestProvider_GenerateFallsBackAfterRepeatedPartialDelegateTextToolCall(t *t
 	}
 }
 
+func TestProvider_GenerateFallsBackAfterRepeatedPartialNoArgumentServiceTextToolCall(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"<tool_call name=\"task_TaskService_List\">"}}]}`))
+	}))
+	defer ts.Close()
+
+	p := NewProvider(
+		ai.WithAPIKey("test-key"),
+		ai.WithBaseURL(ts.URL),
+		ai.WithModel("minimaxai/minimax-m3"),
+	)
+	resp, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "list the current launch-readiness tasks",
+		Tools: []ai.Tool{{
+			Name:         "task_TaskService_List",
+			OriginalName: "task.TaskService.List",
+			Description:  "List persisted launch-readiness tasks",
+			Properties:   map[string]any{},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	want := `<tool_call name="task_TaskService_List">{}</tool_call>`
+	if resp.Reply != want {
+		t.Fatalf("Reply = %q, want %q", resp.Reply, want)
+	}
+}
+
 func TestProvider_GenerateRetriesMinimaxBuiltInsAsTextTools(t *testing.T) {
 	var bodies []map[string]any
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Recover repeated incomplete AtlasCloud text tool-call repairs for no-argument service tools by emitting a complete empty-argument tagged call.
- Add deterministic coverage for the task_TaskService_List plan/delegate failure signature.

Closes #4606
Closes #4611

## Testing
- go test ./ai/atlascloud
- go build ./...
- go test ./... (fails in this sandbox due loopback targets forbidden and live AtlasCloud stream without credentials)
- golangci-lint run ./... (installed binary cannot load Go 1.25.12 config; locally built v2.12.2 reports pre-existing unrelated issues)