### PR TITLE
Reject nested tool-call markup in agent arguments

### DIFF
--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -296,6 +296,9 @@ func (a *agentImpl) planWrap(next ai.ToolHandler) ai.ToolHandler {
 		if call.Name == toolPlan {
 			return a.handlePlan(call)
 		}
+		if containsNestedTextToolCall(call.Input) {
+			return refused(call.ID, ai.RefusedApproval, "malformed tool call: nested text tool-call markup found inside arguments; call the intended tool directly with clean JSON arguments")
+		}
 		if call.Name == toolDelegate {
 			if blocked := a.unfinishedPlanStepsBeforeDelegation(); len(blocked) > 0 {
 				return refused(call.ID, ai.RefusedApproval, "complete these plan steps before delegating: "+strings.Join(blocked, ", "))

--- a/agent/guardrails_test.go
+++ b/agent/guardrails_test.go
@@ -90,3 +90,23 @@ func TestApproveToolDoesNotGatePlan(t *testing.T) {
 		t.Error("plan should have been persisted despite the denying approver")
 	}
 }
+
+func TestNestedTextToolCallArgumentsAreRefused(t *testing.T) {
+	called := false
+	a := newTestAgent(Name("nested-tool-arg"),
+		WithTool("task.add", "add task", nil, func(context.Context, map[string]any) (string, error) {
+			called = true
+			return "created", nil
+		}),
+	)
+
+	content := toolContent(a.toolHandler(), "task.add", map[string]any{
+		"title": `Continue the launch plan. <tool_call name="plan">{"steps":[{"task":"Design","status":"pending"}]}</tool_call>`,
+	})
+	if called {
+		t.Fatal("tool handler ran despite nested text tool-call markup in arguments")
+	}
+	if !strings.Contains(content, "nested text tool-call markup") {
+		t.Fatalf("content = %q, want nested tool-call refusal", content)
+	}
+}

--- a/agent/text_tool_calls.go
+++ b/agent/text_tool_calls.go
@@ -263,6 +263,27 @@ func textToolArguments(raw any) map[string]any {
 	return nil
 }
 
+func containsNestedTextToolCall(v any) bool {
+	switch x := v.(type) {
+	case string:
+		text := html.UnescapeString(x)
+		return openingTaggedToolCall.MatchString(text) || singleTaggedToolCall.MatchString(text)
+	case map[string]any:
+		for _, item := range x {
+			if containsNestedTextToolCall(item) {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range x {
+			if containsNestedTextToolCall(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func decodeTaggedTextToolCalls(text string, allowed map[string]string) []ai.ToolCall {
 	var out []ai.ToolCall
 	for _, match := range singleTaggedToolCall.FindAllStringSubmatch(text, -1) {


### PR DESCRIPTION
Summary:
- Refuse tool calls whose arguments contain nested text tool-call markup so malformed AtlasCloud plan/delegate output is not executed as a side-effecting service call.
- Add regression coverage for nested text tool-call arguments being blocked before the tool handler runs.

Testing:
- go test ./agent
- go build ./...
- go test ./... (fails in this environment: loopback targets forbidden in grpc client/transport tests; AtlasCloud stream conformance received 400 without credentials)
- golangci-lint run ./... (fails: installed golangci-lint was built with Go 1.24, target is Go 1.25.12)

Closes #4699
Closes #4708