### PR TITLE
Verify first-agent next breadcrumbs

### DIFF
--- a/examples/first-agent/README.md
+++ b/examples/first-agent/README.md
@@ -34,5 +34,22 @@ CI keeps this path runnable with:
 go test ./examples/first-agent
 ```
 
-After this, continue to [`examples/support`](../support/) for the full services →
-agents → workflows lifecycle with a flow trigger and an approval gate.
+## Next chat, inspect, and debug breadcrumbs
+
+This example exits after one in-process `assistant.Ask` call so it stays tiny and
+provider-free. When you move from this transcript to a long-running agent, keep
+these commands nearby:
+
+```bash
+micro run
+micro chat assistant --prompt "Summarize my next steps"
+micro inspect agent assistant
+micro agent doctor assistant
+```
+
+Use the [no-secret first-agent guide](../../internal/website/docs/guides/no-secret-first-agent.md)
+to compare this transcript with the CLI demo, then keep the
+[debugging guide](../../internal/website/docs/guides/debugging-agents.md) open for
+preflight, doctor, inspect, and history checks. After that, continue to
+[`examples/support`](../support/) for the full services → agents → workflows
+lifecycle with a flow trigger and an approval gate.

--- a/examples/first-agent/main_test.go
+++ b/examples/first-agent/main_test.go
@@ -20,6 +20,32 @@ func TestRunFirstAgent(t *testing.T) {
 	}
 }
 
+func TestReadmeDocumentsNextBreadcrumbs(t *testing.T) {
+	b, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	readme := string(b)
+	start := strings.Index(readme, "## Next chat, inspect, and debug breadcrumbs")
+	if start < 0 {
+		t.Fatal("README.md missing next chat, inspect, and debug breadcrumbs section")
+	}
+	section := readme[start:]
+	for _, want := range []string{
+		"micro run",
+		"micro chat assistant --prompt \"Summarize my next steps\"",
+		"micro inspect agent assistant",
+		"micro agent doctor assistant",
+		"no-secret-first-agent.md",
+		"debugging-agents.md",
+		"examples/support",
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("README.md next breadcrumbs missing %q", want)
+		}
+	}
+}
+
 func readExpectedTranscript(t *testing.T) string {
 	t.Helper()
 	b, err := os.ReadFile("README.md")


### PR DESCRIPTION
Summary:
- Documents the first-agent handoff from the provider-free transcript to chat, inspect, and doctor/debug CLI breadcrumbs.
- Adds a focused README regression test so the smallest first-agent docs cannot drop those next-step markers while preserving transcript parity.

Testing:
- go test ./examples/first-agent -count=1
- go build ./...
- go test ./... (fails in this environment: atlascloud stream conformance returned 400, and loopback gRPC transport/client tests are blocked by the sandbox envoy)
- golangci-lint run ./... (installed binary built with Go 1.24 cannot load Go 1.25.12 config)
- /root/go/bin/golangci-lint run ./... (fails on pre-existing lint findings outside this change)

Closes #4639
Closes #4641