### PR TITLE
Fix grpcreflect JSON name lint

### DIFF
--- a/gateway/mcp/grpcreflect.go
+++ b/gateway/mcp/grpcreflect.go
@@ -239,7 +239,7 @@ func protoMessageSchema(msg protoreflect.MessageDescriptor) map[string]interface
 	fields := msg.Fields()
 	for i := 0; i < fields.Len(); i++ {
 		field := fields.Get(i)
-		props[string(field.JSONName())] = protoFieldSchema(field)
+		props[field.JSONName()] = protoFieldSchema(field)
 	}
 	return schema
 }

--- a/gateway/mcp/grpcreflect.go
+++ b/gateway/mcp/grpcreflect.go
@@ -1,0 +1,282 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	reflectionpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// ReflectedGRPCTarget describes an external gRPC server whose reflection
+// catalog should be exposed as MCP tools. It is intentionally opt-in: teams can
+// bridge existing reflected gRPC services without changing their servers or
+// registering them in go-micro.
+type ReflectedGRPCTarget struct {
+	// Name prefixes generated tools. When empty, Address is sanitized and used.
+	Name string
+	// Address is the host:port of the reflected gRPC server.
+	Address string
+	// DialOptions customize the connection. If none are supplied, an insecure
+	// transport is used for local/dev interoperability.
+	DialOptions []grpc.DialOption
+	// Timeout bounds reflection discovery and individual tool calls.
+	Timeout time.Duration
+}
+
+func (s *Server) discoverReflectedGRPC() error {
+	for _, target := range s.opts.ReflectedGRPCTargets {
+		if strings.TrimSpace(target.Address) == "" {
+			continue
+		}
+		tools, err := s.reflectedGRPCTools(target)
+		if err != nil {
+			return err
+		}
+		for _, tool := range tools {
+			s.tools[tool.Name] = tool
+		}
+	}
+	return nil
+}
+
+func (s *Server) reflectedGRPCTools(target ReflectedGRPCTarget) ([]*Tool, error) {
+	timeout := target.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(s.opts.Context, timeout)
+	defer cancel()
+
+	dialOpts := target.DialOptions
+	if len(dialOpts) == 0 {
+		dialOpts = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	}
+	conn, err := grpc.NewClient(target.Address, dialOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("connect reflected grpc target %s: %w", target.Address, err)
+	}
+	defer conn.Close()
+
+	files, services, err := loadReflectedFiles(ctx, conn)
+	if err != nil {
+		return nil, fmt.Errorf("reflect grpc target %s: %w", target.Address, err)
+	}
+
+	prefix := target.Name
+	if prefix == "" {
+		prefix = sanitizeToolPart(target.Address)
+	}
+
+	var out []*Tool
+	for _, serviceName := range services {
+		desc, err := files.FindDescriptorByName(protoreflect.FullName(serviceName))
+		if err != nil {
+			continue
+		}
+		svc, ok := desc.(protoreflect.ServiceDescriptor)
+		if !ok {
+			continue
+		}
+		for i := 0; i < svc.Methods().Len(); i++ {
+			method := svc.Methods().Get(i)
+			if method.IsStreamingClient() || method.IsStreamingServer() {
+				continue
+			}
+			fullMethod := "/" + string(svc.FullName()) + "/" + string(method.Name())
+			toolName := prefix + "." + strings.ReplaceAll(string(svc.FullName()), ".", "_") + "." + string(method.Name())
+			input := method.Input()
+			out = append(out, &Tool{
+				Name:        toolName,
+				Description: fmt.Sprintf("Call reflected gRPC method %s on %s", fullMethod, target.Address),
+				InputSchema: protoMessageSchema(input),
+				Handler:     reflectedGRPCHandler(target, fullMethod, input, method.Output()),
+			})
+		}
+	}
+	return out, nil
+}
+
+func loadReflectedFiles(ctx context.Context, conn *grpc.ClientConn) (*protoregistryFiles, []string, error) {
+	client := reflectionpb.NewServerReflectionClient(conn)
+	stream, err := client.ServerReflectionInfo(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := stream.Send(&reflectionpb.ServerReflectionRequest{MessageRequest: &reflectionpb.ServerReflectionRequest_ListServices{ListServices: ""}}); err != nil {
+		return nil, nil, err
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, nil, err
+	}
+	list := resp.GetListServicesResponse()
+	if list == nil {
+		return nil, nil, fmt.Errorf("reflection list services returned %T", resp.MessageResponse)
+	}
+
+	set := &descriptorpb.FileDescriptorSet{}
+	seen := map[string]bool{}
+	var services []string
+	for _, svc := range list.Service {
+		name := svc.Name
+		if strings.HasPrefix(name, "grpc.reflection.") {
+			continue
+		}
+		services = append(services, name)
+		if err := requestFileContainingSymbol(ctx, client, name, set, seen); err != nil {
+			return nil, nil, err
+		}
+	}
+	files, err := newProtoregistryFiles(set)
+	if err != nil {
+		return nil, nil, err
+	}
+	return files, services, nil
+}
+
+func requestFileContainingSymbol(ctx context.Context, client reflectionpb.ServerReflectionClient, symbol string, set *descriptorpb.FileDescriptorSet, seen map[string]bool) error {
+	stream, err := client.ServerReflectionInfo(ctx)
+	if err != nil {
+		return err
+	}
+	if err := stream.Send(&reflectionpb.ServerReflectionRequest{MessageRequest: &reflectionpb.ServerReflectionRequest_FileContainingSymbol{FileContainingSymbol: symbol}}); err != nil {
+		return err
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	fd := resp.GetFileDescriptorResponse()
+	if fd == nil {
+		return fmt.Errorf("reflection lookup for %s returned %T", symbol, resp.MessageResponse)
+	}
+	for _, raw := range fd.FileDescriptorProto {
+		var file descriptorpb.FileDescriptorProto
+		if err := proto.Unmarshal(raw, &file); err != nil {
+			return err
+		}
+		name := file.GetName()
+		if !seen[name] {
+			seen[name] = true
+			set.File = append(set.File, &file)
+		}
+	}
+	return nil
+}
+
+// protoregistryFiles is a narrow wrapper that keeps imports local to this file.
+type protoregistryFiles struct{ files *protoregistry.Files }
+
+func newProtoregistryFiles(set *descriptorpb.FileDescriptorSet) (*protoregistryFiles, error) {
+	files, err := protodesc.NewFiles(set)
+	if err != nil {
+		return nil, err
+	}
+	return &protoregistryFiles{files: files}, nil
+}
+
+func (p *protoregistryFiles) FindDescriptorByName(name protoreflect.FullName) (protoreflect.Descriptor, error) {
+	return p.files.FindDescriptorByName(name)
+}
+
+func reflectedGRPCHandler(target ReflectedGRPCTarget, fullMethod string, input, output protoreflect.MessageDescriptor) func(map[string]interface{}) (interface{}, error) {
+	return func(args map[string]interface{}) (interface{}, error) {
+		timeout := target.Timeout
+		if timeout == 0 {
+			timeout = 10 * time.Second
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		dialOpts := target.DialOptions
+		if len(dialOpts) == 0 {
+			dialOpts = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+		}
+		conn, err := grpc.NewClient(target.Address, dialOpts...)
+		if err != nil {
+			return nil, err
+		}
+		defer conn.Close()
+
+		req := dynamicpb.NewMessage(input)
+		raw, err := json.Marshal(args)
+		if err != nil {
+			return nil, err
+		}
+		if err := protojson.Unmarshal(raw, req); err != nil {
+			return nil, err
+		}
+		rsp := dynamicpb.NewMessage(output)
+		if err := conn.Invoke(ctx, fullMethod, req, rsp); err != nil {
+			return nil, err
+		}
+		b, err := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}.Marshal(rsp)
+		if err != nil {
+			return nil, err
+		}
+		var out interface{}
+		if err := json.Unmarshal(b, &out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+}
+
+func protoMessageSchema(msg protoreflect.MessageDescriptor) map[string]interface{} {
+	schema := map[string]interface{}{"type": "object", "properties": map[string]interface{}{}}
+	props := schema["properties"].(map[string]interface{})
+	fields := msg.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		field := fields.Get(i)
+		props[string(field.JSONName())] = protoFieldSchema(field)
+	}
+	return schema
+}
+
+func protoFieldSchema(field protoreflect.FieldDescriptor) map[string]interface{} {
+	schema := map[string]interface{}{"type": protoJSONType(field)}
+	if field.IsList() {
+		schema["items"] = map[string]interface{}{"type": protoJSONType(field)}
+	}
+	if field.Kind() == protoreflect.MessageKind || field.Kind() == protoreflect.GroupKind {
+		schema = protoMessageSchema(field.Message())
+	}
+	return schema
+}
+
+func protoJSONType(field protoreflect.FieldDescriptor) string {
+	if field.IsList() {
+		return "array"
+	}
+	switch field.Kind() {
+	case protoreflect.BoolKind:
+		return "boolean"
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind,
+		protoreflect.Uint32Kind, protoreflect.Fixed32Kind, protoreflect.Int64Kind,
+		protoreflect.Sint64Kind, protoreflect.Sfixed64Kind, protoreflect.Uint64Kind,
+		protoreflect.Fixed64Kind:
+		return "integer"
+	case protoreflect.FloatKind, protoreflect.DoubleKind:
+		return "number"
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return "object"
+	default:
+		return "string"
+	}
+}
+
+func sanitizeToolPart(s string) string {
+	r := strings.NewReplacer(":", "_", "/", "_", ".", "_", "-", "_")
+	return r.Replace(s)
+}

--- a/gateway/mcp/grpcreflect_test.go
+++ b/gateway/mcp/grpcreflect_test.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	helloworld "google.golang.org/grpc/examples/helloworld/helloworld"
+	"google.golang.org/grpc/reflection"
+)
+
+type reflectedGreeter struct {
+	helloworld.UnimplementedGreeterServer
+}
+
+func (reflectedGreeter) SayHello(_ context.Context, req *helloworld.HelloRequest) (*helloworld.HelloReply, error) {
+	return &helloworld.HelloReply{Message: "hello " + req.Name}, nil
+}
+
+func TestReflectedGRPCTargetDiscoversAndCallsUnaryTool(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	grpcServer := grpc.NewServer()
+	helloworld.RegisterGreeterServer(grpcServer, reflectedGreeter{})
+	reflection.Register(grpcServer)
+	go grpcServer.Serve(lis)
+	defer grpcServer.Stop()
+
+	s := newTestServer(Options{Context: context.Background()})
+	tools, err := s.reflectedGRPCTools(ReflectedGRPCTarget{
+		Name:    "demo",
+		Address: lis.Addr().String(),
+		Timeout: 3 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("discover reflected tools: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("tools len = %d, want 1", len(tools))
+	}
+	tool := tools[0]
+	if tool.Name != "demo.helloworld_Greeter.SayHello" {
+		t.Fatalf("tool name = %q", tool.Name)
+	}
+	props := tool.InputSchema["properties"].(map[string]interface{})
+	if _, ok := props["name"]; !ok {
+		t.Fatalf("input schema missing name: %#v", tool.InputSchema)
+	}
+
+	out, err := tool.Handler(map[string]interface{}{"name": "Ada"})
+	if err != nil {
+		t.Fatalf("call reflected tool: %v", err)
+	}
+	got := out.(map[string]interface{})["message"]
+	if got != "hello Ada" {
+		t.Fatalf("message = %v, want hello Ada", got)
+	}
+}

--- a/gateway/mcp/mcp.go
+++ b/gateway/mcp/mcp.go
@@ -157,6 +157,11 @@ type Options struct {
 	// (the /mcp/call endpoint). Listing tools and health stay free.
 	// Opt-in: leave nil to disable payments.
 	Payment *x402.Config
+
+	// ReflectedGRPCTargets exposes unary methods from external gRPC servers
+	// that support server reflection as MCP tools. This bridges existing gRPC
+	// services into the agent tool catalog without requiring go-micro handlers.
+	ReflectedGRPCTargets []ReflectedGRPCTarget
 }
 
 // Server represents a running MCP gateway
@@ -285,6 +290,10 @@ func (s *Server) discoverServices() error {
 
 	s.toolsMu.Lock()
 	defer s.toolsMu.Unlock()
+
+	if err := s.discoverReflectedGRPC(); err != nil {
+		return err
+	}
 
 	for _, svc := range services {
 		// Get full service details


### PR DESCRIPTION
Fixes the lint failure from run https://github.com/micro/go-micro/actions/runs/29190341408 on top of codex/increment-4820 by removing an unnecessary string conversion around protoreflect FieldDescriptor.JSONName.

Root cause: golangci-lint v2.5.0 reported unconvert at gateway/mcp/grpcreflect.go:242 because FieldDescriptor.JSONName already returns string.

Deduping: searched open and recently closed issues for grpcreflect/unconvert/golangci-lint; only related item found was historical lint CI setup issue #2988, not this defect. No new issue filed because the failed run was on branch codex/increment-4820, not master; this PR fixes the branch regression directly.

Testing:
- go build ./...
- go test ./... (fails locally: atlascloud live API returns 400 and loopback targets are forbidden by the environment)
- golangci-lint run ./... (local installed binary was built with Go 1.24 and cannot load Go 1.25.12 config)
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./... (same local Go 1.24-built linter/config mismatch)