### PR TITLE
Refresh planner priorities for 4622

### DIFF
--- a/.github/loop/PRIORITIES.md
+++ b/.github/loop/PRIORITIES.md
@@ -21,8 +21,7 @@ changes, architectural rewrites. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **Make AtlasCloud universe A2A reachability probe deterministic** ([#4504](https://github.com/micro/go-micro/issues/4504)) — Highest-value remaining Now-phase hardening item after #4595 shipped in #4616: the universe checkout flow completes, but the live AtlasCloud A2A reachability probe can still time out after side effects succeed. Fix this next so the services → agents → workflows harness fails safely without turning a reachable agent into a false negative.
-2. **Add a no-secret first-agent chat transcript check** ([#4618](https://github.com/micro/go-micro/issues/4618)) — Developer adoption stays weighted alongside hardening: README, the website, and the v6.3.15 blog now point at the provider-free first-agent path, but the 0→1 agent experience still needs an expected chat/tool-call transcript that a new developer can compare against before adding provider keys. Make the smallest first-agent path more walkable and CI-verifiable.
+1. **Add a no-secret first-agent chat transcript check** ([#4618](https://github.com/micro/go-micro/issues/4618)) — Developer adoption is now the highest-value open Now-phase item after #4504 shipped in #4621. README, the website, and the v6.3.15 blog point at the provider-free first-agent path, but the 0→1 agent experience still needs an expected chat/tool-call transcript that a new developer can compare against before adding provider keys. Make the smallest first-agent path more walkable and CI-verifiable.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:
- Remove completed #4504 after it shipped in #4621.
- Promote #4618 as the top open developer-adoption priority.

Testing:
- go build ./...
- go test ./... (environment/API failures: AtlasCloud stream 400; loopback targets forbidden for local grpc tests)
- golangci-lint run ./... (tool built with Go 1.24 but target is Go 1.25.12)

Closes #4622