### PR TITLE
Observe agent x402 spend

### DIFF
--- a/agent/builtin.go
+++ b/agent/builtin.go
@@ -451,6 +451,11 @@ func (a *agentImpl) spendWrap(next ai.ToolHandler) ai.ToolHandler {
 				amount, call.Name, a.spend, a.opts.MaxSpend))
 		}
 		a.spend += amount
+		if info, ok := ai.RunInfoFrom(ctx); ok {
+			info.Spent = a.spend
+			info.ToolSpend = amount
+			ctx = ai.WithRunInfo(ctx, info)
+		}
 		res := next(ctx, call)
 		if res.Refused != "" || toolErrorMessage(res) != "" {
 			a.spend -= amount

--- a/agent/guardrails_test.go
+++ b/agent/guardrails_test.go
@@ -211,7 +211,8 @@ func TestAgentPayerPaysX402ToolResultAndRetries(t *testing.T) {
 	defer srv.Close()
 
 	payer := &agentMockPayer{}
-	a := newTestAgent(Name("x402-payer"), Payer(payer), Budget(10), WithTool("paid.http", "paid http", nil, func(ctx context.Context, input map[string]any) (string, error) {
+	st := store.NewMemoryStore()
+	a := newTestAgent(Name("x402-payer"), WithStore(st), Payer(payer), Budget(10), WithTool("paid.http", "paid http", nil, func(ctx context.Context, input map[string]any) (string, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
 		if err != nil {
 			return "", err
@@ -228,12 +229,20 @@ func TestAgentPayerPaysX402ToolResultAndRetries(t *testing.T) {
 		return string(body), nil
 	}))
 
-	res := a.toolHandler()(context.Background(), ai.ToolCall{ID: "pay-1", Name: "paid.http", Input: map[string]any{"url": srv.URL}})
+	ctx := ai.WithRunInfo(context.Background(), ai.RunInfo{RunID: "run-paid", Agent: "x402-payer"})
+	res := a.toolHandler()(ctx, ai.ToolCall{ID: "pay-1", Name: "paid.http", Input: map[string]any{"url": srv.URL}})
 	if !paid || payer.calls != 1 {
 		t.Fatalf("payment not made: paid=%v payer.calls=%d", paid, payer.calls)
 	}
 	if res.Content != `{"ok":true}` || res.Attempts != 2 {
 		t.Fatalf("result = %+v, want paid response with retry attempt", res)
+	}
+	events, err := LoadRunEvents(st, "x402-payer", "run-paid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Spent != 7 || events[0].ToolSpend != 7 {
+		t.Fatalf("spend events = %#v, want one tool event with spent/tool_spend 7", events)
 	}
 }
 

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -51,6 +51,8 @@ const (
 	AttrDispatch         = "agent.dispatch"
 	AttrTrigger          = "agent.trigger"
 	AttrRunEventKind     = "agent.event.kind"
+	AttrSpend            = "agent.spend"
+	AttrToolSpend        = "agent.tool.spend"
 )
 
 type RunEvent struct {
@@ -73,6 +75,8 @@ type RunEvent struct {
 	Error       string    `json:"error,omitempty"`
 	ErrorKind   string    `json:"error_kind,omitempty"`
 	InputChars  int       `json:"input_chars,omitempty"`
+	Spent       int64     `json:"spent,omitempty"`
+	ToolSpend   int64     `json:"tool_spend,omitempty"`
 }
 
 type Usage = ai.Usage
@@ -111,6 +115,7 @@ type RunSummary struct {
 	LastKind      string    `json:"last_kind,omitempty"`
 	LastError     string    `json:"last_error,omitempty"`
 	LastErrorKind string    `json:"last_error_kind,omitempty"`
+	Spent         int64     `json:"spent,omitempty"`
 }
 
 func (a *agentImpl) tracer() trace.Tracer {
@@ -362,6 +367,7 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 	return func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
 		info, _ := ai.RunInfoFrom(ctx)
 		start := time.Now()
+		spentBefore := a.spend
 
 		if a.opts.TraceProvider == nil {
 			res := next(ctx, call)
@@ -371,7 +377,7 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 			if toolAttempts <= 0 {
 				toolAttempts = 1
 			}
-			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, Attempt: toolAttempts, MaxAttempts: a.opts.ToolMaxAttempts, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr)})
+			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, Attempt: toolAttempts, MaxAttempts: a.opts.ToolMaxAttempts, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr), Spent: a.spend, ToolSpend: a.spend - spentBefore})
 			return res
 		}
 
@@ -385,6 +391,7 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 		ctx, span := a.tracer().Start(ctx, spanNameToolCall, trace.WithAttributes(spanAttrs...))
 		res := next(ctx, call)
 		dur := time.Since(start).Milliseconds()
+		toolSpend := a.spend - spentBefore
 		attrs := []attribute.KeyValue{attribute.Int64(AttrLatencyMS, dur)}
 		toolAttempts := res.Attempts
 		if toolAttempts <= 0 {
@@ -393,6 +400,9 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 		attrs = append(attrs, attribute.Int(AttrToolAttempt, toolAttempts))
 		if a.opts.ToolMaxAttempts > 0 {
 			attrs = append(attrs, attribute.Int(AttrToolMaxAttempts, a.opts.ToolMaxAttempts))
+		}
+		if toolSpend > 0 {
+			attrs = append(attrs, attribute.Int64(AttrSpend, a.spend), attribute.Int64(AttrToolSpend, toolSpend))
 		}
 		if res.Refused != "" {
 			attrs = append(attrs, attribute.Bool(AttrGuardrailBlock, true), attribute.String(AttrRefusal, res.Refused))
@@ -409,7 +419,7 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 		} else {
 			span.SetStatus(codes.Ok, "")
 		}
-		a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, Attempt: toolAttempts, MaxAttempts: a.opts.ToolMaxAttempts, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr)})
+		a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, Attempt: toolAttempts, MaxAttempts: a.opts.ToolMaxAttempts, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr), Spent: a.spend, ToolSpend: toolSpend})
 		span.End()
 		return res
 	}
@@ -496,6 +506,12 @@ func runEventAttributes(e RunEvent) []attribute.KeyValue {
 	if e.InputChars > 0 {
 		attrs = append(attrs, attribute.Int(AttrInputChars, e.InputChars))
 	}
+	if e.Spent > 0 {
+		attrs = append(attrs, attribute.Int64(AttrSpend, e.Spent))
+	}
+	if e.ToolSpend > 0 {
+		attrs = append(attrs, attribute.Int64(AttrToolSpend, e.ToolSpend))
+	}
 	attrs = appendUsage(attrs, e.Tokens)
 	if e.Refused != "" {
 		attrs = append(attrs, attribute.Bool(AttrGuardrailBlock, true), attribute.String(AttrRefusal, e.Refused))
@@ -529,6 +545,12 @@ func appendRunInfoAttributes(attrs []attribute.KeyValue, info ai.RunInfo) []attr
 	}
 	if info.Trigger != "" {
 		attrs = append(attrs, attribute.String(AttrTrigger, info.Trigger))
+	}
+	if info.Spent > 0 {
+		attrs = append(attrs, attribute.Int64(AttrSpend, info.Spent))
+	}
+	if info.ToolSpend > 0 {
+		attrs = append(attrs, attribute.Int64(AttrToolSpend, info.ToolSpend))
 	}
 	return attrs
 }
@@ -615,6 +637,9 @@ func ListRunSummariesWithOptions(s store.Store, agentName string, opts RunListOp
 			}
 			if e.ErrorKind != "" {
 				summary.LastErrorKind = e.ErrorKind
+			}
+			if e.Spent > summary.Spent {
+				summary.Spent = e.Spent
 			}
 		}
 		if opts.Status != "" && summary.Status != opts.Status {

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -421,6 +421,63 @@ func spanAttributes(attrs []attribute.KeyValue) map[string]string {
 	return out
 }
 
+func TestAgentOpenTelemetryToolSpanIncludesSpend(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exp))
+	st := store.NewMemoryStore()
+	a := New(Name("spender"), Provider("oteltest"), Model("unit-model"), WithStore(st), TraceProvider(tp), MaxSpend(10), ToolSpend("probe", 7), WithTool("probe", "probe", nil, func(ctx context.Context, input map[string]any) (string, error) {
+		info, ok := ai.RunInfoFrom(ctx)
+		if !ok {
+			t.Fatal("RunInfo missing from paid tool context")
+		}
+		if info.Spent != 7 || info.ToolSpend != 7 {
+			t.Fatalf("RunInfo spend = (%d, %d), want (7, 7)", info.Spent, info.ToolSpend)
+		}
+		return "ok", nil
+	}))
+	if _, err := a.Ask(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+
+	var sawToolSpan bool
+	for _, s := range exp.GetSpans().Snapshots() {
+		if s.Name() != spanNameToolCall {
+			continue
+		}
+		sawToolSpan = true
+		attrs := spanAttributes(s.Attributes())
+		if attrs[AttrSpend] != "7" || attrs[AttrToolSpend] != "7" {
+			t.Fatalf("tool span missing spend attributes: %#v", attrs)
+		}
+		if !spanEventHasAttribute(s.Events(), "agent.tool", AttrToolSpend, "7") {
+			t.Fatalf("tool event missing spend attribute: %#v", s.Events())
+		}
+	}
+	if !sawToolSpan {
+		t.Fatal("tool span not emitted")
+	}
+	summaries, err := ListRunSummaries(st, "spender")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summaries) != 1 || summaries[0].Spent != 7 {
+		t.Fatalf("summary spend = %#v, want 7", summaries)
+	}
+}
+
+func spanEventHasAttribute(events []trace.Event, name, key, value string) bool {
+	for _, e := range events {
+		if e.Name != name {
+			continue
+		}
+		attrs := spanAttributes(e.Attributes)
+		if attrs[key] == value {
+			return true
+		}
+	}
+	return false
+}
+
 func TestAgentOpenTelemetrySpansDelegateLineage(t *testing.T) {
 	exp := tracetest.NewInMemoryExporter()
 	tp := trace.NewTracerProvider(trace.WithSyncer(exp))

--- a/ai/model.go
+++ b/ai/model.go
@@ -135,6 +135,8 @@ type RunInfo struct {
 	VerificationFeedback string // feedback from the previous failed verifier attempt, when retrying a flow step
 	Dispatch             string // how the run was dispatched (direct, broker, schedule, resume) when known
 	Trigger              string // external trigger or schedule label that started the run, when known
+	Spent                int64  // cumulative paid x402 spend in this run, in the asset's smallest unit
+	ToolSpend            int64  // paid x402 spend attributed to the current tool call, in the asset's smallest unit
 }
 
 type runInfoKey struct{}

--- a/cmd/micro/inspect/inspect.go
+++ b/cmd/micro/inspect/inspect.go
@@ -94,6 +94,9 @@ func writeAgentInspection(w io.Writer, name string, runs []goagent.RunSummary, a
 		if run.LastErrorKind != "" {
 			fmt.Fprintf(w, "  error_kind=%s", run.LastErrorKind)
 		}
+		if run.Spent > 0 {
+			fmt.Fprintf(w, "  spent=%d", run.Spent)
+		}
 		if run.LastError != "" {
 			fmt.Fprintf(w, "  error=%q", run.LastError)
 		}

--- a/cmd/micro/inspect/inspect_test.go
+++ b/cmd/micro/inspect/inspect_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 func TestWriteAgentInspectionIncludesActionableBreadcrumbs(t *testing.T) {
-	runs := []goagent.RunSummary{{RunID: "run-1", Status: "auth", Events: 4, LastKind: "model", LastError: "invalid API key", LastErrorKind: "auth", TraceID: "1234567890abcdef", Checkpoint: "failed", Stage: "ask"}}
+	runs := []goagent.RunSummary{{RunID: "run-1", Status: "auth", Events: 4, LastKind: "model", LastError: "invalid API key", LastErrorKind: "auth", TraceID: "1234567890abcdef", Checkpoint: "failed", Stage: "ask", Spent: 7}}
 	var out bytes.Buffer
 	if err := writeAgentInspection(&out, "support", runs, false); err != nil {
 		t.Fatal(err)
 	}
 	got := out.String()
-	for _, want := range []string{"Agent \"support\" runs", "run-1", "status=auth", "events=4", "last=model", "checkpoint=failed", "stage=ask", "error_kind=auth", `error="invalid API key"`, "trace=1234567890ab"} {
+	for _, want := range []string{"Agent \"support\" runs", "run-1", "status=auth", "events=4", "last=model", "checkpoint=failed", "stage=ask", "error_kind=auth", `error="invalid API key"`, "trace=1234567890ab", "spent=7"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q:\n%s", want, got)
 		}


### PR DESCRIPTION
## Summary
- Add cumulative and per-tool x402 spend fields to RunInfo, persisted run events, and run summaries.
- Add agent spend attributes to tool spans and span events.
- Show cumulative run spend in `micro inspect agent` output.

Closes #4787
Closes #4805

## Testing
- go build ./...
- go test ./agent ./cmd/micro/inspect
- go test ./... (fails in this sandbox due existing loopback/provider environment limits: ai atlascloud stream 400; client/grpc and transport/grpc loopback targets forbidden)
- golangci-lint run ./... (fails because installed golangci-lint was built with Go 1.24 while module targets Go 1.25.12)