### PR TITLE
mcp: stdio/ws tool results are JSON + isError (fixes garbage to Claude Desktop)

### DIFF
--- a/gateway/mcp/grpcreflect.go
+++ b/gateway/mcp/grpcreflect.go
@@ -239,7 +239,7 @@ func protoMessageSchema(msg protoreflect.MessageDescriptor) map[string]interface
 	fields := msg.Fields()
 	for i := 0; i < fields.Len(); i++ {
 		field := fields.Get(i)
-		props[string(field.JSONName())] = protoFieldSchema(field)
+		props[field.JSONName()] = protoFieldSchema(field)
 	}
 	return schema
 }

--- a/gateway/mcp/stdio.go
+++ b/gateway/mcp/stdio.go
@@ -294,7 +294,9 @@ func (t *StdioTransport) handleToolsCall(req *JSONRPCRequest) {
 			AccountID: accountID, ScopesRequired: tool.Scopes,
 			Allowed: true, Duration: time.Since(start), Error: err.Error(),
 		})
-		t.sendError(req.ID, InternalError, "RPC call failed", err.Error())
+		// A tool-execution failure is reported as an isError result, not a
+		// JSON-RPC protocol error (per the MCP spec), so the agent can read it.
+		t.sendResponse(req.ID, mcpToolError(traceID, "tool call failed: "+err.Error()))
 		return
 	}
 
@@ -311,24 +313,8 @@ func (t *StdioTransport) handleToolsCall(req *JSONRPCRequest) {
 		Allowed: true, Duration: time.Since(start),
 	})
 
-	// Parse response
-	var result interface{}
-	if err := json.Unmarshal(rsp.Data, &result); err != nil {
-		// If unmarshal fails, return raw data
-		result = map[string]interface{}{
-			"data": string(rsp.Data),
-		}
-	}
-
-	t.sendResponse(req.ID, map[string]interface{}{
-		"content": []interface{}{
-			map[string]interface{}{
-				"type": "text",
-				"text": fmt.Sprintf("%v", result),
-			},
-		},
-		"trace_id": traceID,
-	})
+	// The downstream response is JSON — return it as JSON text, not %v.
+	t.sendResponse(req.ID, mcpToolResult(traceID, rsp.Data))
 }
 
 // sendResponse sends a JSON-RPC response

--- a/gateway/mcp/stdio_test.go
+++ b/gateway/mcp/stdio_test.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"go-micro.dev/v6/client"
+)
+
+// fakeCallClient overrides Call to return canned data or an error; NewRequest
+// and the rest are promoted from the embedded real client.
+type fakeCallClient struct {
+	client.Client
+	data []byte
+	err  error
+}
+
+func (f *fakeCallClient) Call(ctx context.Context, req client.Request, rsp interface{}, opts ...client.CallOption) error {
+	if f.err != nil {
+		return f.err
+	}
+	if r, ok := rsp.(*struct{ Data []byte }); ok {
+		r.Data = f.data
+	}
+	return nil
+}
+
+// isToolError reports whether an MCP tools/call result carries isError:true.
+func isToolError(result interface{}) bool {
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	b, _ := m["isError"].(bool)
+	return b
+}
+
+// toolResultText extracts the first text content of an MCP tools/call result.
+func toolResultText(t *testing.T, result interface{}) string {
+	t.Helper()
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("result is not a map: %#v", result)
+	}
+	content, ok := m["content"].([]interface{})
+	if !ok || len(content) == 0 {
+		t.Fatalf("result has no content: %#v", result)
+	}
+	first, _ := content[0].(map[string]interface{})
+	text, _ := first["text"].(string)
+	return text
+}
+
+// driveStdio sends one JSON-RPC request through a StdioTransport and returns the
+// decoded response, capturing the transport's stdout into a buffer.
+func driveStdio(t *testing.T, s *Server, method string, id interface{}, params interface{}) JSONRPCResponse {
+	t.Helper()
+	tr := NewStdioTransport(s)
+	var out bytes.Buffer
+	tr.writer = bufio.NewWriter(&out)
+	raw, _ := json.Marshal(params)
+	tr.handleRequest(&JSONRPCRequest{JSONRPC: "2.0", ID: id, Method: method, Params: raw})
+	var resp JSONRPCResponse
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp); err != nil {
+		t.Fatalf("decode stdio response: %v (raw=%q)", err, out.String())
+	}
+	return resp
+}
+
+// The stdio transport is the path an external MCP host (Claude Desktop) uses.
+// It must return tool output as JSON text, not fmt.Sprintf("%v", ...) which
+// yields Go map-syntax and is unparseable by a real client.
+func TestStdio_ToolsCall_ReturnsJSONNotGoSyntax(t *testing.T) {
+	s := newTestServer(Options{})
+	s.opts.Client = &fakeCallClient{Client: client.DefaultClient, data: []byte(`{"id":1,"name":"bob"}`)}
+	s.tools["svc.Echo"] = &Tool{Name: "svc.Echo", Service: "svc", Endpoint: "Echo"}
+
+	resp := driveStdio(t, s, "tools/call", 1, map[string]interface{}{
+		"name":      "svc.Echo",
+		"arguments": map[string]interface{}{"msg": "hi"},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected protocol error: %+v", resp.Error)
+	}
+	text := toolResultText(t, resp.Result)
+	// The bug returned Go map-syntax ("map[id:1 name:bob]"), which fails to parse.
+	var got map[string]interface{}
+	if err := json.Unmarshal([]byte(text), &got); err != nil {
+		t.Fatalf("tool result text is not JSON (the %%v bug): %q", text)
+	}
+	if got["name"] != "bob" {
+		t.Errorf("result = %v, want name=bob", got)
+	}
+}
+
+// A tool-execution failure must be an MCP isError result, not a JSON-RPC
+// protocol error, so the agent can read the failure.
+func TestStdio_ToolsCall_FailureIsIsErrorResult(t *testing.T) {
+	s := newTestServer(Options{})
+	s.opts.Client = &fakeCallClient{Client: client.DefaultClient, err: errors.New("backend down")}
+	s.tools["svc.Echo"] = &Tool{Name: "svc.Echo", Service: "svc", Endpoint: "Echo"}
+
+	resp := driveStdio(t, s, "tools/call", 1, map[string]interface{}{
+		"name":      "svc.Echo",
+		"arguments": map[string]interface{}{},
+	})
+	if resp.Error != nil {
+		t.Fatalf("tool failure returned a protocol error, want isError result: %+v", resp.Error)
+	}
+	if !isToolError(resp.Result) {
+		t.Fatalf("expected isError result, got %+v", resp.Result)
+	}
+	if text := toolResultText(t, resp.Result); text == "" {
+		t.Error("isError result should carry the error text")
+	}
+}

--- a/gateway/mcp/toolresult.go
+++ b/gateway/mcp/toolresult.go
@@ -1,0 +1,32 @@
+package mcp
+
+// MCP tools/call result shaping, shared by the stdio and websocket JSON-RPC
+// transports. Kept in one place so both transports produce spec-shaped results.
+
+// mcpToolResult builds a successful MCP tools/call result. The downstream RPC
+// response body (data) is JSON, so it is returned as JSON text — NOT
+// fmt.Sprintf("%v", ...) of a decoded value, which produces Go map-syntax
+// (map[id:1 name:bob]) instead of JSON and is what an external MCP client
+// (e.g. Claude Desktop over stdio) would otherwise receive.
+func mcpToolResult(traceID string, data []byte) map[string]interface{} {
+	return map[string]interface{}{
+		"content": []interface{}{
+			map[string]interface{}{"type": "text", "text": string(data)},
+		},
+		"trace_id": traceID,
+	}
+}
+
+// mcpToolError builds an MCP tools/call result for a tool-EXECUTION failure.
+// Per the MCP spec a tool that fails returns a normal result with isError:true
+// (the error as text content), NOT a JSON-RPC protocol error — that way the
+// agent can read the failure instead of seeing a transport-level error.
+func mcpToolError(traceID, msg string) map[string]interface{} {
+	return map[string]interface{}{
+		"content": []interface{}{
+			map[string]interface{}{"type": "text", "text": msg},
+		},
+		"isError":  true,
+		"trace_id": traceID,
+	}
+}

--- a/gateway/mcp/websocket.go
+++ b/gateway/mcp/websocket.go
@@ -275,7 +275,8 @@ func (wc *wsConn) handleToolsCall(req *JSONRPCRequest) {
 			AccountID: accountID, ScopesRequired: tool.Scopes,
 			Allowed: true, Duration: time.Since(start), Error: err.Error(),
 		})
-		wc.sendError(req.ID, InternalError, "RPC call failed", err.Error())
+		// Tool-execution failure → isError result (MCP spec), not a protocol error.
+		wc.sendResponse(req.ID, mcpToolError(traceID, "tool call failed: "+err.Error()))
 		return
 	}
 
@@ -291,23 +292,8 @@ func (wc *wsConn) handleToolsCall(req *JSONRPCRequest) {
 		Allowed: true, Duration: time.Since(start),
 	})
 
-	// Parse response
-	var result interface{}
-	if err := json.Unmarshal(rsp.Data, &result); err != nil {
-		result = map[string]interface{}{
-			"data": string(rsp.Data),
-		}
-	}
-
-	wc.sendResponse(req.ID, map[string]interface{}{
-		"content": []interface{}{
-			map[string]interface{}{
-				"type": "text",
-				"text": fmt.Sprintf("%v", result),
-			},
-		},
-		"trace_id": traceID,
-	})
+	// The downstream response is JSON — return it as JSON text, not %v.
+	wc.sendResponse(req.ID, mcpToolResult(traceID, rsp.Data))
 }
 
 // sendResponse sends a JSON-RPC success response.

--- a/gateway/mcp/websocket_test.go
+++ b/gateway/mcp/websocket_test.go
@@ -114,12 +114,13 @@ func TestWebSocket_ToolsCall_NoAuth(t *testing.T) {
 		"arguments": map[string]interface{}{"msg": "hi"},
 	})
 
-	// RPC will fail (no backend), but auth should pass (no auth configured)
-	if resp.Error == nil {
-		t.Fatal("expected RPC error (no backend)")
+	// No auth required → the tool runs; the RPC fails (no backend), which the
+	// MCP spec surfaces as an isError result, not a JSON-RPC protocol error.
+	if resp.Error != nil {
+		t.Fatalf("expected no protocol error, got %+v", resp.Error)
 	}
-	if resp.Error.Code != InternalError {
-		t.Errorf("error code = %d, want %d", resp.Error.Code, InternalError)
+	if !isToolError(resp.Result) {
+		t.Fatalf("expected isError tool result, got %+v", resp.Result)
 	}
 }
 
@@ -168,12 +169,13 @@ func TestWebSocket_ToolsCall_AuthRequired(t *testing.T) {
 			"arguments": map[string]interface{}{},
 			"_token":    "valid-token",
 		})
-		// Auth passes, RPC fails (no backend)
-		if resp.Error == nil {
-			t.Fatal("expected RPC error")
+		// Auth passes → the tool runs; RPC fails (no backend) → isError result,
+		// not a JSON-RPC protocol error (which would mean auth failed).
+		if resp.Error != nil {
+			t.Fatalf("expected no protocol error (auth passed), got %+v", resp.Error)
 		}
-		if resp.Error.Code != InternalError {
-			t.Errorf("error code = %d, want %d (RPC fail, not auth fail)", resp.Error.Code, InternalError)
+		if !isToolError(resp.Result) {
+			t.Fatalf("expected isError tool result, got %+v", resp.Result)
 		}
 	})
 
@@ -185,12 +187,13 @@ func TestWebSocket_ToolsCall_AuthRequired(t *testing.T) {
 			"name":      "svc.Do",
 			"arguments": map[string]interface{}{},
 		})
-		// Auth passes via connection-level header, RPC fails (no backend)
-		if resp.Error == nil {
-			t.Fatal("expected RPC error")
+		// Auth passes via connection-level header → tool runs; RPC fails (no
+		// backend) → isError result, not a JSON-RPC protocol error.
+		if resp.Error != nil {
+			t.Fatalf("expected no protocol error (auth passed), got %+v", resp.Error)
 		}
-		if resp.Error.Code != InternalError {
-			t.Errorf("error code = %d, want %d (RPC fail, not auth fail)", resp.Error.Code, InternalError)
+		if !isToolError(resp.Result) {
+			t.Fatalf("expected isError tool result, got %+v", resp.Result)
 		}
 	})
 }


### PR DESCRIPTION
Closes #4813 — the #1 item on the gap-audit build order, built 1:1. Real fix, real result.

## The bug
The stdio transport is the path an external MCP host (Claude Desktop) uses, and it emitted broken output:
- **Tool results were `fmt.Sprintf("%v", decodedJSON)`** → Go map-syntax (`map[id:1 name:bob]`), not JSON. A real MCP client can't parse it. Now returned as JSON text.
- **Tool-execution failures were returned as JSON-RPC protocol errors.** Per the MCP spec a failing tool returns a result with `isError:true` (error as text) so the agent can *read* the failure, not see a transport-level error. Now they do (the span + audit still record the error).

Both fixes are shared between stdio and websocket via new `mcpToolResult`/`mcpToolError` helpers (dedupes the two transports — the audit flagged the duplication).

## Tests
- **Added the missing stdio round-trip tests** — the package had *zero* stdio coverage, which is exactly why the `%v` bug shipped. They drive a real `tools/call` through the transport with an injected fake client and assert the result content is valid JSON (the bug would fail this) and that a tool failure is an `isError` result, not a protocol error.
- Updated the three websocket auth tests that asserted the old protocol-error-on-tool-failure behavior to the new `isError` contract.

## Drive-by
Fixes a pre-existing `golangci-lint` failure on master — an unnecessary `string(field.JSONName())` conversion in `grpcreflect.go` from #4821 — so the mcp package lints clean. **Another one the required-checks gap let through** (lint isn't blocking, so #4821 merged red). Reinforces: make `golangci-lint` a required check.

## Verified
`go build`, `go test ./gateway/mcp/...` (incl. new stdio tests), `go vet`, `golangci-lint` (0 issues), `gofmt` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_