### PR TITLE
Harden plan-delegate plan persistence

### DIFF
--- a/internal/harness/plan-delegate/main.go
+++ b/internal/harness/plan-delegate/main.go
@@ -474,10 +474,11 @@ func runPlanDelegate(provider string) error {
 		agent.Name("conductor"),
 		agent.Address("127.0.0.1:0"),
 		agent.Services("task"),
-		agent.Prompt("You coordinate launch work. Plan first, create exactly one Design task, one Build task, and one Ship task, then delegate exactly one readiness notification to the \"comms\" agent. Do not create duplicate tasks and do not send notifications yourself."),
+		agent.Prompt("You coordinate launch work. Before any task or delegate tool call, you must persist the launch-readiness plan with the built-in plan tool. Then create exactly one Design task, one Build task, and one Ship task, then delegate exactly one readiness notification to the \"comms\" agent. Do not create duplicate tasks and do not send notifications yourself."),
 		agent.Provider(provider), agent.APIKey(apiKey),
 		agent.WithRegistry(reg), agent.WithClient(cl), agent.WithStore(mem),
 		agent.WithCheckpoint(conductorCheckpoint),
+		agent.WrapTool(requirePersistedPlanBeforeConductorActions(mem)),
 	}
 	conductorOpts = append(conductorOpts, liveAgentOpts...)
 	conductor := agent.New(conductorOpts...)
@@ -540,6 +541,26 @@ func runPlanDelegate(provider string) error {
 
 	fmt.Println("\n\033[32m✓ 0→hero flow complete (services → agents → workflow)\033[0m")
 	return nil
+}
+
+func requirePersistedPlanBeforeConductorActions(mem store.Store) ai.ToolWrapper {
+	return func(next ai.ToolHandler) ai.ToolHandler {
+		return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+			if call.Name == "plan" {
+				return next(ctx, call)
+			}
+			if recs, err := store.Scope(mem, "agent", "conductor").Read("plan"); err == nil && len(recs) > 0 {
+				return next(ctx, call)
+			}
+			msg := "persist the launch-readiness plan first by calling the built-in plan tool before task or delegate side effects"
+			return ai.ToolResult{
+				ID:      call.ID,
+				Value:   map[string]string{"error": msg},
+				Content: `{"error":"` + msg + `"}`,
+				Refused: ai.RefusedApproval,
+			}
+		}
+	}
 }
 
 func requireConductorPlan(ctx context.Context, mem store.Store, conductor agent.Agent) error {

--- a/internal/harness/plan-delegate/main_test.go
+++ b/internal/harness/plan-delegate/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -436,6 +437,50 @@ func TestRequireConductorPlanFailureNamesScopedRecord(t *testing.T) {
 		if got := err.Error(); !strings.Contains(got, want) {
 			t.Fatalf("error = %q, want %q", got, want)
 		}
+	}
+}
+
+func TestRequirePersistedPlanBeforeConductorActionsBlocksSideEffects(t *testing.T) {
+	mem := store.NewMemoryStore()
+	called := false
+	wrapped := requirePersistedPlanBeforeConductorActions(mem)(func(context.Context, ai.ToolCall) ai.ToolResult {
+		called = true
+		return ai.ToolResult{ID: "call-1", Content: `{"ok":true}`}
+	})
+
+	res := wrapped(context.Background(), ai.ToolCall{ID: "call-1", Name: "task.Add"})
+	if called {
+		t.Fatal("side-effecting tool ran before persisted plan")
+	}
+	if res.Refused != ai.RefusedApproval {
+		t.Fatalf("Refused = %q, want %q", res.Refused, ai.RefusedApproval)
+	}
+	if !strings.Contains(res.Content, "built-in plan tool") {
+		t.Fatalf("Content = %q, want plan-first steering message", res.Content)
+	}
+}
+
+func TestRequirePersistedPlanBeforeConductorActionsAllowsPlanAndPlannedActions(t *testing.T) {
+	mem := store.NewMemoryStore()
+	var calls []string
+	wrapped := requirePersistedPlanBeforeConductorActions(mem)(func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		calls = append(calls, call.Name)
+		if call.Name == "plan" {
+			if err := store.Scope(mem, "agent", "conductor").Write(&store.Record{Key: "plan", Value: []byte(`{"steps":[{"task":"Design","status":"pending"}]}`)}); err != nil {
+				t.Fatalf("write plan: %v", err)
+			}
+		}
+		return ai.ToolResult{ID: call.ID, Content: `{"ok":true}`}
+	})
+
+	if res := wrapped(context.Background(), ai.ToolCall{ID: "call-1", Name: "plan"}); res.Refused != "" {
+		t.Fatalf("plan Refused = %q, want allowed", res.Refused)
+	}
+	if res := wrapped(context.Background(), ai.ToolCall{ID: "call-2", Name: "task.Add"}); res.Refused != "" {
+		t.Fatalf("planned action Refused = %q, want allowed", res.Refused)
+	}
+	if want := []string{"plan", "task.Add"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Require the live plan-delegate conductor to persist its built-in plan before task or delegate side effects.
- Add harness tests for plan-first blocking and planned action pass-through.

Closes #4665
Closes #4673

## Testing
- go test ./internal/harness/plan-delegate
- go build ./...
- go test ./... (fails in this sandbox due atlascloud stream 400 and loopback targets forbidden in grpc tests)
- golangci-lint run ./... (installed binary cannot load Go 1.25 target; /tmp/codex-bin/golangci-lint run ./... reports pre-existing lint outside touched package)
- /tmp/codex-bin/golangci-lint run ./internal/harness/plan-delegate