### PR TITLE
docs: refresh coherence changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,29 @@ below is kept current between tags and rolled into the next version when it ship
 ## [Unreleased]
 
 ### Added
+- **First-agent chat/inspect fixture** — the maintained first-agent CLI fixture now covers chat and inspect boundaries together. (`internal/harness/`, `cmd/micro/`)
+- **Zero-to-hero inspect transcript check** — the 0→hero harness now verifies the inspect transcript path stays visible in the lifecycle walkthrough. (`internal/harness/zero-to-hero-ci/`, `internal/website/docs/`)
+
+### Changed
+- **Plan-delegate plan persistence** — plan/delegate runs now persist plan state more defensively across harness scenarios. (`agent/`, `internal/harness/`)
+
+### Fixed
+- **Zero-to-hero fixture output race** — 0→hero fixture output is less race-prone during harness runs. (`internal/harness/zero-to-hero-ci/`)
+
+---
+
+## [6.6.0] - July 2026
+
+### Added
 - **First-agent guide chain contract** — the harness now verifies the install → demo → examples → 0→hero guide chain stays connected for new agent builders. (`internal/harness/`, `internal/website/docs/`)
+- **First-agent docs wayfinding guard** — the local harness now includes a focused no-network check for first-agent and 0→hero docs links. (`Makefile`, `internal/harness/`)
+- **First-agent quickcheck breadcrumbs** — first-agent docs now surface quickcheck wayfinding for install, scaffold, chat, inspect, and recovery paths. (`internal/website/docs/`, `README.md`)
+- **First-agent chat wayfinding verification** — the harness now verifies first-agent chat wayfinding remains discoverable from the public docs route. (`internal/harness/`, `internal/website/docs/`)
+
+### Changed
+- **Universe A2A reachability probe** — the universe harness now exercises A2A reachability more defensively. (`internal/harness/`)
+- **AtlasCloud workspace repair fallback** — AtlasCloud fallback handling now recovers workspace-repair tool calls more reliably. (`ai/atlascloud/`, `agent/`)
+- **AtlasCloud empty-argument tool repair** — AtlasCloud text tool-call repair now handles empty-argument calls more consistently. (`ai/atlascloud/`, `agent/`)
 
 ### Fixed
 - **A2A fallback artifact text** — A2A fallback responses now avoid leaking provider artifact text into agent-visible output. (`gateway/a2a/`, `agent/`)
@@ -26,6 +48,20 @@ below is kept current between tags and rolled into the next version when it ship
 - **Plan-delegate harness cleanup** — plan/delegate harness cleanup is more reliable after conformance runs. (`internal/harness/`)
 - **AtlasCloud spoken notify replays** — AtlasCloud fallback handling now collapses spoken notification replays more consistently. (`ai/atlascloud/`, `agent/`)
 - **Agent-flow onboarding side effects** — onboarding side-effect checks are more stable across the agent-flow harness. (`agent/`, `internal/harness/`)
+- **Plan-delegate plan-only side effects** — plan/delegate recovery now preserves plan-only side effects more reliably. (`agent/`, `internal/harness/`)
+- **Checkpointed tool result recording** — checkpoint resume paths now guard tool-result recording against duplicate or stale writes. (`agent/`)
+- **Agent timeout notification completion** — universe runs now finalize observed notifications more reliably after agent timeouts. (`agent/`, `internal/harness/`)
+- **Completed plan-delegate side effects** — completed plan/delegate side effects are accepted more consistently in recovery paths. (`agent/`, `internal/harness/`)
+- **Agent-flow onboarding notifications** — agent-flow onboarding notification recovery is more reliable across replay scenarios. (`agent/`, `internal/harness/`)
+
+### Documentation
+- **Agent-agnostic mention model** — loop docs now describe the mention-driven agent model without binding it to one coding agent. (`internal/docs/`, `.github/loop/`)
+- **First-agent quickcheck docs** — public docs now surface the first-agent quickcheck path for faster troubleshooting. (`internal/website/docs/`)
+- **Agent resume breadcrumbs** — docs now add clearer resume breadcrumbs for checkpointed agent runs. (`internal/website/docs/`)
+
+### Security
+- **Govulncheck vulnerability gate** — CI now includes a govulncheck gate and wires vulnerability failures into loop triage. (`.github/workflows/`, `cmd/micro/loop/`)
+- **Dependency vulnerability patches** — toolchain and dependency updates patch reachable CVEs across the project. (`go.mod`, `go.sum`)
 
 ---
 

--- a/internal/website/docs/architecture.md
+++ b/internal/website/docs/architecture.md
@@ -104,16 +104,25 @@ If you are new, follow the architecture in the same order the runtime composes i
    CLI, `PATH`, version, and no-secret smoke path are healthy.
 2. [`micro agent demo`](getting-started.html#first-agent-on-ramp) — print the
    provider-free first-agent command and next docs steps from the installed CLI.
-3. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent)
+3. `micro agent quickcheck` (or `micro agent debug`) — print the short recovery
+   map when scaffold → run → chat → inspect stalls.
+4. `micro examples` — list the maintained provider-free runnable examples in
+   copy/paste order.
+5. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle
+   harness and runnable examples.
+6. [Examples wayfinding index](https://github.com/micro/go-micro/blob/master/examples/INDEX.md)
+   — choose the smallest no-secret first-agent, support reference, and interop
+   examples from one map.
+7. [Smallest first-agent example](https://github.com/micro/go-micro/tree/master/examples/first-agent)
    — run one service-backed agent with a mock model.
-4. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — see the
+8. [No-secret first-agent transcript](guides/no-secret-first-agent.html) — see the
    maintained support-agent path work without a provider key.
-5. [Your First Agent](guides/your-first-agent.html) — build and chat with a
+9. [Your First Agent](guides/your-first-agent.html) — build and chat with a
    service-backed agent.
-6. [Debugging your agent](guides/debugging-agents.html) — inspect service
-   registration, tools, memory, providers, and run history.
-7. [0→hero Reference](guides/zero-to-hero.html) — walk scaffold → run → chat →
-   inspect → flow → deploy dry-run as the maintained lifecycle contract.
+10. [Debugging your agent](guides/debugging-agents.html) — inspect service
+    registration, tools, memory, providers, and run history.
+11. [0→hero Reference](guides/zero-to-hero.html) — walk scaffold → run → chat →
+    inspect → flow → deploy dry-run as the maintained lifecycle contract.
 
 ## Related
 


### PR DESCRIPTION
Summary:
- Roll the prior unreleased changelog content into v6.6.0 after the tag and add new unreleased entries for the latest user-facing changes.
- Align architecture docs' developer path with the README/getting-started first-agent sequence.

Testing:
- timeout 180 go build ./... (passed)
- timeout 180 go test ./... (failed/timed out: AtlasCloud provider returned 400 without credentials; grpc loopback tests were blocked by environment; command timed out)
- golangci-lint run ./... (failed: installed golangci-lint was built with Go 1.24, below target Go 1.25.12)

Closes #4668