### PR TITLE
Add agent x402 spend budget guardrail

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -81,6 +81,8 @@ type agentImpl struct {
 
 	// steps counts tool executions in the current Ask, for MaxSteps.
 	steps int
+	// spend counts reserved paid-tool spend in the current Ask, for MaxSpend.
+	spend int64
 	// calls counts identical tool calls (name+args) in the current Ask,
 	// for LoopLimit.
 	calls map[string]int
@@ -304,6 +306,7 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 		a.mem.Add("user", message)
 	}
 	a.steps = 0
+	a.spend = 0
 	a.calls = map[string]int{}
 	a.pause = nil
 

--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -131,6 +131,7 @@ func (a *agentImpl) toolHandler() ai.ToolHandler {
 	h = a.toolRetryWrap(h)
 	h = a.checkpointToolWrap(h)
 	h = a.approveWrap(h)
+	h = a.spendWrap(h)
 	h = a.loopWrap(h)
 	h = a.stepWrap(h)
 	h = a.planWrap(h)
@@ -372,6 +373,27 @@ func (a *agentImpl) approveWrap(next ai.ToolHandler) ai.ToolHandler {
 			}
 		}
 		return next(ctx, call)
+	}
+}
+
+// spendWrap reserves a per-run x402 spend budget before paid tool execution.
+func (a *agentImpl) spendWrap(next ai.ToolHandler) ai.ToolHandler {
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		amount := a.opts.ToolSpend[call.Name]
+		if amount <= 0 || a.opts.MaxSpend <= 0 {
+			return next(ctx, call)
+		}
+		if a.spend+amount > a.opts.MaxSpend {
+			return refused(call.ID, ai.RefusedSpendBudget, fmt.Sprintf(
+				"x402 spend budget exceeded: paying %d for %s would exceed per-run budget (spent %d of %d)",
+				amount, call.Name, a.spend, a.opts.MaxSpend))
+		}
+		a.spend += amount
+		res := next(ctx, call)
+		if res.Refused != "" || toolErrorMessage(res) != "" {
+			a.spend -= amount
+		}
+		return res
 	}
 }
 

--- a/agent/guardrails_test.go
+++ b/agent/guardrails_test.go
@@ -91,6 +91,77 @@ func TestApproveToolDoesNotGatePlan(t *testing.T) {
 	}
 }
 
+func TestMaxSpendAllowsPaidToolWithinBudget(t *testing.T) {
+	calls := 0
+	a := newTestAgent(Name("paid-within-budget"),
+		MaxSpend(10),
+		ToolSpend("paid.lookup", 7),
+		WithTool("paid.lookup", "paid lookup", nil, func(context.Context, map[string]any) (string, error) {
+			calls++
+			return `{"ok":true}`, nil
+		}),
+	)
+
+	res := a.toolHandler()(context.Background(), ai.ToolCall{ID: "paid-1", Name: "paid.lookup", Input: map[string]any{}})
+	if calls != 1 {
+		t.Fatalf("paid tool was not executed")
+	}
+	if res.Refused != "" {
+		t.Fatalf("paid tool was refused: %+v", res)
+	}
+	if res.Content != `{"ok":true}` {
+		t.Fatalf("content = %q, want paid result", res.Content)
+	}
+}
+
+func TestMaxSpendRefusesPaidToolBeforePaymentWhenBudgetExceeded(t *testing.T) {
+	calls := 0
+	a := newTestAgent(Name("paid-over-budget"),
+		MaxSpend(5),
+		ToolSpend("paid.lookup", 7),
+		WithTool("paid.lookup", "paid lookup", nil, func(context.Context, map[string]any) (string, error) {
+			calls++
+			return `{"ok":true}`, nil
+		}),
+	)
+
+	res := a.toolHandler()(context.Background(), ai.ToolCall{ID: "paid-1", Name: "paid.lookup", Input: map[string]any{}})
+	if calls != 0 {
+		t.Fatalf("paid tool ran despite budget refusal")
+	}
+	if res.Refused != ai.RefusedSpendBudget {
+		t.Fatalf("Refused = %q, want %q (result %+v)", res.Refused, ai.RefusedSpendBudget, res)
+	}
+	if !strings.Contains(res.Content, "x402 spend budget exceeded") {
+		t.Fatalf("content = %q, want inspectable budget refusal", res.Content)
+	}
+}
+
+func TestMaxSpendRollsBackFailedPaidToolReservation(t *testing.T) {
+	calls := 0
+	a := newTestAgent(Name("paid-rollback"),
+		MaxSpend(10),
+		ToolSpend("paid.lookup", 7),
+		WithTool("paid.lookup", "paid lookup", nil, func(context.Context, map[string]any) (string, error) {
+			calls++
+			if calls == 1 {
+				return "", context.Canceled
+			}
+			return `{"ok":true}`, nil
+		}),
+	)
+
+	h := a.toolHandler()
+	first := h(context.Background(), ai.ToolCall{ID: "paid-1", Name: "paid.lookup", Input: map[string]any{}})
+	if first.Refused != "" || !strings.Contains(first.Content, "context canceled") {
+		t.Fatalf("first result = %+v, want tool error without guardrail refusal", first)
+	}
+	second := h(context.Background(), ai.ToolCall{ID: "paid-2", Name: "paid.lookup", Input: map[string]any{}})
+	if second.Refused != "" || second.Content != `{"ok":true}` {
+		t.Fatalf("second result = %+v, want reservation rollback to allow retry", second)
+	}
+}
+
 func TestNestedTextToolCallArgumentsAreRefused(t *testing.T) {
 	called := false
 	a := newTestAgent(Name("nested-tool-arg"),

--- a/agent/options.go
+++ b/agent/options.go
@@ -98,6 +98,10 @@ type Options struct {
 	LoopLimit int
 	// Approve gates each action before it runs. Nil = allow all.
 	Approve ApproveFunc
+	// MaxSpend bounds paid x402 tool spend per Ask in the asset's smallest
+	// unit (0 = disabled). ToolSpend lists known paid tools and their prices.
+	MaxSpend  int64
+	ToolSpend map[string]int64
 
 	// A2AAddress, if set, makes Run serve this agent over the A2A protocol
 	// on that address directly (no separate gateway), e.g. ":4000".
@@ -222,6 +226,25 @@ func MaxSteps(n int) Option {
 // action (service tools and delegate). Returning false blocks the call.
 func ApproveTool(fn ApproveFunc) Option {
 	return func(o *Options) { o.Approve = fn }
+}
+
+// MaxSpend bounds paid x402 tool spend per Ask, in the asset's smallest unit
+// (0 = disabled). A paid tool that would exceed the cap is refused before the
+// tool handler runs or any payment can be made.
+func MaxSpend(amount int64) Option {
+	return func(o *Options) { o.MaxSpend = amount }
+}
+
+// ToolSpend records the x402 price for a tool, in the asset's smallest unit,
+// so MaxSpend can reserve budget before execution. Non-positive amounts are
+// treated as free.
+func ToolSpend(tool string, amount int64) Option {
+	return func(o *Options) {
+		if o.ToolSpend == nil {
+			o.ToolSpend = map[string]int64{}
+		}
+		o.ToolSpend[tool] = amount
+	}
 }
 
 // LoopLimit sets how many times the agent may repeat the same tool call

--- a/ai/model.go
+++ b/ai/model.go
@@ -109,6 +109,9 @@ const (
 	RefusedMaxSteps = "max_steps"
 	RefusedLoop     = "loop"
 	RefusedApproval = "approval"
+	// RefusedSpendBudget means an agent refused a paid tool before execution
+	// because the configured per-run x402 spend budget would be exceeded.
+	RefusedSpendBudget = "spend_budget"
 )
 
 // RunInfo describes the agent run a tool call belongs to. The agent

--- a/internal/website/docs/guides/x402-payments.md
+++ b/internal/website/docs/guides/x402-payments.md
@@ -100,7 +100,21 @@ c := &x402.Client{
 resp, err := c.Do(req) // a 402 is paid and retried; over-budget calls error instead
 ```
 
-`Payer` is an interface (`Pay(ctx, Requirements) (payment string, error)`) — the consumer counterpart to `Facilitator`. The budget accumulates across calls, so a long-running agent can be handed a fixed allowance for a task. Budget is reserved before payment is created, which means parallel paid calls cannot race past the cap; if payment creation or verification fails, the reservation is released. (The agent-level `AgentMaxSpend` option, wiring this into the agent loop next to `MaxSteps`/`ApproveTool`, is the next step.)
+`Payer` is an interface (`Pay(ctx, Requirements) (payment string, error)`) — the consumer counterpart to `Facilitator`. The budget accumulates across calls, so a long-running agent can be handed a fixed allowance for a task. Budget is reserved before payment is created, which means parallel paid calls cannot race past the cap; if payment creation or verification fails, the reservation is released.
+
+## Agent-level spend guardrail
+
+For unattended agents, set the same cap at the agent tool-execution layer so paid tools are refused before their handler — and therefore before a payer — can run:
+
+```go
+agent := micro.NewAgent("buyer",
+    micro.AgentMaxSteps(8),
+    micro.AgentMaxSpend(20_000), // per Ask, smallest units
+    micro.AgentToolSpend("weather.Weather.Forecast", 10_000),
+)
+```
+
+`AgentMaxSpend` is disabled by default (`0`). `AgentToolSpend` records the price discovered from your shoppable MCP/x402 catalog for the tools this agent may call. When a call would exceed the per-run allowance, the result is a normal structured guardrail refusal with `Refused: "spend_budget"` and an explanatory error in the run timeline/inspect output, distinct from provider/model failures.
 
 ### Live facilitator conformance
 
@@ -121,7 +135,7 @@ Leave those variables unset in normal CI; the live test skips unless the facilit
 
 - **Opt-in.** No pay-to address (and no config), no payments — nothing changes.
 - **No crypto in the framework.** The facilitator does verification and settlement on-chain; Go Micro speaks HTTP.
-- **A paying agent needs a budget.** On the agent side, an unattended agent that spends money needs a spend cap next to `MaxSteps` and `ApproveTool` — see [Plan & Delegate](plan-delegate.html) for the guardrail model. This is active work.
+- **A paying agent needs a budget.** Use `AgentMaxSpend` plus `AgentToolSpend` next to `MaxSteps` and `ApproveTool` so a run has an explicit allowance before any paid tool can execute.
 
 ## See also
 

--- a/micro.go
+++ b/micro.go
@@ -120,6 +120,16 @@ func AgentLoopLimit(n int) AgentOption { return agent.LoopLimit(n) }
 // each action the agent takes.
 func AgentApproveTool(fn ApproveFunc) AgentOption { return agent.ApproveTool(fn) }
 
+// AgentMaxSpend bounds paid x402 tool spend per Ask, in the asset's smallest
+// unit (0 = disabled). Calls that would exceed it are refused before payment.
+func AgentMaxSpend(amount int64) AgentOption { return agent.MaxSpend(amount) }
+
+// AgentToolSpend records the x402 price for a tool, in the asset's smallest
+// unit, so AgentMaxSpend can reserve budget before execution.
+func AgentToolSpend(tool string, amount int64) AgentOption {
+	return agent.ToolSpend(tool, amount)
+}
+
 // AgentModelCallTimeout sets the timeout for each provider Generate call.
 func AgentModelCallTimeout(d time.Duration) AgentOption { return agent.ModelCallTimeout(d) }
 


### PR DESCRIPTION
## Summary
- Adds an agent-level per-run x402 spend guardrail with AgentMaxSpend/AgentToolSpend.
- Refuses paid tools before execution when the configured allowance would be exceeded, surfacing Refused=\"spend_budget\" for run inspection.
- Documents the guardrail in the x402 payments guide.

## Testing
- go build ./...
- NO_PROXY=localhost,127.0.0.1,::1 no_proxy=localhost,127.0.0.1,::1 HTTP_PROXY= HTTPS_PROXY= http_proxy= https_proxy= ATLASCLOUD_API_KEY= go test ./...
- golangci-lint run ./...

Closes #4743
Closes #4747