### PR TITLE
Stabilize first-agent fixture registration wait

### DIFF
--- a/internal/harness/zero-to-hero-ci/docs_test.go
+++ b/internal/harness/zero-to-hero-ci/docs_test.go
@@ -1047,6 +1047,7 @@ func TestFirstAgentCLIChatInspectFixture(t *testing.T) {
 	}()
 
 	waitForCLIOutput(t, &fixtureOut, "first-agent fixture ready", 15*time.Second)
+	waitForRegisteredAgent(t, micro, home, "assistant", &fixtureOut, 15*time.Second)
 
 	chat := runMicroCLIWithHome(t, micro, home, "chat", "--prompt", "Summarize my first-agent next steps", "assistant")
 	for _, want := range []string{"assistant:", "install the CLI", "run a service", "chat with an agent"} {
@@ -1091,6 +1092,23 @@ func waitForCLIOutput(t *testing.T, out *lockedBuffer, want string, timeout time
 		time.Sleep(100 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for fixture output %q; got:\n%s", want, out.String())
+}
+
+func waitForRegisteredAgent(t *testing.T, micro, home, agent string, fixtureOut *lockedBuffer, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastOut []byte
+	var lastErr error
+	for time.Now().Before(deadline) {
+		cmd := exec.Command(micro, "agent", "list")
+		cmd.Env = microCLIEnv(home)
+		lastOut, lastErr = cmd.CombinedOutput()
+		if lastErr == nil && strings.Contains(string(lastOut), agent) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for registered agent %q; last micro agent list error: %v\nlast output:\n%s\nfixture output:\n%s", agent, lastErr, lastOut, fixtureOut.String())
 }
 
 type lockedBuffer struct {
@@ -1211,18 +1229,22 @@ func buildMicroBinary(t *testing.T, root string) string {
 func runMicroCLIWithHome(t *testing.T, micro, home string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command(micro, args...)
-	cmd.Env = append(os.Environ(),
+	cmd.Env = microCLIEnv(home)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("micro %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+func microCLIEnv(home string) []string {
+	return append(os.Environ(),
 		"HOME="+home,
 		"MICRO_AI_API_KEY=",
 		"OPENAI_API_KEY=",
 		"ANTHROPIC_API_KEY=",
 		"GEMINI_API_KEY=",
 	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("micro %s failed: %v\n%s", strings.Join(args, " "), err, out)
-	}
-	return string(out)
 }
 
 func TestFirstAgentWayfindingTargetsExist(t *testing.T) {


### PR DESCRIPTION
Summary:
- Wait for `micro agent list` to show the assistant before running the first-agent CLI chat/inspect fixture.
- Share the provider-secret-free CLI environment setup across fixture polling and CLI invocations.

Testing:
- `go test ./internal/harness/zero-to-hero-ci -run TestFirstAgentCLIChatInspectFixture -count=1`
- `go test ./internal/harness/zero-to-hero-ci -run 'TestNoSecretFirstAgentTranscript|TestFirstAgentCLIChatInspectFixture|TestNoSecretFirstAgentDebuggingSmoke|TestZeroToHeroReferenceDocs|TestZeroToHeroDeployDryRunCommandSmoke|TestYourFirstAgentTutorialSmoke' -count=1`\n- `go build ./...`\n- `go test ./...` (fails in this sandbox: loopback targets forbidden for grpc client/transport tests; atlascloud stream returns 400)\n- `golangci-lint run ./...` (installed binary built with Go 1.24 cannot load Go 1.25.12 config; temporary Go 1.25-built v2.12.2 reports pre-existing issues outside this change)\n\nCloses #4680\nCloses #4683