### PR TITLE
Check first-agent transcript drift

### DIFF
--- a/examples/first-agent/main.go
+++ b/examples/first-agent/main.go
@@ -13,6 +13,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -33,13 +34,13 @@ type ListNotesResponse struct {
 	Notes []string `json:"notes" description:"Notes the assistant can summarize"`
 }
 
-type NotesService struct{}
+type NotesService struct{ w io.Writer }
 
 // List returns the starter notes the first agent can read.
 // @example {}
 func (s *NotesService) List(ctx context.Context, req *ListNotesRequest, rsp *ListNotesResponse) error {
 	rsp.Notes = []string{"Install the micro CLI", "Run a service", "Chat with an agent"}
-	fmt.Println("  [notes] listed starter notes")
+	fmt.Fprintln(s.w, "  [notes] listed starter notes")
 	return nil
 }
 
@@ -90,6 +91,10 @@ func waitFor(reg registry.Registry, names ...string) error {
 }
 
 func runFirstAgent() error {
+	return runFirstAgentWithWriter(os.Stdout)
+}
+
+func runFirstAgentWithWriter(w io.Writer) error {
 	ai.Register("first-agent-mock", newMock)
 
 	reg := registry.NewMemoryRegistry()
@@ -104,7 +109,7 @@ func runFirstAgent() error {
 	cl := client.NewClient(client.Registry(reg), client.Selector(selector.NewSelector(selector.Registry(reg))), client.Broker(br))
 
 	notes := service.New(service.Name("notes"), service.Address("127.0.0.1:0"), service.Registry(reg), service.Client(cl), service.Broker(br), service.HandleSignal(false))
-	if err := notes.Handle(new(NotesService)); err != nil {
+	if err := notes.Handle(&NotesService{w: w}); err != nil {
 		return fmt.Errorf("handle notes: %w", err)
 	}
 	svcErr := make(chan error, 1)
@@ -137,14 +142,14 @@ func runFirstAgent() error {
 		return err
 	}
 
-	fmt.Println("First agent (provider: mock, no API key)")
-	fmt.Println("> Summarize my next steps")
+	fmt.Fprintln(w, "First agent (provider: mock, no API key)")
+	fmt.Fprintln(w, "> Summarize my next steps")
 	resp, err := assistant.Ask(context.Background(), "Summarize my next steps")
 	if err != nil {
 		return fmt.Errorf("ask assistant: %w", err)
 	}
-	fmt.Println("assistant:", resp.Reply)
-	fmt.Println("✓ service-backed agent completed without provider secrets")
+	fmt.Fprintln(w, "assistant:", resp.Reply)
+	fmt.Fprintln(w, "✓ service-backed agent completed without provider secrets")
 	return nil
 }
 

--- a/examples/first-agent/main_test.go
+++ b/examples/first-agent/main_test.go
@@ -1,9 +1,45 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
 
 func TestRunFirstAgent(t *testing.T) {
-	if err := runFirstAgent(); err != nil {
+	var out bytes.Buffer
+	if err := runFirstAgentWithWriter(&out); err != nil {
 		t.Fatalf("first-agent example failed: %v", err)
 	}
+
+	want := strings.TrimSpace(readExpectedTranscript(t))
+	got := strings.TrimSpace(out.String())
+	if got != want {
+		t.Fatalf("first-agent transcript drifted from README.md\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func readExpectedTranscript(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	readme := string(b)
+	const fence = "```text"
+	start := strings.Index(readme, "Expected transcript:")
+	if start < 0 {
+		t.Fatal("README.md missing Expected transcript section")
+	}
+	fenceStart := strings.Index(readme[start:], fence)
+	if fenceStart < 0 {
+		t.Fatal("README.md missing transcript text fence")
+	}
+	start += fenceStart + len(fence)
+	end := strings.Index(readme[start:], "```")
+	if end < 0 {
+		t.Fatal("README.md missing closing transcript fence")
+	}
+	return readme[start : start+end]
 }


### PR DESCRIPTION
Adds a focused no-secret first-agent transcript guard so the README expected output stays aligned with the runnable example.

Summary:
- Capture the first-agent example transcript through an injectable writer.
- Compare the runnable output with the Expected transcript block in examples/first-agent/README.md.

Testing:
- go test ./examples/first-agent -run TestRunFirstAgent -count=1
- go test ./cmd/micro -run 'TestFirstAgent|TestExamples' -count=1\n- go build ./...\n- go test ./... (fails in this environment: provider/loopback transport restrictions)\n- golangci-lint run ./... (fails: installed golangci-lint built with Go 1.24, module targets Go 1.25.12)\n\nCloses #4618\nCloses #4624