### PR TITLE
Add model retry jitter control

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -400,6 +400,7 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 			Timeout:     a.opts.ModelTimeout,
 			MaxAttempts: a.opts.ModelMaxAttempts,
 			Backoff:     a.opts.ModelRetryBackoff,
+			Jitter:      a.opts.ModelRetryJitter,
 		})
 		if err != nil {
 			run.Status = agentRunFailureStatus(err)

--- a/agent/options.go
+++ b/agent/options.go
@@ -59,6 +59,9 @@ type Options struct {
 	// ModelRetryBackoff is the base delay between transient provider failures
 	// (grows exponentially per attempt when retries are enabled).
 	ModelRetryBackoff time.Duration
+	// ModelRetryJitter adds up to this random delay to each provider retry
+	// backoff. Default 0 preserves deterministic timing unless explicitly set.
+	ModelRetryJitter time.Duration
 	// ToolTimeout bounds each tool execution (0 disables). The timeout is
 	// applied before custom tools, delegate, and service RPC calls so context
 	// deadlines propagate consistently through the agent loop.
@@ -273,6 +276,12 @@ func ModelRetry(maxAttempts int, backoff time.Duration) Option {
 		o.ModelMaxAttempts = maxAttempts
 		o.ModelRetryBackoff = backoff
 	}
+}
+
+// ModelRetryJitter adds bounded random jitter to provider retry backoff.
+// Set 0 to disable.
+func ModelRetryJitter(d time.Duration) Option {
+	return func(o *Options) { o.ModelRetryJitter = d }
 }
 
 // ToolRetry sets the tool retry budget and backoff for transient failures.

--- a/ai/retry.go
+++ b/ai/retry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"strconv"
 	"strings"
@@ -130,6 +131,9 @@ type GeneratePolicy struct {
 	Timeout     time.Duration
 	MaxAttempts int
 	Backoff     time.Duration
+	// Jitter adds up to this duration of random delay to retry backoff.
+	// It is opt-in so existing retry timing remains deterministic by default.
+	Jitter time.Duration
 }
 
 // GenerateWithRetry calls m.Generate with per-attempt timeout and bounded retry.
@@ -183,7 +187,7 @@ func GenerateWithRetry(ctx context.Context, m Model, req *Request, policy Genera
 		// Always back off between retries — exponential and capped — so an
 		// opt-in retry can never become a tight loop hammering the provider,
 		// even if Backoff was left at zero.
-		backoff := retryBackoff(err, attempt, policy.Backoff)
+		backoff := retryBackoffWithJitter(err, attempt, policy.Backoff, policy.Jitter)
 		t := time.NewTimer(backoff)
 		select {
 		case <-ctx.Done():
@@ -219,6 +223,10 @@ func generateAttempt(ctx context.Context, m Model, req *Request, opts ...Generat
 }
 
 func retryBackoff(err error, attempt int, base time.Duration) time.Duration {
+	return retryBackoffWithJitter(err, attempt, base, 0)
+}
+
+func retryBackoffWithJitter(err error, attempt int, base, jitter time.Duration) time.Duration {
 	backoff := base
 	if backoff <= 0 {
 		backoff = 200 * time.Millisecond
@@ -235,6 +243,9 @@ func retryBackoff(err error, attempt int, base time.Duration) time.Duration {
 		if delay := retryAfter.RetryAfter(); delay > backoff {
 			backoff = delay
 		}
+	}
+	if jitter > 0 {
+		backoff += time.Duration(rand.Int64N(int64(jitter) + 1))
 	}
 	if backoff > 30*time.Second {
 		return 30 * time.Second

--- a/ai/retry_test.go
+++ b/ai/retry_test.go
@@ -423,3 +423,15 @@ func TestHTTPErrorExposesStatusAndRetryAfter(t *testing.T) {
 		t.Fatalf("RetryAfter() = %s, want 2s", got)
 	}
 }
+
+func TestRetryBackoffAddsBoundedJitter(t *testing.T) {
+	const base = 10 * time.Millisecond
+	const jitter = 5 * time.Millisecond
+
+	for range 100 {
+		got := retryBackoffWithJitter(errors.New("temporary"), 1, base, jitter)
+		if got < base || got > base+jitter {
+			t.Fatalf("retryBackoffWithJitter() = %s, want in [%s, %s]", got, base, base+jitter)
+		}
+	}
+}


### PR DESCRIPTION
Summary:
- Adds opt-in jitter for agent model retry backoff while preserving deterministic retry timing by default.
- Wires the agent option into GenerateWithRetry and covers bounded jitter behavior with a unit test.

Testing:
- go build ./...
- go test ./... (fails in this environment: configured provider stream conformance unexpectedly reaches atlascloud; loopback gRPC targets are blocked; store file table flake)
- golangci-lint run ./... (fails because installed golangci-lint was built with Go 1.24 and this module targets Go 1.25.12)

Closes #4771
Closes #4774