### PR TITLE
docs: integration/exposure gap audit; repoint the loop queue to well-defined work

### DIFF
--- a/.github/loop/PRIORITIES.md
+++ b/.github/loop/PRIORITIES.md
@@ -1,36 +1,47 @@
 # Priorities
 
-The ranked work queue for the autonomous improvement loop. The **planner** owns
-this file: each run it turns the [roadmap](../../ROADMAP.md) plus an internal scan
-into a single ordered list — highest-value first — each item linked to a tracking
-issue. The **builder** works the top item whose issue is still open. So the
-planner decides *what*, the builder *builds* it.
+The ranked work queue for the autonomous improvement loop. The **planner** ranks
+it; the **builder** works the top item whose linked issue is still open. Direction
+comes from the human (the [roadmap](../../ROADMAP.md) and the
+[gap audit](../../internal/docs/GAP_AUDIT.md)) — the planner does NOT invent work,
+it ranks the curated backlog. The builder executes well-defined issues; it does
+not improvise.
 
-**Bias to capability, not busy-work.** The top of this queue is net-new capability
-from the roadmap's *Now/Next* items. Hardening/conformance/DX polish is background
-work (roadmap *Ongoing*) — kept low here and capped, never allowed to crowd out
-capability. If an area has had several increments with no user-visible gain, it is done
-for now; rank real-headroom capability instead.
+**Advances the strategy vs. grooms a proxy.** Rank by whether an item advances
+the actual strategy — real integration/exposure, real capability — not by whether
+it produces a green increment. Making MCP speak MCP to an external client, A2A
+interoperate with a real external agent, and x402 actually settle is real work.
+Guarding docs the loop wrote or chasing a weak provider's quirks is grooming —
+`needs-human` it.
 
-**Reading / editing.** An item is done when its linked issue closes (the PR that
-builds it adds `Closes #<issue>`). The human can reorder this list or the issues at
-any time — direction always wins.
+**Reading / editing.** An item is done when its linked issue closes (the PR adds
+`Closes #<issue>`). The human reorders this list or the issues at any time.
 
-**Off-limits to the loop** (planner proposes as notes, never auto-merged queue
-items): brand/positioning copy, breaking public-API changes, architectural
-rewrites.
+**Off-limits to the loop** (never auto-merged): brand/positioning copy, breaking
+public-API changes, architectural rewrites. Items labelled `needs-human` below are
+1:1 development work — the loop must not auto-build them.
 
 ## Work queue (ranked)
 
-### Capability — the headline (roadmap: Now / Next)
+### Strategic spine — make integration/exposure actually robust (gap audit)
 
-1. **Example: an agent that pays for a paid tool** ([#4788](https://github.com/micro/go-micro/issues/4788)) — the runnable artifact that makes it real for a developer, against a mock facilitator (no live funds). (Follows #4786/#4787.)
-2. **gRPC-reflection MCP** ([#4796](https://github.com/micro/go-micro/issues/4796)) — expose external reflected gRPC services as MCP tools, not only go-micro-native handlers. A large jump in what agents can operate without requiring teams to rewrite existing services.
-3. **Kubernetes operator + CRDs foundation** ([#4797](https://github.com/micro/go-micro/issues/4797)) — add the first opt-in `Agent`, `Service`, and `Flow` resource foundation so the services → agents → workflows lifecycle has a native deployment path for Kubernetes users.
+These are the surfaces the strategy rests on, and they're the least externally-proven
+part of the codebase. Highest value.
 
-### Background — hardening & DX (roadmap: Ongoing; capped)
+1. **MCP: stdio/ws tool results must be JSON + `isError`, with a stdio test** ([#4813](https://github.com/micro/go-micro/issues/4813)) — the path Claude Desktop uses currently returns Go `%v` map-syntax instead of JSON and misreports tool errors. Cheapest, highest-impact fix.
+2. **x402: fix the budget-cap bypass + require a real Settler** ([#4814](https://github.com/micro/go-micro/issues/4814)) — a malformed amount defeats the spend cap; verify-only serves the resource for free. Hardens the safety the flagship relies on.
+3. **A2A: conform to external clients — well-known path + spec SSE events** ([#4815](https://github.com/micro/go-micro/issues/4815)) — an external A2A SDK 404s on discovery and can't parse the stream. Real cross-framework interop.
+4. **Agents that pay — wire the x402 buyer into the agent runtime** ([#4786](https://github.com/micro/go-micro/issues/4786)) — the flagship capability; the buyer `Client` exists but is wired into nothing (the agent's "spend budget" is bookkeeping that never pays).
 
-_Background hardening is intentionally empty right now. Recent work covered first-agent
-wayfinding, plan/delegate recovery, provider fallback repair, streaming, memory
-compaction, retry controls, and provider-failure inspection. Further churn in those
-areas should be marked `needs-human` unless it unlocks a clear user-visible capability._
+### Capability — reach & deployment (roadmap: Next; builds on the spine)
+
+5. **gRPC-reflection MCP** ([#4796](https://github.com/micro/go-micro/issues/4796)) — expose external reflected gRPC services as MCP tools.
+6. **Kubernetes operator + CRDs foundation** ([#4797](https://github.com/micro/go-micro/issues/4797)) — `Agent`/`Service`/`Flow` as native K8s resources.
+
+### Human-led — real 1:1 development (needs-human; the loop must NOT auto-build these)
+
+- **MCP transport unification** ([gap audit](../../internal/docs/GAP_AUDIT.md) item 2) — mount the JSON-RPC handler as the HTTP transport and run all transports through one pre-call pipeline (auth→rate→breaker→payment). Architectural.
+- **Durable agentic workflow: HITL pause + per-tool-call checkpointing** ([#4816](https://github.com/micro/go-micro/issues/4816)) — the convergence leg; core primitive design.
+- **In-process dispatch fast-path** ([#4817](https://github.com/micro/go-micro/issues/4817)) — a local transport so in-process calls skip codec + network hop.
+
+_Evidence base: [`internal/docs/GAP_AUDIT.md`](../../internal/docs/GAP_AUDIT.md) (this session's code audit) + the "requirements discovered from Mu" notes. Restocked by Claude Code; the planner ranks, it does not invent._

--- a/internal/docs/GAP_AUDIT.md
+++ b/internal/docs/GAP_AUDIT.md
@@ -1,0 +1,68 @@
+# Gap Audit — the integration/exposure surface (MCP, A2A, x402) + foundations
+
+A code-grounded robustness audit of the surfaces the strategy rests on, plus the
+two foundations a real app (Mu) discovered it needed. Pair this with the
+"requirements discovered from Mu" notes — together they are the roadmap's
+evidence base. Each finding is `file:line`, severity, and what "robust in
+practice" requires.
+
+## Headline
+
+All four surfaces are **well-built internally and fragile at the edge.** The
+strategic spine — **MCP gateway, A2A, x402** — is *demo-robust, not
+production-robust*: it works go-micro-to-go-micro and is **unverified or broken
+against the real external clients the whole "integration and exposure" strategy
+depends on.** Not one test drives a real external MCP host, a real third-party
+A2A SDK, or a real x402 facilitator/wallet.
+
+There are two kinds of hardening, and the loop was doing the wrong one: guarding
+docs and chasing a weak provider's quirks is grooming; making MCP actually speak
+MCP to Claude Desktop, A2A interoperate with a real external agent, and x402
+actually settle is **strategic** hardening. The axis is *advances the strategy*
+vs *grooms a proxy*, not *capability* vs *hardening*.
+
+## MCP gateway — `gateway/mcp/`
+Works as go-micro plumbing; does not speak MCP to the outside world.
+
+- **BLOCKER** `mcp.go:610` — default HTTP transport is bespoke `{tool,input}` REST, not JSON-RPC/MCP. A conformant JSON-RPC handler exists (`httpjsonrpc.go` `NewHandler`) but is **never mounted**. → mount it / implement Streamable HTTP; unify transports behind one pre-call pipeline.
+- **BLOCKER** `stdio.go:323`, `websocket.go:302` — tool results are `fmt.Sprintf("%v", result)` → Go map-syntax, not JSON, on the path Claude Desktop uses. **Zero stdio tests.** → marshal JSON; add a stdio round-trip test.
+- **BLOCKER** `stdio.go:297`, `websocket.go:278` — downstream errors returned as JSON-RPC protocol errors, not `{isError:true}` results. → wrap as tool-error results.
+- **BLOCKER** `websocket.go:20` — `CheckOrigin` always `true` (DNS-rebinding); and `/mcp/ws` **bypasses payment + circuit breaker** → paid tools free over WS. → origin allowlist; one shared pre-call pipeline.
+- **MAJOR** deregistered tools never pruned (`mcp.go:280`); watcher never recovers + no `list_changed` (`mcp.go:564`); unbounded goroutines, no `recover()` (`stdio.go:112`); no HTTP/WS timeouts or body limits; unauthenticated `micro_store_write`/`micro_broker_publish` by default (`mcp.go:474`).
+
+## A2A gateway — `gateway/a2a/`
+Clean binding; cross-framework interop unproven.
+
+- **MAJOR** `a2a.go:111` — well-known path is `agent.json`; spec 0.3.0 serves `agent-card.json` → external clients 404. → serve both.
+- **MAJOR** `a2a.go:587` — `message/stream` emits full `Task` snapshots, not `TaskStatusUpdateEvent`/`TaskArtifactUpdateEvent` with `final:true`; `:596` sets JSON-RPC `result`+`error` together (spec violation). → emit discriminated update events.
+- **MAJOR** `a2a.go:584` — streaming ignores write errors / client disconnect (burns tokens on a dead socket); `:531` "streaming" is single-shot despite `streaming:true`; `:508` `tasks/cancel` is a stub; `:874` push callbacks SSRF-open + auth ignored; **no gateway auth / no security schemes** (`:342`); in-memory state breaks multi-replica (`:466`).
+- **Critical:** no test against a real third-party A2A SDK — all interop claims self-certified.
+
+## x402 — `wrapper/x402/`
+Clean, spec-aware scaffold; no real money can move.
+
+- **BLOCKER** — no real wallet `Payer` (no EIP-3009 signer); buyer `Client` wired into nothing — the agent's "spend budget" (`agent/builtin.go:380` `spendWrap`) is bookkeeping that never pays; CDP mainnet settlement unreachable from the CLI (creds never attached). This is the flagship (#4786).
+- **MAJOR** `client.go:84` — `ParseInt` error swallowed → malformed amount parses to `0`, spend-cap check trivially passes while the Payer signs the string amount. **Fix as part of #4786.**
+- **MAJOR** `x402.go:225` — verify-only facilitator serves the resource for free; `:198` no replay/idempotency; `:262` non-conformant settlement header; `client.go:83` no network/asset validation before signing.
+
+## Foundations (Mu-discovered)
+
+### In-process dispatch — `client/`, `transport/`
+- **MAJOR** `client/rpc_client.go:148` — no in-process fast-path: an in-process `Call` still dials a transport and simulates a network hop; `transport/memory.go:82` double-serializes (gob over a pipe on top of the RPC codec) with ~4–5 goroutine handoffs. ~64µs/187 allocs confirmed. → a local transport / direct `router.ServeRequest` dispatch (the server already keeps a process-local handler table; the codec already passes `*Frame` bodies through unserialized). **Moderate, low-risk; plausibly low-single-digit µs.**
+
+### Durable agentic workflow — `flow/`
+`flow/` is genuinely close on the *deterministic* axis (checkpoints, resumes without replaying completed steps, `ParentID`, retry). The gap is the *agentic* axis:
+- **BLOCKER** `flow/steps.go:107` — no human-in-the-loop pause (no `waiting` state / `Resume(runID, input)`). Exactly what Mu hand-rolled. → add a `waiting` status + await-input signal + resume-with-input.
+- **MAJOR** `flow/steps.go:269` — the agent's dynamic plan→tool→tool loop is one opaque flow step; a crash mid-turn replays every tool call. The durable unit is a fixed step list, not the agent's pausable per-tool-call loop — the convergence thesis is unmet. → checkpoint per tool call.
+- **MAJOR** `flow/loop.go:82` `Loop` not per-iteration checkpointed; `flow/steps.go:457` at-least-once, not exactly-once (duplicate side effects on resume); `:158` no run leasing for multi-replica.
+
+## Build order (prioritized)
+
+1. **MCP stdio: real JSON + `isError` results + a round-trip test.** Cheapest, highest-impact — the Claude Desktop path, currently emitting garbage. *(loop-buildable)*
+2. **MCP: mount JSON-RPC as the HTTP transport + unify all transports behind one pre-call pipeline.** *(architectural — human-reviewed)*
+3. **x402 flagship (#4786) done right:** signing `Payer`, buyer wired into the agent seam, budget-bypass fix, require a real `Settler`. *(mixed — the wiring is human-reviewed; the budget-bypass fix is loop-buildable)*
+4. **Durable agentic workflow:** HITL pause + per-tool-call checkpointing in `flow`. *(architectural — human-reviewed)*
+5. **In-process dispatch fast-path** (local transport). *(foundational, low-risk)*
+6. **A2A external conformance:** well-known path + SSE event shapes, then a test against a real third-party A2A SDK. *(loop-buildable + a test-setup task)*
+
+The architectural items (2, 4, 5) are the "real 1:1 development" work — too central and too ambiguous to hand to an autonomous agent. The well-scoped items (1, 3-budget-fix, 6) are what a forced, well-defined loop task looks like.

--- a/internal/docs/GAP_AUDIT.md
+++ b/internal/docs/GAP_AUDIT.md
@@ -25,7 +25,7 @@ vs *grooms a proxy*, not *capability* vs *hardening*.
 Works as go-micro plumbing; does not speak MCP to the outside world.
 
 - **BLOCKER** `mcp.go:610` — default HTTP transport is bespoke `{tool,input}` REST, not JSON-RPC/MCP. A conformant JSON-RPC handler exists (`httpjsonrpc.go` `NewHandler`) but is **never mounted**. → mount it / implement Streamable HTTP; unify transports behind one pre-call pipeline.
-- **BLOCKER** `stdio.go:323`, `websocket.go:302` — tool results are `fmt.Sprintf("%v", result)` → Go map-syntax, not JSON, on the path Claude Desktop uses. **Zero stdio tests.** → marshal JSON; add a stdio round-trip test.
+- **BLOCKER** `stdio.go:327`, `websocket.go:306` — tool results are `fmt.Sprintf("%v", result)` → Go map-syntax, not JSON, on the path Claude Desktop uses. **Zero stdio tests.** → marshal JSON; add a stdio round-trip test.
 - **BLOCKER** `stdio.go:297`, `websocket.go:278` — downstream errors returned as JSON-RPC protocol errors, not `{isError:true}` results. → wrap as tool-error results.
 - **BLOCKER** `websocket.go:20` — `CheckOrigin` always `true` (DNS-rebinding); and `/mcp/ws` **bypasses payment + circuit breaker** → paid tools free over WS. → origin allowlist; one shared pre-call pipeline.
 - **MAJOR** deregistered tools never pruned (`mcp.go:280`); watcher never recovers + no `list_changed` (`mcp.go:564`); unbounded goroutines, no `recover()` (`stdio.go:112`); no HTTP/WS timeouts or body limits; unauthenticated `micro_store_write`/`micro_broker_publish` by default (`mcp.go:474`).

--- a/internal/docs/GAP_AUDIT.md
+++ b/internal/docs/GAP_AUDIT.md
@@ -48,7 +48,7 @@ Clean, spec-aware scaffold; no real money can move.
 ## Foundations (Mu-discovered)
 
 ### In-process dispatch — `client/`, `transport/`
-- **MAJOR** `client/rpc_client.go:148` — no in-process fast-path: an in-process `Call` still dials a transport and simulates a network hop; `transport/memory.go:82` double-serializes (gob over a pipe on top of the RPC codec) with ~4–5 goroutine handoffs. ~64µs/187 allocs confirmed. → a local transport / direct `router.ServeRequest` dispatch (the server already keeps a process-local handler table; the codec already passes `*Frame` bodies through unserialized). **Moderate, low-risk; plausibly low-single-digit µs.**
+- **MAJOR** `client/rpc_client.go:148` — no in-process fast-path: an in-process `Call` still dials a transport and simulates a network hop; `transport/memory.go:82` double-serializes (gob over a pipe on top of the RPC codec) with ~4–5 goroutine handoffs. ~64µs/187 allocs confirmed. → a local transport / direct `router.ServeRequest` dispatch (the server already keeps a process-local handler table; the codec already passes `*Frame` bodies through unserialized). **Low-risk; plausibly low-single-digit µs.**
 
 ### Durable agentic workflow — `flow/`
 `flow/` is genuinely close on the *deterministic* axis (checkpoints, resumes without replaying completed steps, `ParentID`, retry). The gap is the *agentic* axis:


### PR DESCRIPTION
The gap audit you asked for, turned into a well-defined backlog.

## What's here
- **`internal/docs/GAP_AUDIT.md`** — a code-grounded audit of the strategic spine (MCP gateway, A2A, x402) + the two Mu-discovered foundations (in-process dispatch, durable agentic workflow). Every finding is `file:line` + severity + what "robust in practice" requires, with a prioritized build order.
- **`.github/loop/PRIORITIES.md`** — repointed so the loop pulls the **well-defined** spine fixes first, and the architectural items are marked `needs-human` (1:1 development, not for the loop).

## The headline
All four surfaces are **well-built internally and fragile at the edge.** The exposure surface the whole strategy rests on is the *least externally-proven part of the codebase* — no test drives a real external MCP host, a real third-party A2A SDK, or a real x402 facilitator/wallet. Concretely: the stdio path Claude Desktop uses returns Go `%v` map-syntax instead of JSON; an external A2A client 404s on discovery; the x402 buyer is wired into nothing and the spend cap is bypassable.

## Filed as well-defined issues (the "force it with well-defined tasks" backlog)
Loop-buildable (tight scope + acceptance): #4813 (MCP stdio JSON+isError+test), #4814 (x402 budget-bypass), #4815 (A2A conformance).
Human-led / `needs-human` (real 1:1 development): #4816 (durable agentic workflow), #4817 (in-process dispatch fast-path), MCP transport unification.

## Note
Reframes the queue around **"advances the strategy vs. grooms a proxy"** and makes explicit that the planner *ranks a curated backlog, it does not invent work* — the fix for the busy-work problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_