### PR TITLE
roadmap: restock with capability bets; repoint the loop queue

### DIFF
--- a/.github/loop/PRIORITIES.md
+++ b/.github/loop/PRIORITIES.md
@@ -1,27 +1,38 @@
 # Priorities
 
-The ranked work queue for the autonomous improvement loop. The
-**architecture-review** pass (the *architect*) owns this file: each run it turns
-the [roadmap](../../ROADMAP.md) plus an internal scan (gaps in the
-services → agents → workflows lifecycle, API coherence, drift, tech debt, test and
-DX friction) into a single ordered list — highest-value first — and links each
-item to a tracking issue. The hourly **continuous-improvement** pass works the
-**top item whose issue is still open**. So the architect decides *what*, and the
-increment loop *builds* it.
+The ranked work queue for the autonomous improvement loop. The **planner** owns
+this file: each run it turns the [roadmap](../../ROADMAP.md) plus an internal scan
+into a single ordered list — highest-value first — each item linked to a tracking
+issue. The **builder** works the top item whose issue is still open. So the
+planner decides *what*, the builder *builds* it.
 
-**Reading / editing.** An item is done when its linked issue closes (the increment
-that builds it adds `Closes #<issue>`). Roadmap phase (Now → Next → Later) is the
-primary ordering; internal findings are interleaved by value, not kept in a
-separate list. The human can reorder this list — or the issues — at any time to
-redirect the loop; direction always wins.
+**Bias to capability, not busy-work.** The top of this queue is net-new capability
+from the roadmap's *Now/Next* bets. Hardening/conformance/DX polish is background
+work (roadmap *Ongoing*) — kept low here and capped, never allowed to crowd out the
+bets. If an area has had several increments with no user-visible gain, it is done
+for now; rank real-headroom capability instead.
 
-**Off-limits to the loop** (the architect proposes these as notes, never as queue
-items the loop can auto-merge): brand/positioning copy, breaking public-API
-changes, architectural rewrites. Those go to the human.
+**Reading / editing.** An item is done when its linked issue closes (the PR that
+builds it adds `Closes #<issue>`). The human can reorder this list or the issues at
+any time — direction always wins.
+
+**Off-limits to the loop** (planner proposes as notes, never auto-merged queue
+items): brand/positioning copy, breaking public-API changes, architectural
+rewrites.
 
 ## Work queue (ranked)
 
-1. **Add Gemini provider streaming support** ([#4784](https://github.com/micro/go-micro/issues/4784)) — #4782 closed the provider failure inspection gap, so the next highest-value user-facing gap is the last plain chat streaming hole in provider coverage: implement usable Gemini `ai.Stream` support so `micro chat`, agent streaming, and A2A streaming behave consistently across supported providers, with focused parser/error coverage and no broad public API changes.
+### Capability — the headline (roadmap: Now / Next)
 
-_Seeded by Claude Code from the roadmap + open issues; thereafter maintained by the
-architecture-review pass._
+1. **Agents that pay — wire the x402 buyer into the agent runtime** ([#4786](https://github.com/micro/go-micro/issues/4786)) — the flagship bet. The buyer `x402.Client`/`Payer`/budget already exists; wire it so an agent autonomously settles a payment-required tool within budget and retries, opt-in and observable. Makes go-micro a runtime for autonomous agent commerce.
+2. **AP2 mandate foundation over A2A + x402** ([#3552](https://github.com/micro/go-micro/issues/3552)) — signed Checkout/Payment mandates attached over A2A, the Payment Mandate naming an x402 rail. The authorization/audit layer of the emerging agent-payments standard; additive and opt-in.
+3. **Agent spend observability** ([#4787](https://github.com/micro/go-micro/issues/4787)) — surface x402 spend in `RunInfo` and OpenTelemetry so payments are inspectable like every other agent action. (Follows #4786.)
+4. **Example: an agent that pays for a paid tool** ([#4788](https://github.com/micro/go-micro/issues/4788)) — the runnable artifact that makes the bet real for a developer, against a mock facilitator (no live funds). (Follows #4786/#4787.)
+
+### Background — hardening & DX (roadmap: Ongoing; capped)
+
+5. **Harden agent provider failure resilience** ([#4650](https://github.com/micro/go-micro/issues/4650)) — timeouts, cancellation, rate limits, retry/backoff, inspectable failure metadata through the agent loop. Real, but maintenance — keep it below the capability bets.
+
+_Restocked by Claude Code from the roadmap's capability bets; thereafter maintained
+by the planner. Next capability bets to decompose when the above land:
+gRPC-reflection MCP, Kubernetes operator + CRDs (roadmap: Next)._

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,44 +32,55 @@ default.
    and history, end to end.
 5. Battle-tested: works across every provider, fails safely, observable.
 
-## Now — hardening
+The forward work is **net-new capability**, not more hardening. Maintenance
+(conformance, resilience, DX polish) continues in the background (see *Ongoing*
+below) — but it is not the roadmap. These bets are.
 
-- **Cross-provider conformance** — the same agent scenario across all seven
-  providers, gated on keys, on a schedule.
-- **Failure & resilience** — timeouts, rate limits, cancellation, deadline/context
-  propagation, retry/backoff.
-- **Getting-started contract** — define and CI-verify the 0→1 and 0→hero flows.
+## Now — capability
 
-## Shipped agent depth
+- **Agents that pay (x402 buyer in the runtime).** The seller side ships (paid
+  tools via the `wrapper/x402` middleware) and the buyer `x402.Client` (a
+  budget-capped `Payer` that turns a `402` into pay-and-retry) exists — but an
+  agent can't yet *autonomously* pay for a paid tool. Wire the buyer into the
+  agent tool loop: a budget-capped `AgentPayer` so an agent that hits a
+  payment-required tool settles it within budget and retries, with the spend
+  gated (like `ApproveTool`) and observable in `RunInfo`/traces. This makes
+  go-micro a runtime for **autonomous agent commerce**. *(flagship — decomposed
+  into issues in the loop queue)*
+- **AP2 mandate foundation** ([#3552](https://github.com/micro/go-micro/issues/3552))
+  — verifiable payment **mandates** (a Checkout Mandate and a Payment Mandate),
+  signed and attached over A2A, with the Payment Mandate naming an x402 rail. The
+  authorization/audit layer above A2A + x402 that positions go-micro early in the
+  emerging agent-payments standard (Google's AP2, standardized via FIDO).
+  Additive and opt-in.
 
-- **Durable agent loop** — opt-in `Checkpoint` support lets agent `Ask` and
-  streaming runs persist, list pending work, and resume without replaying completed
-  tool calls. Human-input pauses resume through explicit input helpers.
-- **Agent observability** — agent `RunInfo` now feeds OpenTelemetry spans/events
-  across runs, model turns, tool calls, retries, delegation lineage, and resume
-  checkpoints.
+## Next — reach & deployment
 
-## Next — agentic depth
+- **gRPC-reflection MCP** — derive MCP tools from *any* gRPC service via server
+  reflection, not just go-micro-native handlers. Point the gateway at an external
+  gRPC service and its methods become agent tools — a large jump in what an agent
+  can operate.
+- **Kubernetes operator + CRDs** — `Agent`, `Service`, and `Flow` as first-class
+  Kubernetes resources; an operator reconciles them into Deployments wired to the
+  registry. The production deployment story for teams already on K8s.
 
-- **Streaming** — broaden provider-backed `ai.Stream` coverage and keep chat/A2A streaming end to end.
-- **Resume operations polish** — keep improving CLI/docs breadcrumbs for finding
-  pending agent runs and deciding whether to call resume, resume-input, or stream
-  resume in production.
-- **Observability hardening** — keep span attributes and run inspection coherent
-  across agents, flows, and gateways as more providers and workflow paths are
-  exercised.
+## Later — exploratory
 
-## Later
+- **Runtime-fitness loop** — a persistently-running dogfood app (Mu) plus an
+  operator/canary loop role, so the autonomous loop evolves go-micro against
+  **real runtime signal** (latency, errors, cost) with canary + rollback — not
+  just green CI. The demand signal the loop is missing today.
+- **HTTP/3 transport**; richer A2A live-stream reconnection (`tasks/resubscribe`,
+  `input-required` handoffs); memory management (summarization, retrieval/RAG).
 
-- Memory management (summarization, retrieval/RAG); human-in-the-loop pause/resume;
-  richer A2A live-stream reconnection (`tasks/resubscribe`) and `input-required`
-  handoffs.
+## Ongoing — hardening & DX (background, not the headline)
 
-## Developer experience (ongoing)
-
-- A seamless CLI inner loop (scaffold → run → chat → inspect → deploy); UI
-  discipline (trim what isn't great); a maintained real-world example that doubles
-  as the 0→hero reference; docs kept in lockstep with the code.
+Continuous but **capped** so it never crowds out capability: cross-provider
+conformance, failure/resilience (timeouts, cancellation, retry/backoff), the
+0→1 and 0→hero getting-started contract, streaming/observability coherence, and a
+seamless CLI inner loop (scaffold → run → chat → inspect → deploy). Real, but
+maintenance — the loop should spend the majority of its cycles on the bets above,
+not here.
 
 ## How it's sustained
 


### PR DESCRIPTION
This is the fix for "the loop feels like busy-work" — at the source.

**The root cause wasn't the loop; it was the roadmap.** Reading `ROADMAP.md`, every forward item (Now/Next/Later) was hardening, conformance, or docs-polish — zero net-new capability. The loop was faithfully executing a maintenance backlog, so its output *was* busy-work. An agent scanning a healthy codebase finds infinite hardening; it can't invent ambition. That has to come from the roadmap.

## What this does
**`ROADMAP.md`** — restocked with real capability bets, maintenance explicitly demoted:
- **Now:** *Agents that pay* (wire the existing `x402` buyer into the agent runtime — autonomous agent commerce); *AP2 mandate foundation* over A2A+x402 (#3552).
- **Next:** gRPC-reflection MCP (expose *any* gRPC service as agent tools); Kubernetes operator + CRDs.
- **Later:** the runtime-fitness loop (live Mu + operator/canary); HTTP/3; A2A reconnection; memory/RAG.
- **Ongoing:** hardening/conformance/DX — kept, but *capped and background*, "not the headline."

**`.github/loop/PRIORITIES.md`** — repointed so the loop pulls capability first. The flagship is decomposed into buildable, CI-verifiable issues I filed and grounded in the actual code (the buyer `x402.Client`/`Payer`/budget already exists; the agent tool-handler chain is the wiring seam):
- #4786 — wire the x402 buyer into the agent runtime *(flagship)*
- #4787 — agent spend observability (RunInfo/OTel)
- #4788 — a runnable "agent that pays" example

## Not auto-merged — your call on the bets
You said you'd react to / reorder the bets, so this is yours to steer. **Reorder, veto, or swap any bet before merging** — e.g. if you'd rather lead with the K8s operator or the runtime-fitness/Mu loop than payments, say so and I'll re-rank (and close the x402 issues if that bet drops). Once you merge, the next planner/builder runs start building real capability instead of grooming the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_