### PR TITLE
Add first-agent debug smoke breadcrumbs

### DIFF
--- a/cmd/micro/cli/agent/agent.go
+++ b/cmd/micro/cli/agent/agent.go
@@ -35,6 +35,7 @@ smallest provider-free recovery loop before reading the full docs.
 5. If provider chat is not configured yet, prove the no-secret path still works:
    micro agent demo
    go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1
+   go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1
 
 Recovery docs:
   https://go-micro.dev/docs/guides/debugging-agents.html
@@ -52,6 +53,7 @@ What this proves:
   - service tools can be called by an agent
   - chat behavior is exercised without contacting a live provider
   - run history can be inspected after the prompt
+  - the debug smoke seeds a stalled-first-agent recovery transcript
 
 After it passes:
   - Build your own service-backed agent: https://go-micro.dev/docs/guides/your-first-agent.html
@@ -63,7 +65,10 @@ Use live-provider chat when you are ready for real model behavior:
   micro run
   micro chat
   micro agent doctor     # after micro run: chat/gateway/inspect recovery
-  micro inspect agent <name>`
+  micro inspect agent <name>
+
+Debug transcript smoke:
+  go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1`
 
 func init() {
 	cmd.Register(&cli.Command{

--- a/cmd/micro/cli/agent/doctor_test.go
+++ b/cmd/micro/cli/agent/doctor_test.go
@@ -86,6 +86,7 @@ func TestAgentQuickcheckPrintsProviderFreeFailureModeBreadcrumbs(t *testing.T) {
 		"micro runs <name>",
 		"micro agent demo",
 		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1",
+		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1",
 		"debugging-agents.html",
 		"no-secret-first-agent.html",
 	} {

--- a/cmd/micro/first_agent_walkthrough_test.go
+++ b/cmd/micro/first_agent_walkthrough_test.go
@@ -136,6 +136,7 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 		"micro runs <name>",
 		"micro agent demo",
 		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1",
+		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1",
 		"debugging-agents.html",
 	} {
 		if !strings.Contains(out.String(), want) {
@@ -151,7 +152,9 @@ func TestFirstAgentWalkthroughCLIBoundaries(t *testing.T) {
 	for _, want := range []string{
 		"No-secret first-agent demo",
 		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentTranscript -count=1",
+		"go test ./internal/harness/zero-to-hero-ci -run TestNoSecretFirstAgentDebuggingSmoke -count=1",
 		"provider-free",
+		"stalled-first-agent recovery transcript",
 		"micro agent preflight  # before micro run: prerequisites",
 		"micro chat",
 		"micro agent doctor     # after micro run: chat/gateway/inspect recovery",


### PR DESCRIPTION
Summary:
- Add the no-secret first-agent debugging smoke command to `micro agent quickcheck` and `micro agent demo` output so stalled first-agent recovery points directly at the maintained golden debug transcript.
- Lock the new breadcrumb into CLI boundary and agent quickcheck tests.

Testing:
- go test ./cmd/micro ./cmd/micro/cli/agent ./internal/harness/zero-to-hero-ci -run 'TestFirstAgentWalkthroughCLIBoundaries|TestAgentQuickcheckPrintsProviderFreeFailureModeBreadcrumbs|TestNoSecretFirstAgentTranscript|TestNoSecretFirstAgentDebuggingSmoke' -count=1
- go build ./...
- go test ./... (fails in this environment due loopback targets forbidden in existing grpc tests and live atlascloud conformance request returning not found)
- golangci-lint run ./... (system binary too old for Go 1.25.12)
- /root/go/bin/golangci-lint run ./...

Closes #4712
Closes #4719