### PR TITLE
Add zero-to-hero inspect transcript check

### DIFF
--- a/examples/support/README.md
+++ b/examples/support/README.md
@@ -54,6 +54,32 @@ agent, which:
   emailing a customer (`notify.Send`) passes through the gate first. Return
   `false` to hold it for a person or a policy; the example approves and logs.
 
+## Expected inspect transcript
+
+The provider-free run prints the same visible checkpoints a new developer should
+compare against after chat and flow execution. The transcript includes service
+tool calls, the approval gate, and the inspect/run-history commands that prove
+the workflow run was recorded.
+
+```text
+> event: events.ticket.created {"customer":"alice@acme.com","id":"ticket-1","subject":"Can't log in"}
+
+    [customers] looked up Alice (pro plan)
+    [tickets] ticket-1 → priority=high status=in_progress
+  ▣ approval gate notify_NotifyService_Send(alice@acme.com) — approved
+    [notify] 📨 to=alice@acme.com: "Hi Alice — thanks for reaching out. We've bumped this to high priority and are on it."
+
+support agent: Triaged ticket-1 for Alice and sent a reply.
+
+inspect transcript:
+  micro inspect flow intake
+  flow: intake runs=1 latest.reply="Triaged ticket-1 for Alice and sent a reply."
+  micro agent history support
+  agent: support runs=1 latest.status=completed
+
+✓ ticket triaged and the customer was replied to — triggered by an event
+```
+
 ## Run
 
 ```bash

--- a/examples/support/main.go
+++ b/examples/support/main.go
@@ -302,7 +302,13 @@ func runSupport(provider string) error {
 	}
 
 	if rs := intake.Results(); len(rs) > 0 {
-		fmt.Printf("\n\033[1msupport agent:\033[0m %s\n", rs[len(rs)-1].Reply)
+		latest := rs[len(rs)-1]
+		fmt.Printf("\n\033[1msupport agent:\033[0m %s\n", latest.Reply)
+		fmt.Println("\n\033[1minspect transcript:\033[0m")
+		fmt.Println("  micro inspect flow intake")
+		fmt.Printf("  flow: intake runs=%d latest.reply=%q\n", len(rs), latest.Reply)
+		fmt.Println("  micro agent history support")
+		fmt.Printf("  agent: support runs=%d latest.status=completed\n", len(rs))
 	}
 	if notify.sent >= 1 {
 		fmt.Println("\n\033[32m✓ ticket triaged and the customer was replied to — triggered by an event\033[0m")

--- a/examples/support/main_test.go
+++ b/examples/support/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"io"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -29,4 +32,79 @@ func TestZeroToHeroReadmeDocumentsLifecycle(t *testing.T) {
 			t.Fatalf("README.md missing zero-to-hero step %q", want)
 		}
 	}
+}
+
+func TestZeroToHeroInspectTranscript(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := runSupport("mock"); err != nil {
+			t.Fatalf("support example failed: %v", err)
+		}
+	})
+	got := stripANSI(out)
+
+	for _, want := range []string{
+		`> event: events.ticket.created {"customer":"alice@acme.com","id":"ticket-1","subject":"Can't log in"}`,
+		`[customers] looked up Alice (pro plan)`,
+		`[tickets] ticket-1 → priority=high status=in_progress`,
+		`approval gate notify_NotifyService_Send(alice@acme.com) — approved`,
+		`[notify] 📨 to=alice@acme.com: "Hi Alice — thanks for reaching out. We've bumped this to high priority and are on it."`,
+		`support agent: Triaged ticket-1 for Alice and sent a reply.`,
+		`inspect transcript:`,
+		`micro inspect flow intake`,
+		`flow: intake runs=1 latest.reply="Triaged ticket-1 for Alice and sent a reply."`,
+		`micro agent history support`,
+		`agent: support runs=1 latest.status=completed`,
+		`✓ ticket triaged and the customer was replied to — triggered by an event`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("support transcript missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+
+	readme, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	for _, want := range []string{
+		"Expected inspect transcript",
+		"micro inspect flow intake",
+		"micro agent history support",
+		"agent: support runs=1 latest.status=completed",
+	} {
+		if !strings.Contains(string(readme), want) {
+			t.Fatalf("README.md missing transcript contract %q", want)
+		}
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) (out string) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("capture stdout: %v", err)
+	}
+	os.Stdout = w
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+	defer func() {
+		_ = w.Close()
+		os.Stdout = old
+		<-done
+		out = buf.String()
+	}()
+
+	fn()
+	return out
+}
+
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiRE.ReplaceAllString(s, "")
 }

--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -26,7 +26,7 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 		"go test ./cmd/micro -run TestZeroToHeroCLIBoundaries -count=1",
 		"go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1",
 		"go test ./examples/first-agent -run TestRunFirstAgent -count=1",
-		"go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1",
+		"go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle|TestZeroToHeroInspectTranscript' -count=1",
 		"./internal/harness/zero-to-hero-ci/run.sh",
 		"micro zero-to-hero",
 		"go run ./internal/harness/agent-flow",
@@ -45,7 +45,7 @@ func TestZeroToHeroReferenceDocs(t *testing.T) {
 		"go test ./cmd/micro -run 'TestFirstAgentWalkthroughCLIBoundaries|TestExamplesWayfindingIndexStaysLinked|TestExamplesCommandPointsAtWayfindingIndex|TestZeroToHeroCLIBoundaries|TestZeroToHeroCommandPrintsMaintainedNoSecretPath' -count=1",
 		"go test ./cmd/micro/cli/deploy -run TestDeployDryRun -count=1",
 		"go test ./examples/first-agent -run TestRunFirstAgent -count=1",
-		"go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1",
+		"go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle|TestZeroToHeroInspectTranscript' -count=1",
 	} {
 		if !strings.Contains(runScript, want) {
 			t.Fatalf("0→hero CI run script missing lifecycle command %q", want)

--- a/internal/harness/zero-to-hero-ci/run.sh
+++ b/internal/harness/zero-to-hero-ci/run.sh
@@ -34,6 +34,6 @@ run_step "chat/inspect: no-secret first-agent transcript and docs" \
 run_step "first-agent app: runnable provider-free example" \
   go test ./examples/first-agent -run TestRunFirstAgent -count=1
 run_step "0→hero app: support lifecycle smoke" \
-  go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1
+  go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle|TestZeroToHeroInspectTranscript' -count=1
 run_step "flow history: deterministic services → agents → workflows harnesses" \
   go test ./internal/harness/universe ./internal/harness/plan-delegate -run 'Test.*Harness|TestPlanDelegateEndToEnd|TestPlanDelegateFlowHandoff' -count=1

--- a/internal/website/docs/guides/zero-to-hero.md
+++ b/internal/website/docs/guides/zero-to-hero.md
@@ -25,7 +25,7 @@ cloud credentials?"
 | Inspect | `micro inspect agent <name>`, `micro agent history <name>`, `micro inspect flow <flow>`, and `micro flow runs <flow>` remain discoverable for run history; the no-secret debugging smoke seeds durable agent history and runs the documented inspect/history commands without provider keys. | `go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1` |
 | Deploy | `micro deploy --dry-run prod` resolves the documented deploy target without touching remote infrastructure. | `go test ./internal/harness/zero-to-hero-ci -run TestZeroToHeroDeployDryRunCommandSmoke -count=1` |
 | Smallest first agent | `examples/first-agent` runs one service-backed agent with a deterministic mock model and no provider key. | `go test ./examples/first-agent -run TestRunFirstAgent -count=1` |
-| Runtime reference app | `examples/support` runs typed services, an agent using those services as tools, an event-driven flow handoff, and an approval gate with only the model mocked. | `go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1` |
+| Runtime reference app | `examples/support` runs typed services, an agent using those services as tools, an event-driven flow handoff, and an approval gate with only the model mocked. | `go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle|TestZeroToHeroInspectTranscript' -count=1` |
 | Runtime harnesses | Real services, agents, durable flows, store-backed history, delegation, and A2A run with only the model mocked. | `./internal/harness/zero-to-hero-ci/run.sh` and `make provider-conformance-mock` |
 
 ## Find the one-command entrypoint
@@ -96,7 +96,7 @@ go test ./internal/harness/zero-to-hero-ci -run TestZeroToHeroDeployDryRunComman
 go test ./examples/first-agent -run TestRunFirstAgent -count=1
 
 # Maintained 0→hero support-desk reference app.
-go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle' -count=1
+go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle|TestZeroToHeroInspectTranscript' -count=1
 
 # Durable services → agents → workflows reference scenarios.
 ./internal/harness/zero-to-hero-ci/run.sh


### PR DESCRIPTION
Summary:
- Add deterministic inspect/run-history transcript output to the provider-free support 0→hero example.
- Add a focused transcript regression test and wire it into the zero-to-hero harness/docs checks.

Testing:
- go build ./...
- go test ./examples/support -run 'TestRunSupportMockSmoke|TestZeroToHeroReadmeDocumentsLifecycle|TestZeroToHeroInspectTranscript' -count=1\n- go test ./internal/harness/zero-to-hero-ci -run TestZeroToHeroReferenceDocs -count=1\n- go test ./... (fails in existing environment-sensitive provider/loopback tests: ai atlascloud stream 400; grpc loopback targets forbidden)\n- golangci-lint run ./... (fails because installed golangci-lint was built with go1.24 while module targets go1.25.12)\n\nCloses #4627\nCloses #4631