### PR TITLE
x402: harden spend cap — reject invalid amounts, require settler option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ below is kept current between tags and rolled into the next version when it ship
 ### Fixed
 - **Provider failure inspection metadata** — provider failures recorded during agent runs now retain classification metadata for inspection. (`agent/`, `ai/`)
 
+### Security
+- **x402 spend-cap hardening** — the paying `Client` now refuses a 402 whose `maxAmountRequired` is not a positive integer (a swallowed parse error or negative amount previously bypassed the budget cap), and a new `Config.RequireSettlement` fails closed when a paid request is served by a verify-only facilitator that never captures funds. (`wrapper/x402/`)
+
 ---
 
 ## [6.7.0] - July 2026

--- a/wrapper/x402/client.go
+++ b/wrapper/x402/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -81,7 +82,16 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		return resp, fmt.Errorf("x402: 402 response carried no requirements")
 	}
 	reqd := ch.Accepts[0]
-	amount, _ := strconv.ParseInt(reqd.MaxAmountRequired, 10, 64)
+	// The amount governs the whole spend cap, so it must be a real positive
+	// integer. A swallowed parse error (non-decimal, overflow, empty) would
+	// yield 0 and pass the budget check trivially, and a negative amount would
+	// inflate the remaining allowance — either way the cap is defeated. Refuse
+	// before signing anything.
+	amount, err := strconv.ParseInt(strings.TrimSpace(reqd.MaxAmountRequired), 10, 64)
+	if err != nil || amount <= 0 {
+		return resp, fmt.Errorf("x402: refusing to pay %s: invalid maxAmountRequired %q",
+			reqd.Resource, reqd.MaxAmountRequired)
+	}
 
 	// Spend cap: reserve before paying so concurrent calls cannot all pass
 	// the check and overspend the caller's allowance. Roll the reservation

--- a/wrapper/x402/client_test.go
+++ b/wrapper/x402/client_test.go
@@ -172,6 +172,33 @@ func TestClientBudgetReservationRollsBackOnPayError(t *testing.T) {
 	}
 }
 
+// A 402 whose maxAmountRequired is not a positive integer must be refused
+// before any payment — otherwise a swallowed parse error (0) or a negative
+// amount defeats the spend cap. The payer is never called and nothing is spent.
+func TestClientRefusesInvalidAmount(t *testing.T) {
+	for _, amount := range []string{"abc", "-100", "99999999999999999999999999", "0x10", "1.5"} {
+		srv := paidServer(amount)
+
+		payer := &mockPayer{}
+		c := &Client{Payer: payer, Budget: 1_000_000}
+		req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+		resp, err := c.Do(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil {
+			t.Errorf("amount %q: expected refusal, got nil error", amount)
+		}
+		if payer.calls != 0 {
+			t.Errorf("amount %q: payer called %d times, want 0", amount, payer.calls)
+		}
+		if c.Spent() != 0 {
+			t.Errorf("amount %q: spent %d, want 0", amount, c.Spent())
+		}
+		srv.Close()
+	}
+}
+
 type payerFunc func(context.Context, Requirements) (string, error)
 
 func (f payerFunc) Pay(ctx context.Context, req Requirements) (string, error) {

--- a/wrapper/x402/x402.go
+++ b/wrapper/x402/x402.go
@@ -126,6 +126,11 @@ type Config struct {
 	// FacilitatorURL is the verify/settle endpoint used when Facilitator
 	// is nil (e.g. Coinbase CDP or Alchemy).
 	FacilitatorURL string `json:"facilitator,omitempty"`
+	// RequireSettlement fails closed when a paid request cannot be settled:
+	// if the facilitator only verifies (does not implement Settler), Require
+	// refuses to serve rather than releasing the resource while no funds move.
+	// Leave false only for verify-only flows where authorization is enough.
+	RequireSettlement bool `json:"requireSettlement,omitempty"`
 }
 
 func (c Config) network() string {
@@ -222,7 +227,14 @@ func (c Config) Require(w http.ResponseWriter, r *http.Request, amount, resource
 	}
 	// Capture the funds when the facilitator can settle. Verify alone only
 	// authorizes the "exact" transfer; settlement broadcasts it.
-	if s, ok := fac.(Settler); ok {
+	s, canSettle := fac.(Settler)
+	if c.RequireSettlement && !canSettle {
+		// Fail closed: a paid config must not serve the resource on a
+		// verify-only facilitator, or it gives the tool away for free.
+		writeChallenge(w, req, "payment settlement unavailable")
+		return false
+	}
+	if canSettle {
 		sres, err := s.Settle(r.Context(), payment, req)
 		if err != nil {
 			writeChallenge(w, req, "payment settlement failed: "+err.Error())

--- a/wrapper/x402/x402_settle_test.go
+++ b/wrapper/x402/x402_settle_test.go
@@ -159,4 +159,58 @@ func TestCDPAuthorizeAttachesBearer(t *testing.T) {
 	}
 }
 
+// TestRequireSettlementFailsClosed checks that a paid config with
+// RequireSettlement refuses to serve when the facilitator only verifies (does
+// not settle) — otherwise the resource is released while no funds move.
+func TestRequireSettlementFailsClosed(t *testing.T) {
+	// mockFacilitator implements Verify but not Settler.
+	cfg := Config{PayTo: "0xpay", Facilitator: mockFacilitator{valid: true}, RequireSettlement: true}
+	r := httptest.NewRequest(http.MethodGet, "/tool", nil)
+	r.Header.Set(PaymentHeader, "eyJ4IjoxfQ==")
+	rec := httptest.NewRecorder()
+
+	if cfg.Require(rec, r, "10000", "chat") {
+		t.Fatal("Require should fail closed when settlement is required but unavailable")
+	}
+	if rec.Code != http.StatusPaymentRequired {
+		t.Errorf("status = %d, want 402", rec.Code)
+	}
+
+	// Without RequireSettlement the verify-only facilitator still serves.
+	cfg.RequireSettlement = false
+	rec = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "/tool", nil)
+	r.Header.Set(PaymentHeader, "eyJ4IjoxfQ==")
+	if !cfg.Require(rec, r, "10000", "chat") {
+		t.Fatalf("verify-only should serve when settlement is not required; body=%s", rec.Body.String())
+	}
+}
+
+// TestRequireSettlementServesWithSettler checks that a paid config with
+// RequireSettlement serves when the facilitator can settle.
+func TestRequireSettlementServesWithSettler(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/verify":
+			_ = json.NewEncoder(w).Encode(map[string]any{"isValid": true})
+		case "/settle":
+			_ = json.NewEncoder(w).Encode(map[string]any{"success": true, "transaction": "0xabc"})
+		}
+	}))
+	defer srv.Close()
+
+	// HTTPFacilitator implements Settler.
+	cfg := Config{PayTo: "0xpay", FacilitatorURL: srv.URL, RequireSettlement: true}
+	r := httptest.NewRequest(http.MethodGet, "/tool", nil)
+	r.Header.Set(PaymentHeader, "eyJ4IjoxfQ==")
+	rec := httptest.NewRecorder()
+
+	if !cfg.Require(rec, r, "10000", "chat") {
+		t.Fatalf("Require should serve with a settling facilitator; body=%s", rec.Body.String())
+	}
+	if got := rec.Header().Get(PaymentResponseHeader); got != "0xabc" {
+		t.Errorf("settlement header = %q, want 0xabc", got)
+	}
+}
+
 var _ Settler = (*HTTPFacilitator)(nil)


### PR DESCRIPTION
Closes #4814.

Two spend-safety holes from the gap audit, both fail-open today:

**1. Budget-cap bypass (`wrapper/x402/client.go`).** `Client.Do` parsed `maxAmountRequired` with a swallowed error:

```go
amount, _ := strconv.ParseInt(reqd.MaxAmountRequired, 10, 64)
```

A non-decimal, overflowing, or empty amount became `0`, so `spent+0 > Budget` passed trivially — while `Payer.Pay` still signed against the raw string. A negative amount similarly inflated remaining budget. The spend cap, which is the whole safety story for an autonomous paying agent, was defeatable by the server it's paying.

Now the amount must parse as a **positive** integer or the 402 is refused before anything is signed.

**2. Verify-only serves free (`wrapper/x402/x402.go`).** `Require` settled only `if fac.(Settler)`. A facilitator that verifies but never settles returned `true` and the resource was served while no funds moved. New `Config.RequireSettlement` **fails closed** in that case (refuses to serve rather than giving the tool away). Default `false` preserves existing verify-only flows.

### Tests
- `TestClientRefusesInvalidAmount` — non-decimal / negative / overflow / hex / fractional `maxAmountRequired` are all refused with no payment and no spend.
- `TestRequireSettlementFailsClosed` — a paid config with a verify-only facilitator refuses when `RequireSettlement` is set, and still serves when it isn't.
- `TestRequireSettlementServesWithSettler` — a settling facilitator serves and surfaces the settlement header.

`go build ./...`, `go test ./wrapper/x402/...`, and `golangci-lint run ./wrapper/x402/...` pass.

Complements #4786 (buyer wiring), which relies on this cap holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_