### PR TITLE
Refresh planner priorities for 4681

### DIFF
--- a/.github/loop/PRIORITIES.md
+++ b/.github/loop/PRIORITIES.md
@@ -21,8 +21,8 @@ changes, architectural rewrites. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **Add scheduled cross-provider agent conformance** ([#4649](https://github.com/micro/go-micro/issues/4649)) — With the active AtlasCloud plan/delegate persistence failure closed by #4674, the highest-value remaining Now-roadmap gap is battle-testing the same agent scenario across providers. Verify tool-calling, multi-step turns, plan/delegate, and guardrails on the live-provider matrix behind key-gated scheduled CI, without slowing the local harness.
-2. **Harden agent provider failure resilience** ([#4650](https://github.com/micro/go-micro/issues/4650)) — The next reliability seam is making timeouts, cancellation, rate limits, retry/backoff, and inspectable failure metadata predictable through the agent loop. Keep this scoped to existing behavior and tests; surface any breaking API or default changes as human review notes instead of queue work.
+1. **Stabilize first-agent CLI fixture registration wait** ([#4680](https://github.com/micro/go-micro/issues/4680)) — Developer adoption is the current goal, and the first-agent chat/inspect fixture is part of the Now-roadmap getting-started contract. Make the provider-free fixture prove the `assistant` agent is registered before `micro chat` runs so scaffold → run → chat → inspect remains a reliable CI-verified on-ramp instead of a flaky promise.
+2. **Harden agent provider failure resilience** ([#4650](https://github.com/micro/go-micro/issues/4650)) — With scheduled cross-provider conformance closed by #4678, the next reliability seam is making timeouts, cancellation, rate limits, retry/backoff, and inspectable failure metadata predictable through the agent loop. Keep this scoped to existing behavior and tests; surface any breaking API or default changes as human review notes instead of queue work.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:
- Remove closed cross-provider conformance item #4649 from the active planner queue.
- Promote #4680 as the top adoption-contract fix and keep #4650 next for provider resilience.

Testing:
- go build ./...
- go test ./... (fails in existing/environmental paths: ai atlascloud stream 400 and loopback-forbidden grpc tests)
- golangci-lint run ./... (fails because installed golangci-lint was built with Go 1.24 while repo targets Go 1.25.12)

Closes #4681