### PR TITLE
Record agent provider failure metadata

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -355,6 +355,8 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		})
 		if err != nil {
 			run.Status = agentRunFailureStatus(err)
+			failureKind := ai.ClassifyError(err)
+			attempts := agentRunFailureAttempts(err)
 			err = agentOperationalError(err)
 			if a.currentRun != nil {
 				run.Steps = a.currentRun.Steps
@@ -363,7 +365,9 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 				run.Steps = []flow.StepRecord{{Name: agentAskStep}}
 			}
 			run.Steps[0].Status = run.Status
+			run.Steps[0].Attempts = attempts
 			run.Steps[0].Error = err.Error()
+			run.Steps[0].ErrorKind = string(failureKind)
 			_ = a.saveRun(ctx, run)
 			return nil, err
 		}

--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -213,6 +214,14 @@ func (e *operationalError) Unwrap() error {
 		return nil
 	}
 	return e.err
+}
+
+func agentRunFailureAttempts(err error) int {
+	var retryErr *ai.RetryError
+	if err != nil && errors.As(err, &retryErr) && retryErr.Attempts > 0 {
+		return retryErr.Attempts
+	}
+	return 1
 }
 
 func agentOperationalError(err error) error {

--- a/agent/resilience_test.go
+++ b/agent/resilience_test.go
@@ -327,6 +327,12 @@ func TestAskCheckpointRecordsTerminalOperationalFailureStatus(t *testing.T) {
 			if len(runs[0].Steps) == 0 || runs[0].Steps[0].Status != tt.want {
 				t.Fatalf("step status = %#v, want %q", runs[0].Steps, tt.want)
 			}
+			if runs[0].Steps[0].Attempts != 1 {
+				t.Fatalf("step attempts = %d, want 1", runs[0].Steps[0].Attempts)
+			}
+			if got := runs[0].Steps[0].ErrorKind; got != string(ai.ClassifyError(tt.err)) {
+				t.Fatalf("step error kind = %q, want %q", got, ai.ClassifyError(tt.err))
+			}
 			if pending, err := Pending(context.Background(), a); err != nil || len(pending) != 0 {
 				t.Fatalf("Pending = %#v, %v; want no terminal run", pending, err)
 			}


### PR DESCRIPTION
Summary:
- Record classified provider failure kind and attempt count on the checkpointed agent ask step so failed runs are easier to inspect.
- Extend resilience coverage for terminal cancellation, timeout, and rate-limit checkpoint metadata.

Testing:
- go build ./...
- go test ./agent -run 'TestAskCheckpointRecordsTerminalOperationalFailureStatus|TestAskRetriesTransientErrorsThenSurfacesStructuredError'\n- go test ./... (environment failures: existing atlascloud stream conformance without credentials; loopback gRPC targets forbidden)\n- golangci-lint run ./... (environment/tooling failure: installed golangci-lint built with Go 1.24, repo targets Go 1.25.12)\n\nCloses #4650\nCloses #4687