### PR TITLE
Refresh planner priority after memory compaction

### DIFF
--- a/.github/loop/PRIORITIES.md
+++ b/.github/loop/PRIORITIES.md
@@ -21,7 +21,7 @@ changes, architectural rewrites. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **Add memory compaction controls for long-running agents** ([#4765](https://github.com/micro/go-micro/issues/4765)) — #4763 closed the live registered-agent `micro chat --stream` gap, and the recent run also over-invested in docs-link guards, AtlasCloud-specific repair, and plan/delegate edge hardening. The next highest-value user-facing gap is memory that survives beyond toy conversations without unbounded prompt growth: add opt-in compaction/summarization that preserves recent turns/tool results, stores an inspectable summary, and keeps `Ask`/stream/checkpoint behavior coherent without changing defaults.
+1. **Add provider retry and timeout controls for agent model calls** ([#4771](https://github.com/micro/go-micro/issues/4771)) — #4769 closed the compacted-memory summary gap, so the next highest-value user-facing gap is resilience under real provider instability: add opt-in timeout/retry/backoff controls around agent model calls, preserve cancellation/deadline semantics, and make retry/timeout state visible through existing run inspection or tracing without changing defaults.
 
 _Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
 architecture-review pass._


### PR DESCRIPTION
Summary:
- Drop closed memory compaction priority #4765 after PR #4769 merged.
- Add #4771 as the next builder item for provider retry/timeout controls.

Testing:
- git diff --check

Closes #4770