### PR TITLE
agent: wire x402 payer into tool runtime

### DIFF
--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -5,6 +5,8 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	codecBytes "go-micro.dev/v6/codec/bytes"
 	"go-micro.dev/v6/gateway/a2a"
 	"go-micro.dev/v6/store"
+	"go-micro.dev/v6/wrapper/x402"
 )
 
 // Built-in agent tools. These are not service endpoints — they are
@@ -128,6 +131,7 @@ func (a *agentImpl) toolHandler() ai.ToolHandler {
 	// so the result runs plan → step → loop → approve → checkpoint → base.
 	h := a.baseHandler()
 	h = a.toolTimeoutWrap(h)
+	h = a.x402PayWrap(h)
 	h = a.toolRetryWrap(h)
 	h = a.checkpointToolWrap(h)
 	h = a.approveWrap(h)
@@ -171,6 +175,64 @@ func (a *agentImpl) toolTimeoutWrap(next ai.ToolHandler) ai.ToolHandler {
 		defer cancel()
 		return next(toolCtx, call)
 	}
+}
+
+// x402PayWrap pays an x402 Payment Required tool result and retries the
+// underlying HTTP tool once. Tools that proxy HTTP paid resources can return the
+// raw x402 402 challenge body and include a "url" input; the agent then uses
+// wrapper/x402.Client so payer and budget semantics stay in one place.
+func (a *agentImpl) x402PayWrap(next ai.ToolHandler) ai.ToolHandler {
+	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+		res := next(ctx, call)
+		if res.Refused != "" || !isX402Challenge(res.Content) {
+			return res
+		}
+		url, _ := call.Input["url"].(string)
+		if url == "" {
+			return errResult(call.ID, "x402: payment required but tool result did not include a retryable url input")
+		}
+		budget := a.opts.Budget
+		if budget > 0 {
+			remaining := budget - a.spend
+			if remaining <= 0 {
+				return refused(call.ID, ai.RefusedSpendBudget, fmt.Sprintf(
+					"x402 spend budget exceeded: no budget remaining for %s (spent %d of %d)",
+					call.Name, a.spend, budget))
+			}
+			budget = remaining
+		}
+		client := &x402.Client{Payer: a.opts.Payer, Budget: budget}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return errResult(call.ID, err.Error())
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			if strings.Contains(err.Error(), "would exceed budget") {
+				return refused(call.ID, ai.RefusedSpendBudget, err.Error())
+			}
+			return errResult(call.ID, err.Error())
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errResult(call.ID, err.Error())
+		}
+		a.spend += client.Spent()
+		var value any
+		if err := json.Unmarshal(body, &value); err != nil {
+			value = string(body)
+		}
+		return ai.ToolResult{ID: call.ID, Value: value, Content: string(body), Attempts: 2}
+	}
+}
+
+func isX402Challenge(content string) bool {
+	var ch struct {
+		X402Version int                 `json:"x402Version"`
+		Accepts     []x402.Requirements `json:"accepts"`
+	}
+	return json.Unmarshal([]byte(content), &ch) == nil && ch.X402Version > 0 && len(ch.Accepts) > 0
 }
 
 // toolRetryWrap retries transient tool failures with bounded backoff. It is

--- a/agent/guardrails_test.go
+++ b/agent/guardrails_test.go
@@ -2,12 +2,17 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/store"
+	"go-micro.dev/v6/wrapper/x402"
 )
 
 // toolContent runs a tool call through a handler and returns the content
@@ -179,5 +184,125 @@ func TestNestedTextToolCallArgumentsAreRefused(t *testing.T) {
 	}
 	if !strings.Contains(content, "nested text tool-call markup") {
 		t.Fatalf("content = %q, want nested tool-call refusal", content)
+	}
+}
+
+type agentMockPayer struct{ calls int }
+
+func (p *agentMockPayer) Pay(ctx context.Context, req x402.Requirements) (string, error) {
+	p.calls++
+	return "paid", nil
+}
+
+func TestAgentPayerPaysX402ToolResultAndRetries(t *testing.T) {
+	paid := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(x402.PaymentHeader) == "paid" {
+			paid = true
+			_, _ = w.Write([]byte(`{"ok":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusPaymentRequired)
+		json.NewEncoder(w).Encode(map[string]any{
+			"x402Version": x402.Version,
+			"accepts":     []x402.Requirements{{Scheme: "exact", Network: "base", MaxAmountRequired: "7", Resource: r.URL.String(), PayTo: "0xmerchant"}},
+		})
+	}))
+	defer srv.Close()
+
+	payer := &agentMockPayer{}
+	a := newTestAgent(Name("x402-payer"), Payer(payer), Budget(10), WithTool("paid.http", "paid http", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+		if err != nil {
+			return "", err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return string(body), nil
+	}))
+
+	res := a.toolHandler()(context.Background(), ai.ToolCall{ID: "pay-1", Name: "paid.http", Input: map[string]any{"url": srv.URL}})
+	if !paid || payer.calls != 1 {
+		t.Fatalf("payment not made: paid=%v payer.calls=%d", paid, payer.calls)
+	}
+	if res.Content != `{"ok":true}` || res.Attempts != 2 {
+		t.Fatalf("result = %+v, want paid response with retry attempt", res)
+	}
+}
+
+func TestAgentPayerRefusesX402OverBudget(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPaymentRequired)
+		json.NewEncoder(w).Encode(map[string]any{
+			"x402Version": x402.Version,
+			"accepts":     []x402.Requirements{{Scheme: "exact", Network: "base", MaxAmountRequired: "70", Resource: r.URL.String(), PayTo: "0xmerchant"}},
+		})
+	}))
+	defer srv.Close()
+
+	payer := &agentMockPayer{}
+	a := newTestAgent(Name("x402-over-budget"), Payer(payer), Budget(10), WithTool("paid.http", "paid http", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+		if err != nil {
+			return "", err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return string(body), nil
+	}))
+
+	res := a.toolHandler()(context.Background(), ai.ToolCall{ID: "pay-1", Name: "paid.http", Input: map[string]any{"url": srv.URL}})
+	if payer.calls != 0 {
+		t.Fatalf("payer called despite over-budget refusal")
+	}
+	if res.Refused != ai.RefusedSpendBudget || !strings.Contains(res.Content, "would exceed budget") {
+		t.Fatalf("result = %+v, want budget refusal", res)
+	}
+}
+
+func TestAgentPayerRequiredWithoutPayerReturnsClearError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPaymentRequired)
+		json.NewEncoder(w).Encode(map[string]any{
+			"x402Version": x402.Version,
+			"accepts":     []x402.Requirements{{Scheme: "exact", Network: "base", MaxAmountRequired: "7", Resource: r.URL.String(), PayTo: "0xmerchant"}},
+		})
+	}))
+	defer srv.Close()
+
+	a := newTestAgent(Name("x402-no-payer"), Budget(10), WithTool("paid.http", "paid http", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+		if err != nil {
+			return "", err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return string(body), nil
+	}))
+
+	res := a.toolHandler()(context.Background(), ai.ToolCall{ID: "pay-1", Name: "paid.http", Input: map[string]any{"url": srv.URL}})
+	if !strings.Contains(res.Content, "no Payer configured") {
+		t.Fatalf("content = %q, want no payer error", res.Content)
 	}
 }

--- a/agent/options.go
+++ b/agent/options.go
@@ -10,6 +10,7 @@ import (
 	"go-micro.dev/v6/flow"
 	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/store"
+	"go-micro.dev/v6/wrapper/x402"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -105,6 +106,10 @@ type Options struct {
 	// unit (0 = disabled). ToolSpend lists known paid tools and their prices.
 	MaxSpend  int64
 	ToolSpend map[string]int64
+	// Payer lets the agent settle x402 Payment Required challenges from tools.
+	// Budget bounds autonomous x402 payments per Ask (0 = unlimited).
+	Payer  x402.Payer
+	Budget int64
 
 	// A2AAddress, if set, makes Run serve this agent over the A2A protocol
 	// on that address directly (no separate gateway), e.g. ":4000".
@@ -248,6 +253,18 @@ func ToolSpend(tool string, amount int64) Option {
 		}
 		o.ToolSpend[tool] = amount
 	}
+}
+
+// Payer configures the wallet/signing hook used to settle x402-paid tools.
+// Without a payer, payment-required tool results are returned as clear errors.
+func Payer(p x402.Payer) Option {
+	return func(o *Options) { o.Payer = p }
+}
+
+// Budget bounds autonomous x402 payments per Ask, in the asset's smallest
+// unit (0 = unlimited). The budget is enforced by wrapper/x402.Client.
+func Budget(amount int64) Option {
+	return func(o *Options) { o.Budget = amount }
 }
 
 // LoopLimit sets how many times the agent may repeat the same tool call

--- a/micro.go
+++ b/micro.go
@@ -12,6 +12,7 @@ import (
 	"go-micro.dev/v6/server"
 	"go-micro.dev/v6/service"
 	"go-micro.dev/v6/store"
+	"go-micro.dev/v6/wrapper/x402"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -129,6 +130,13 @@ func AgentMaxSpend(amount int64) AgentOption { return agent.MaxSpend(amount) }
 func AgentToolSpend(tool string, amount int64) AgentOption {
 	return agent.ToolSpend(tool, amount)
 }
+
+// AgentPayer configures the wallet/signing hook used to settle x402-paid tools.
+func AgentPayer(p x402.Payer) AgentOption { return agent.Payer(p) }
+
+// AgentBudget bounds autonomous x402 payments per Ask, in the asset's smallest
+// unit (0 = unlimited).
+func AgentBudget(amount int64) AgentOption { return agent.Budget(amount) }
 
 // AgentModelCallTimeout sets the timeout for each provider Generate call.
 func AgentModelCallTimeout(d time.Duration) AgentOption { return agent.ModelCallTimeout(d) }


### PR DESCRIPTION
## Summary
- Add opt-in agent x402 payer and budget options for autonomous paid tool settlement.
- Add an agent tool wrapper that detects x402 payment-required tool results, pays through wrapper/x402.Client within budget, and retries once.
- Cover success, over-budget refusal, and missing-payer errors with httptest paid-tool coverage.

Closes #4786
Closes #4801

## Testing
- go build ./...
- go test ./agent/... ./wrapper/x402/...
- env -u ATLASCLOUD_API_KEY go test ./... (environment warning: grpc loopback tests blocked by sandbox envoy)
- golangci-lint run ./... (environment warning: installed binary targets Go 1.24 while module targets Go 1.25.12)