### PR TITLE
roadmap: drop the word "bets" (development, not bets)

### DIFF
--- a/.github/loop/PRIORITIES.md
+++ b/.github/loop/PRIORITIES.md
@@ -7,9 +7,9 @@ issue. The **builder** works the top item whose issue is still open. So the
 planner decides *what*, the builder *builds* it.
 
 **Bias to capability, not busy-work.** The top of this queue is net-new capability
-from the roadmap's *Now/Next* bets. Hardening/conformance/DX polish is background
-work (roadmap *Ongoing*) — kept low here and capped, never allowed to crowd out the
-bets. If an area has had several increments with no user-visible gain, it is done
+from the roadmap's *Now/Next* items. Hardening/conformance/DX polish is background
+work (roadmap *Ongoing*) — kept low here and capped, never allowed to crowd out
+capability. If an area has had several increments with no user-visible gain, it is done
 for now; rank real-headroom capability instead.
 
 **Reading / editing.** An item is done when its linked issue closes (the PR that
@@ -24,15 +24,15 @@ rewrites.
 
 ### Capability — the headline (roadmap: Now / Next)
 
-1. **Agents that pay — wire the x402 buyer into the agent runtime** ([#4786](https://github.com/micro/go-micro/issues/4786)) — the flagship bet. The buyer `x402.Client`/`Payer`/budget already exists; wire it so an agent autonomously settles a payment-required tool within budget and retries, opt-in and observable. Makes go-micro a runtime for autonomous agent commerce.
+1. **Agents that pay — wire the x402 buyer into the agent runtime** ([#4786](https://github.com/micro/go-micro/issues/4786)) — the flagship. The buyer `x402.Client`/`Payer`/budget already exists; wire it so an agent autonomously settles a payment-required tool within budget and retries, opt-in and observable. Makes go-micro a runtime for autonomous agent commerce.
 2. **AP2 mandate foundation over A2A + x402** ([#3552](https://github.com/micro/go-micro/issues/3552)) — signed Checkout/Payment mandates attached over A2A, the Payment Mandate naming an x402 rail. The authorization/audit layer of the emerging agent-payments standard; additive and opt-in.
 3. **Agent spend observability** ([#4787](https://github.com/micro/go-micro/issues/4787)) — surface x402 spend in `RunInfo` and OpenTelemetry so payments are inspectable like every other agent action. (Follows #4786.)
-4. **Example: an agent that pays for a paid tool** ([#4788](https://github.com/micro/go-micro/issues/4788)) — the runnable artifact that makes the bet real for a developer, against a mock facilitator (no live funds). (Follows #4786/#4787.)
+4. **Example: an agent that pays for a paid tool** ([#4788](https://github.com/micro/go-micro/issues/4788)) — the runnable artifact that makes it real for a developer, against a mock facilitator (no live funds). (Follows #4786/#4787.)
 
 ### Background — hardening & DX (roadmap: Ongoing; capped)
 
-5. **Harden agent provider failure resilience** ([#4650](https://github.com/micro/go-micro/issues/4650)) — timeouts, cancellation, rate limits, retry/backoff, inspectable failure metadata through the agent loop. Real, but maintenance — keep it below the capability bets.
+5. **Harden agent provider failure resilience** ([#4650](https://github.com/micro/go-micro/issues/4650)) — timeouts, cancellation, rate limits, retry/backoff, inspectable failure metadata through the agent loop. Real, but maintenance — keep it below the capability work.
 
-_Restocked by Claude Code from the roadmap's capability bets; thereafter maintained
-by the planner. Next capability bets to decompose when the above land:
+_Restocked by Claude Code from the roadmap's capability items; thereafter maintained
+by the planner. Next capability to decompose when the above land:
 gRPC-reflection MCP, Kubernetes operator + CRDs (roadmap: Next)._

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ default.
 
 The forward work is **net-new capability**, not more hardening. Maintenance
 (conformance, resilience, DX polish) continues in the background (see *Ongoing*
-below) — but it is not the roadmap. These bets are.
+below) — but it is not the roadmap. This capability work is.
 
 ## Now — capability
 
@@ -79,7 +79,7 @@ Continuous but **capped** so it never crowds out capability: cross-provider
 conformance, failure/resilience (timeouts, cancellation, retry/backoff), the
 0→1 and 0→hero getting-started contract, streaming/observability coherence, and a
 seamless CLI inner loop (scaffold → run → chat → inspect → deploy). Real, but
-maintenance — the loop should spend the majority of its cycles on the bets above,
+maintenance — the loop should spend the majority of its cycles on the capability above,
 not here.
 
 ## How it's sustained


### PR DESCRIPTION
Language fix — you noted (again) that it's **development, not "bets."** I'd let the word back into `ROADMAP.md` and `.github/loop/PRIORITIES.md`; removed it. No change to what the loop builds — just wording.

Two pre-existing occurrences I did **not** touch, since they're canonical positioning copy and your call: `internal/docs/THESIS.md` ("The bet: whoever gives Go…") and `internal/docs/DEVELOPMENT_STRATEGY_ASSESSMENT.md` ("product bets"). Want me to clean those too?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_