### PR TITLE
Stream remote agent replies in micro chat

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -15,7 +15,9 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -261,6 +263,36 @@ func (a *agentImpl) Stream(ctx context.Context, message string) (ai.Stream, erro
 	}
 	a.mem.Add("user", message)
 	return &memoryRecordingStream{stream: stream, memory: a.mem}, nil
+}
+
+// StreamChat serves the Agent.StreamChat RPC endpoint by forwarding stream-capable
+// remote clients to the agent streaming path. If the model cannot stream, the
+// underlying error is returned so callers can fall back to Agent.Chat.
+func (a *agentImpl) StreamChat(ctx context.Context, stream pb.Agent_StreamChatStream) error {
+	req, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	aiStream, err := a.streamAskAI(ctx, req.Message)
+	if err != nil {
+		return err
+	}
+	defer aiStream.Close()
+	for {
+		chunk, err := aiStream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if chunk == nil || chunk.Reply == "" {
+			continue
+		}
+		if err := stream.Send(&pb.ChatResponse{Reply: chunk.Reply, Agent: a.opts.Name}); err != nil {
+			return err
+		}
+	}
 }
 
 // Pending returns checkpointed agent runs that have not completed. It mirrors

--- a/agent/proto/agent.pb.micro.go
+++ b/agent/proto/agent.pb.micro.go
@@ -29,6 +29,7 @@ var _ server.Option
 
 type AgentService interface {
 	Chat(ctx context.Context, in *ChatRequest, opts ...client.CallOption) (*ChatResponse, error)
+	StreamChat(ctx context.Context, in *ChatRequest, opts ...client.CallOption) (Agent_StreamChatService, error)
 }
 
 type agentService struct {
@@ -53,6 +54,40 @@ func (c *agentService) Chat(ctx context.Context, in *ChatRequest, opts ...client
 	return out, nil
 }
 
+func (c *agentService) StreamChat(ctx context.Context, in *ChatRequest, opts ...client.CallOption) (Agent_StreamChatService, error) {
+	req := c.c.NewRequest(c.name, "Agent.StreamChat", in)
+	stream, err := c.c.Stream(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err := stream.Send(in); err != nil {
+		_ = stream.Close()
+		return nil, err
+	}
+	return &agentServiceStreamChat{stream}, nil
+}
+
+type Agent_StreamChatService interface {
+	Close() error
+	Recv() (*ChatResponse, error)
+}
+
+type agentServiceStreamChat struct {
+	stream client.Stream
+}
+
+func (x *agentServiceStreamChat) Close() error {
+	return x.stream.Close()
+}
+
+func (x *agentServiceStreamChat) Recv() (*ChatResponse, error) {
+	m := new(ChatResponse)
+	if err := x.stream.Recv(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // Server API for Agent service
 
 type AgentHandler interface {
@@ -62,6 +97,7 @@ type AgentHandler interface {
 func RegisterAgentHandler(s server.Server, hdlr AgentHandler, opts ...server.HandlerOption) error {
 	type agent interface {
 		Chat(ctx context.Context, in *ChatRequest, out *ChatResponse) error
+		StreamChat(ctx context.Context, stream server.Stream) error
 	}
 	type Agent struct {
 		agent
@@ -76,4 +112,40 @@ type agentHandler struct {
 
 func (h *agentHandler) Chat(ctx context.Context, in *ChatRequest, out *ChatResponse) error {
 	return h.AgentHandler.Chat(ctx, in, out)
+}
+
+func (h *agentHandler) StreamChat(ctx context.Context, stream server.Stream) error {
+	streamer, ok := h.AgentHandler.(interface {
+		StreamChat(context.Context, Agent_StreamChatStream) error
+	})
+	if !ok {
+		return fmt.Errorf("agent: StreamChat unsupported")
+	}
+	return streamer.StreamChat(ctx, &agentStreamChatStream{stream})
+}
+
+type Agent_StreamChatStream interface {
+	Close() error
+	Send(*ChatResponse) error
+	Recv() (*ChatRequest, error)
+}
+
+type agentStreamChatStream struct {
+	stream server.Stream
+}
+
+func (x *agentStreamChatStream) Close() error {
+	return x.stream.Close()
+}
+
+func (x *agentStreamChatStream) Send(m *ChatResponse) error {
+	return x.stream.Send(m)
+}
+
+func (x *agentStreamChatStream) Recv() (*ChatRequest, error) {
+	m := new(ChatRequest)
+	if err := x.stream.Recv(m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }

--- a/agent/proto/agent.proto
+++ b/agent/proto/agent.proto
@@ -7,6 +7,7 @@ option go_package = "./proto;agent";
 // Agent is the RPC interface for an AI agent.
 service Agent {
 	rpc Chat(ChatRequest) returns (ChatResponse) {}
+	rpc StreamChat(ChatRequest) returns (stream ChatResponse) {}
 }
 
 message ChatRequest {

--- a/cmd/micro/chat/chat.go
+++ b/cmd/micro/chat/chat.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 	"go-micro.dev/v6/agent"
+	agentpb "go-micro.dev/v6/agent/proto"
 	"go-micro.dev/v6/ai"
 	clt "go-micro.dev/v6/client"
 	"go-micro.dev/v6/cmd"
@@ -187,6 +188,36 @@ func (s *session) callAgent(ctx context.Context, name, message string) (*agent.R
 		})
 	}
 	return r, nil
+}
+
+// streamAgent calls an agent's StreamChat endpoint and prints chunks as they
+// arrive. Agents that do not expose StreamChat return an error; callers use that
+// signal to fall back to Agent.Chat.
+func (s *session) streamAgent(ctx context.Context, name, message string) error {
+	stream, err := agentpb.NewAgentService(name, s.cl).StreamChat(ctx, &agentpb.ChatRequest{Message: message})
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+	var reply strings.Builder
+	for {
+		chunk, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if chunk == nil || chunk.Reply == "" {
+			continue
+		}
+		fmt.Print(chunk.Reply)
+		reply.WriteString(chunk.Reply)
+	}
+	if reply.Len() > 0 {
+		fmt.Println()
+	}
+	return nil
 }
 
 // buildRouterPrompt creates a system prompt for the router that
@@ -552,6 +583,11 @@ func (s *session) routeToAgent(ctx context.Context, prompt string) error {
 	if len(s.agents) == 1 {
 		for name := range s.agents {
 			fmt.Printf("  \033[35m◆\033[0m \033[2m%s\033[0m\n", name)
+			if s.stream {
+				if err := s.streamAgent(ctx, name, prompt); err == nil {
+					return nil
+				}
+			}
 			resp, err := s.callAgent(ctx, name, prompt)
 			if err != nil {
 				return err
@@ -590,6 +626,11 @@ func (s *session) routeToAgent(ctx context.Context, prompt string) error {
 		}
 
 		fmt.Printf("  \033[35m◆\033[0m \033[2m%s\033[0m\n", agentName)
+		if s.stream {
+			if err := s.streamAgent(ctx, agentName, message); err == nil {
+				return ai.ToolResult{ID: call.ID, Value: map[string]string{"agent": agentName, "streamed": "true"}, Content: `{"streamed":true}`}
+			}
+		}
 		resp, err := s.callAgent(ctx, agentName, message)
 		if err != nil {
 			return ai.ToolResult{ID: call.ID, Value: map[string]string{"error": err.Error()}, Content: `{"error":"` + err.Error() + `"}`}


### PR DESCRIPTION
## Summary
- Add an Agent.StreamChat RPC for stream-capable registered agents.
- Teach micro chat --stream to consume remote agent chunks and fall back to Agent.Chat when streaming is unavailable.

Closes #4760
Closes #4762

## Testing
- go build ./...
- go test ./... (environment failures: configured atlascloud stream check returned 400; loopback gRPC tests blocked by sandbox envoy)
- go test ./agent ./agent/proto ./cmd/micro/chat ./gateway/a2a
- golangci-lint run ./... (environment/tooling failure: lint binary built with Go 1.24 while repo targets Go 1.25.12)