### PR TITLE
Report provider conformance skips per harness

### DIFF
--- a/internal/docs/AGENT_CONFORMANCE.md
+++ b/internal/docs/AGENT_CONFORMANCE.md
@@ -43,7 +43,20 @@ live model credits.
 
 Use `make provider-conformance` when you want the live-provider sweep: providers
 without keys are skipped, and configured providers must satisfy the same harness
-contract.
+contract. For the exact scheduled command, run:
+
+```sh
+go run ./internal/harness/provider-conformance \
+  -providers anthropic,openai,gemini,groq,minimax,mistral,together,atlascloud \
+  -harnesses agent,universe,agent-flow,plan-delegate,a2a-stream-fallback \
+  -summary-json provider-conformance-summary.json \
+  -summary-markdown provider-conformance-summary.md \
+  -capabilities-markdown provider-capabilities.md
+```
+
+The generated summary records one row for every selected provider/harness pair;
+missing live-provider keys become skipped rows for each harness, while configured
+providers produce pass/fail rows per harness.
 
 ## Scheduled CI
 

--- a/internal/harness/provider-conformance/main.go
+++ b/internal/harness/provider-conformance/main.go
@@ -92,11 +92,11 @@ func main() {
 			if *requireConfiguredFlag {
 				fmt.Printf("FAIL %s: missing API key (%s)\n", provider, msg)
 				failed++
-				results = append(results, conformanceResult{Provider: provider, Status: statusFailed, Error: "missing API key: " + msg})
+				results = append(results, missingKeyResults(provider, harnesses, statusFailed, "missing API key: "+msg)...)
 			} else {
 				fmt.Printf("- %s: skipped (%s)\n", provider, msg)
 				skipped++
-				results = append(results, conformanceResult{Provider: provider, Status: statusSkipped, Error: msg})
+				results = append(results, missingKeyResults(provider, harnesses, statusSkipped, msg)...)
 			}
 			continue
 		}
@@ -164,6 +164,20 @@ type conformanceSummary struct {
 	Passed       int                 `json:"passed"`
 	Skipped      int                 `json:"skipped"`
 	Failed       int                 `json:"failed"`
+}
+
+func missingKeyResults(provider string, harnesses []string, status, detail string) []conformanceResult {
+	results := make([]conformanceResult, 0, len(harnesses))
+	for _, harness := range harnesses {
+		results = append(results, conformanceResult{
+			Provider: provider,
+			Harness:  harness,
+			Phase:    harnessPhase(harness),
+			Status:   status,
+			Error:    detail,
+		})
+	}
+	return results
 }
 
 func writeSummaryJSON(path string, summary conformanceSummary) error {

--- a/internal/harness/provider-conformance/main_test.go
+++ b/internal/harness/provider-conformance/main_test.go
@@ -77,6 +77,23 @@ func TestCapabilityMatrixHasRegisteredProviders(t *testing.T) {
 	}
 }
 
+func TestMissingKeyResultsReportsEachHarness(t *testing.T) {
+	results := missingKeyResults("openai", []string{"agent", "plan-delegate"}, statusSkipped, "set OPENAI_API_KEY")
+	if len(results) != 2 {
+		t.Fatalf("missingKeyResults returned %d results, want 2", len(results))
+	}
+
+	wants := []conformanceResult{
+		{Provider: "openai", Harness: "agent", Phase: harnessPhase("agent"), Status: statusSkipped, Error: "set OPENAI_API_KEY"},
+		{Provider: "openai", Harness: "plan-delegate", Phase: harnessPhase("plan-delegate"), Status: statusSkipped, Error: "set OPENAI_API_KEY"},
+	}
+	for i, want := range wants {
+		if results[i] != want {
+			t.Fatalf("result[%d] = %#v, want %#v", i, results[i], want)
+		}
+	}
+}
+
 func TestWriteCapabilityMarkdown(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "capabilities.md")
 	rows := []ai.CapabilityRow{


### PR DESCRIPTION
## Summary
- Record missing live-provider credentials as skipped/failed rows for every selected harness so the provider conformance summary shows the full provider x harness matrix.
- Document the exact scheduled provider-conformance command and summary semantics.

Closes #4649
Closes #4677

## Testing
- go test ./internal/harness/provider-conformance
- env -u MICRO_AI_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ATLASCLOUD_API_KEY -u GEMINI_API_KEY -u GROQ_API_KEY -u MINIMAX_API_KEY -u MISTRAL_API_KEY -u TOGETHER_API_KEY go run ./internal/harness/provider-conformance -providers openai,anthropic -harnesses agent,plan-delegate -summary-markdown /tmp/provider-summary.md
- go build ./...
- go test ./... (fails in this sandbox: live AtlasCloud stream test saw configured credentials and returned 400; gRPC loopback tests are blocked by environment proxy)
- golangci-lint run ./... (installed Go 1.25.12-built golangci-lint after system binary mismatch; lint reports pre-existing issues in model/postgres, cmd/micro/cli/build, and server/comments_test.go)