### PR TITLE
Harden universe A2A reachability probe

### DIFF
--- a/internal/harness/universe/main.go
+++ b/internal/harness/universe/main.go
@@ -357,14 +357,55 @@ func check(cond bool, format string, args ...any) {
 // should not depend on a live model deciding to send another notification.
 func a2aReachable(ctx context.Context, base, agent string) error {
 	probe := "A2A reachability probe only. Reply with the words concierge reachable. Do not call tools or send notifications."
-	reply, err := a2a.NewClient(base+"/agents/"+agent).Send(ctx, probe)
-	if err != nil {
-		return err
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(10 * time.Second)
 	}
-	if strings.TrimSpace(reply) == "" {
-		return fmt.Errorf("empty A2A reply")
+
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				return fmt.Errorf("A2A reachability probe failed after %d attempt(s): %w", attempt-1, lastErr)
+			}
+			return err
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			if lastErr != nil {
+				return fmt.Errorf("A2A reachability probe failed after %d attempt(s): %w", attempt-1, lastErr)
+			}
+			return context.DeadlineExceeded
+		}
+
+		attemptTimeout := 4 * time.Second
+		if remaining < attemptTimeout {
+			attemptTimeout = remaining
+		}
+		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+		reply, err := a2a.NewClient(base+"/agents/"+agent).Send(attemptCtx, probe)
+		cancel()
+		if err == nil && strings.TrimSpace(reply) != "" {
+			return nil
+		}
+		if err == nil {
+			err = fmt.Errorf("empty A2A reply")
+		}
+		lastErr = err
+
+		if time.Until(deadline) <= 0 {
+			return fmt.Errorf("A2A reachability probe failed after %d attempt(s): %w", attempt, lastErr)
+		}
+		time.Sleep(minDuration(200*time.Millisecond*time.Duration(attempt), time.Until(deadline)))
 	}
-	return nil
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func providerKey(provider string) string {

--- a/internal/harness/universe/main_test.go
+++ b/internal/harness/universe/main_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,6 +25,31 @@ func TestUniverseHarnessContract(t *testing.T) {
 
 	if code := runUniverse("mock"); code != 0 {
 		t.Fatalf("universe harness exited with code %d", code)
+	}
+}
+
+func TestA2AReachableRetriesTransientTimeout(t *testing.T) {
+	var calls int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/agents/concierge"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+		if atomic.AddInt64(&calls, 1) == 1 {
+			time.Sleep(5 * time.Second)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"kind":"task","id":"task-1","contextId":"ctx-1","status":{"state":"completed"},"artifacts":[{"artifactId":"artifact-1","parts":[{"kind":"text","text":"concierge reachable"}]}]}}`)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	if err := a2aReachable(ctx, srv.URL, "concierge"); err != nil {
+		t.Fatalf("a2aReachable returned error: %v", err)
+	}
+	if got := atomic.LoadInt64(&calls); got < 2 {
+		t.Fatalf("A2A calls = %d, want retry after transient timeout", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Retry the universe harness A2A reachability probe within the caller deadline so transient gateway/provider latency does not turn a reachable concierge agent into a false negative.
- Keep the probe side-effect safe by reusing the explicit no-notification prompt and preserving the post-probe notification-count assertion.
- Add a regression test that forces a first A2A request timeout and verifies the probe retries successfully.

Closes #4504
Closes #4620

## Testing
- go test ./internal/harness/universe
- go build ./...
- go test ./... (fails in this sandbox: AtlasCloud stream conformance received live 400, and gRPC loopback targets are forbidden by envoy)
- golangci-lint run ./... (fails in this sandbox: installed golangci-lint was built with Go 1.24 while repo targets Go 1.25.12)