### PR TITLE
a2a: conform to external A2A clients — well-known path + spec SSE events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ below is kept current between tags and rolled into the next version when it ship
 
 ### Changed
 - **Remote agent chat streaming** — `micro chat` now streams replies from remote agents instead of waiting for the full response. (`cmd/micro/`, `agent/`)
+- **A2A external-client conformance** — the A2A gateway now serves the Agent Card at the spec 0.3.0 `/.well-known/agent-card.json` (keeping `/.well-known/agent.json` as a legacy alias), and `message/stream` emits spec-shaped `status-update`/`artifact-update` events ending in a `final:true` status-update instead of repeated full `Task` snapshots — and never sends `result` and `error` together. Standard A2A clients (ADK, LangGraph, a2a-SDK) can now discover and stream from go-micro agents. (`gateway/a2a/`)
 
 ### Fixed
 - **Provider failure inspection metadata** — provider failures recorded during agent runs now retain classification metadata for inspection. (`agent/`, `ai/`)

--- a/agent/a2a_stream_test.go
+++ b/agent/a2a_stream_test.go
@@ -68,35 +68,79 @@ func TestA2AStreamUsesAgentChatPathWithTools(t *testing.T) {
 		t.Fatalf("stream body missing tool marker: %s", rr.Body.String())
 	}
 
-	var final struct {
-		Result struct {
-			Status struct {
-				State string `json:"state"`
-			} `json:"status"`
-			Artifacts []struct {
-				Parts []struct {
-					Text string `json:"text"`
-				} `json:"parts"`
-			} `json:"artifacts"`
-		} `json:"result"`
-		Error any `json:"error"`
-	}
+	// The spec-shaped stream carries the answer as append artifact-update
+	// deltas and closes with a completed status-update (final:true).
+	var (
+		text       strings.Builder
+		finalState string
+		sawFinal   bool
+	)
 	for _, line := range strings.Split(strings.TrimSpace(rr.Body.String()), "\n") {
 		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "data: "))
 		if line == "" {
 			continue
 		}
-		if err := json.Unmarshal([]byte(line), &final); err != nil {
+		var ev struct {
+			Result json.RawMessage `json:"result"`
+			Error  any             `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
 			t.Fatalf("decode event %q: %v", line, err)
 		}
+		if ev.Error != nil {
+			t.Fatalf("event carried an error field: %+v", ev.Error)
+		}
+		var kind struct {
+			Kind string `json:"kind"`
+		}
+		_ = json.Unmarshal(ev.Result, &kind)
+		switch kind.Kind {
+		case "artifact-update":
+			var au struct {
+				Artifact struct {
+					Parts []struct {
+						Text string `json:"text"`
+					} `json:"parts"`
+				} `json:"artifact"`
+			}
+			_ = json.Unmarshal(ev.Result, &au)
+			for _, p := range au.Artifact.Parts {
+				text.WriteString(p.Text)
+			}
+		case "status-update":
+			var su struct {
+				Status struct {
+					State string `json:"state"`
+				} `json:"status"`
+				Final bool `json:"final"`
+			}
+			_ = json.Unmarshal(ev.Result, &su)
+			if su.Final {
+				sawFinal = true
+				finalState = su.Status.State
+			}
+		default: // opening "task" snapshot
+			var task struct {
+				Artifacts []struct {
+					Parts []struct {
+						Text string `json:"text"`
+					} `json:"parts"`
+				} `json:"artifacts"`
+			}
+			_ = json.Unmarshal(ev.Result, &task)
+			for _, a := range task.Artifacts {
+				for _, p := range a.Parts {
+					if p.Text != "" {
+						text.WriteString(p.Text)
+					}
+				}
+			}
+		}
 	}
-	if final.Error != nil {
-		t.Fatalf("final event error: %+v", final.Error)
+	if !sawFinal || finalState != "completed" {
+		t.Fatalf("want a completed final:true status-update; sawFinal=%v state=%q", sawFinal, finalState)
 	}
-	if final.Result.Status.State != "completed" {
-		t.Fatalf("final state = %q, want completed", final.Result.Status.State)
-	}
-	if len(final.Result.Artifacts) != 1 || len(final.Result.Artifacts[0].Parts) != 1 || !strings.Contains(final.Result.Artifacts[0].Parts[0].Text, "a2a-stream-ok") {
-		t.Fatalf("final artifacts = %+v, want tool marker", final.Result.Artifacts)
+	if !strings.Contains(text.String(), "a2a-stream-ok") {
+		t.Fatalf("reassembled stream text missing tool marker: %q", text.String())
 	}
 }

--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -108,6 +108,9 @@ func NewAgentHandler(card AgentCard, invoke Invoke) http.Handler {
 	card.URL = strings.TrimRight(card.URL, "/")
 	serveCard := func(w http.ResponseWriter, _ *http.Request) { writeJSON(w, http.StatusOK, card) }
 	mux.HandleFunc("GET /{$}", serveCard)
+	// A2A 0.3.0 discovery is /.well-known/agent-card.json; agent.json is the
+	// pre-0.3 alias, kept so existing clients don't break.
+	mux.HandleFunc("GET /.well-known/agent-card.json", serveCard)
 	mux.HandleFunc("GET /.well-known/agent.json", serveCard)
 	mux.HandleFunc("POST /{$}", func(w http.ResponseWriter, r *http.Request) { d.serve(w, r, invoke) })
 	return mux
@@ -121,6 +124,7 @@ func NewAgentStreamHandler(card AgentCard, invoke Invoke, stream StreamInvoke) h
 	card.URL = strings.TrimRight(card.URL, "/")
 	serveCard := func(w http.ResponseWriter, _ *http.Request) { writeJSON(w, http.StatusOK, card) }
 	mux.HandleFunc("GET /{$}", serveCard)
+	mux.HandleFunc("GET /.well-known/agent-card.json", serveCard)
 	mux.HandleFunc("GET /.well-known/agent.json", serveCard)
 	mux.HandleFunc("POST /{$}", func(w http.ResponseWriter, r *http.Request) { d.serveWithStream(w, r, invoke, stream) })
 	return mux
@@ -139,15 +143,19 @@ func (g *Gateway) Handler() http.Handler {
 	// Discovery: a directory of all agent cards.
 	mux.HandleFunc("GET /agents", g.handleList)
 	// Per-agent card (served at the agent's url and at its well-known path).
+	// A2A 0.3.0 uses agent-card.json; agent.json is the pre-0.3 alias.
 	mux.HandleFunc("GET /agents/{name}", g.handleCard)
+	mux.HandleFunc("GET /agents/{name}/.well-known/agent-card.json", g.handleCard)
 	mux.HandleFunc("GET /agents/{name}/.well-known/agent.json", g.handleCard)
 	mux.HandleFunc("GET /agents/{name}/skills/{skill}", g.handleSkillCard)
+	mux.HandleFunc("GET /agents/{name}/skills/{skill}/.well-known/agent-card.json", g.handleSkillCard)
 	mux.HandleFunc("GET /agents/{name}/skills/{skill}/.well-known/agent.json", g.handleSkillCard)
 	// Per-agent JSON-RPC endpoint.
 	mux.HandleFunc("POST /agents/{name}", g.handleRPC)
 	mux.HandleFunc("POST /agents/{name}/skills/{skill}", g.handleSkillRPC)
 	// Top-level well-known: serve the single agent's card if there's
 	// exactly one, otherwise point to the directory.
+	mux.HandleFunc("GET /.well-known/agent-card.json", g.handleWellKnown)
 	mux.HandleFunc("GET /.well-known/agent.json", g.handleWellKnown)
 	return mux
 }
@@ -220,6 +228,39 @@ type TaskStatus struct {
 type Artifact struct {
 	ArtifactID string `json:"artifactId"`
 	Parts      []Part `json:"parts"`
+}
+
+// TaskStatusUpdateEvent is an A2A streaming event reporting a change in a
+// task's status. External SSE clients parse stream events by `kind` and stop
+// on the event whose `final` is true — a full Task snapshot (which older
+// versions emitted) carries neither, so strict clients never terminate.
+type TaskStatusUpdateEvent struct {
+	TaskID    string     `json:"taskId"`
+	ContextID string     `json:"contextId"`
+	Kind      string     `json:"kind"` // "status-update"
+	Status    TaskStatus `json:"status"`
+	Final     bool       `json:"final"`
+}
+
+// TaskArtifactUpdateEvent is an A2A streaming event carrying an artifact (or,
+// with Append, one incremental chunk of one).
+type TaskArtifactUpdateEvent struct {
+	TaskID    string   `json:"taskId"`
+	ContextID string   `json:"contextId"`
+	Kind      string   `json:"kind"` // "artifact-update"
+	Artifact  Artifact `json:"artifact"`
+	Append    bool     `json:"append,omitempty"`
+	LastChunk bool     `json:"lastChunk,omitempty"`
+}
+
+func statusUpdateEvent(t *Task, final bool) TaskStatusUpdateEvent {
+	return TaskStatusUpdateEvent{
+		TaskID:    t.ID,
+		ContextID: t.ContextID,
+		Kind:      "status-update",
+		Status:    t.Status,
+		Final:     final,
+	}
 }
 
 // Task is the unit of work returned by message/send and tasks/get.
@@ -534,14 +575,11 @@ func (d *dispatcher) stream(ctx context.Context, w http.ResponseWriter, req rpcR
 		writeRPC(w, req.ID, nil, e)
 		return
 	}
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(sseWriter{w: w}).Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: task})
-	if f, ok := w.(http.Flusher); ok {
-		f.Flush()
-	}
+	enc, flush := sseResponse(w)
+	// The Task snapshot first (carries ids and the final artifact), then a
+	// terminal status-update so external SSE clients see `final:true` and stop.
+	writeSSE(enc, flush, req.ID, task)
+	writeSSE(enc, flush, req.ID, statusUpdateEvent(task, true))
 }
 
 func (d *dispatcher) streamChunks(ctx context.Context, w http.ResponseWriter, req rpcRequest, invoke StreamInvoke, fallback Invoke) {
@@ -565,46 +603,53 @@ func (d *dispatcher) streamChunks(ctx context.Context, w http.ResponseWriter, re
 		return
 	}
 	defer stream.Close()
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(http.StatusOK)
-	enc := json.NewEncoder(sseWriter{w: w})
-	flush := func() {
-		if f, ok := w.(http.Flusher); ok {
-			f.Flush()
-		}
-	}
+	enc, flush := sseResponse(w)
 	taskID := uuid.New().String()
 	contextID := p.Message.ContextID
 	if contextID == "" {
 		contextID = uuid.New().String()
 	}
+	// One artifact id for the whole stream so append:true chunks target it.
+	artifactID := uuid.New().String()
+
+	// Open with the Task snapshot (working) so the client learns the ids.
+	initial := taskFromReplyWithIDs(p.Message, "", stateWorking, taskID, contextID)
+	d.store(initial)
+	writeSSE(enc, flush, req.ID, initial)
+
 	var reply strings.Builder
 	for {
 		chunk, err := stream.Recv()
 		if err == io.EOF {
 			task := taskFromReplyWithIDs(p.Message, reply.String(), stateCompleted, taskID, contextID)
 			d.store(task)
-			_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: task})
-			flush()
+			// Spec-shaped terminal: a status-update with final:true — not a
+			// full Task snapshot, which carries no terminal marker.
+			writeSSE(enc, flush, req.ID, statusUpdateEvent(task, true))
 			return
 		}
 		if err != nil {
 			task := taskFromReplyWithIDs(p.Message, "error: "+err.Error(), stateFailed, taskID, contextID)
 			d.store(task)
-			_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: task, Error: &rpcError{Code: errInternal, Message: err.Error()}})
-			flush()
+			// A failed status-update (final) — never `result` and `error`
+			// together in one response, which strict clients reject.
+			writeSSE(enc, flush, req.ID, statusUpdateEvent(task, true))
 			return
 		}
 		if chunk == nil || chunk.Reply == "" {
 			continue
 		}
 		reply.WriteString(chunk.Reply)
-		task := taskFromReplyWithIDs(p.Message, reply.String(), stateWorking, taskID, contextID)
-		d.store(task)
-		_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: task})
-		flush()
+		// Emit the delta as an append artifact-update; keep the stored task
+		// current for tasks/get and resubscribe watchers.
+		d.store(taskFromReplyWithIDs(p.Message, reply.String(), stateWorking, taskID, contextID))
+		writeSSE(enc, flush, req.ID, TaskArtifactUpdateEvent{
+			TaskID:    taskID,
+			ContextID: contextID,
+			Kind:      "artifact-update",
+			Artifact:  Artifact{ArtifactID: artifactID, Parts: []Part{{Kind: "text", Text: chunk.Reply}}},
+			Append:    true,
+		})
 	}
 }
 
@@ -653,20 +698,16 @@ func (d *dispatcher) resubscribe(ctx context.Context, w http.ResponseWriter, req
 	}
 	defer unsubscribe()
 
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(http.StatusOK)
-	enc := json.NewEncoder(sseWriter{w: w})
-	flush := func() {
-		if f, ok := w.(http.Flusher); ok {
-			f.Flush()
-		}
-	}
+	enc, flush := sseResponse(w)
 	writeEvent := func(t *Task) bool {
-		_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: t})
-		flush()
-		return isTerminal(t.Status.State)
+		writeSSE(enc, flush, req.ID, t)
+		if isTerminal(t.Status.State) {
+			// Close the stream with a spec-shaped terminal marker so external
+			// clients see `final:true`.
+			writeSSE(enc, flush, req.ID, statusUpdateEvent(t, true))
+			return true
+		}
+		return false
 	}
 	if writeEvent(task) {
 		return
@@ -1027,6 +1068,27 @@ func requestContext(parent context.Context) context.Context {
 		cancel()
 	}()
 	return ctx
+}
+
+// sseResponse writes the SSE response headers and returns an encoder and a
+// flush func for emitting `data:`-framed JSON-RPC events.
+func sseResponse(w http.ResponseWriter) (*json.Encoder, func()) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	enc := json.NewEncoder(sseWriter{w: w})
+	return enc, func() {
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+}
+
+// writeSSE emits one JSON-RPC event (result only — never with an error) and flushes.
+func writeSSE(enc *json.Encoder, flush func(), id json.RawMessage, result any) {
+	_ = enc.Encode(rpcResponse{JSONRPC: "2.0", ID: id, Result: result})
+	flush()
 }
 
 type sseWriter struct {

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -99,6 +99,38 @@ func TestAgentCardFromRegistry(t *testing.T) {
 	}
 }
 
+// A2A 0.3.0 discovery is /.well-known/agent-card.json. The card must be
+// reachable there (canonical) as well as at the legacy agent.json alias, both
+// per-agent and at the single-agent top level.
+func TestAgentCardCanonicalWellKnownPath(t *testing.T) {
+	ts, cleanup := newGatewayWithAgent(t)
+	defer cleanup()
+
+	for _, path := range []string{
+		"/agents/echo/.well-known/agent-card.json",
+		"/agents/echo/.well-known/agent.json",
+		"/agents/echo/skills/task/.well-known/agent-card.json",
+	} {
+		resp, err := http.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("get %s: %v", path, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			t.Fatalf("%s status = %d, want 200", path, resp.StatusCode)
+		}
+		var card AgentCard
+		if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+			resp.Body.Close()
+			t.Fatalf("%s decode card: %v", path, err)
+		}
+		resp.Body.Close()
+		if card.Name != "echo" {
+			t.Errorf("%s card name = %q, want echo", path, card.Name)
+		}
+	}
+}
+
 func TestSkillEndpointServesFocusedCardAndRoutesRPC(t *testing.T) {
 	ts, cleanup := newGatewayWithAgent(t)
 	defer cleanup()
@@ -335,6 +367,67 @@ func (s *sliceStream) Recv() (*ai.Response, error) {
 
 func (s *sliceStream) Close() error { return nil }
 
+// streamEvent is one decoded SSE JSON-RPC event from a message/stream response.
+// A2A streams carry heterogeneous results (Task, status-update, artifact-update)
+// discriminated by `kind`, so we keep the raw result and decode on demand.
+type streamEvent struct {
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+}
+
+func (e streamEvent) kind() string {
+	var k struct {
+		Kind string `json:"kind"`
+	}
+	_ = json.Unmarshal(e.Result, &k)
+	return k.Kind
+}
+
+func (e streamEvent) task(t *testing.T) Task {
+	t.Helper()
+	var task Task
+	if err := json.Unmarshal(e.Result, &task); err != nil {
+		t.Fatalf("decode task event: %v", err)
+	}
+	return task
+}
+
+func (e streamEvent) status(t *testing.T) TaskStatusUpdateEvent {
+	t.Helper()
+	var s TaskStatusUpdateEvent
+	if err := json.Unmarshal(e.Result, &s); err != nil {
+		t.Fatalf("decode status-update event: %v", err)
+	}
+	return s
+}
+
+func (e streamEvent) artifactUpdate(t *testing.T) TaskArtifactUpdateEvent {
+	t.Helper()
+	var a TaskArtifactUpdateEvent
+	if err := json.Unmarshal(e.Result, &a); err != nil {
+		t.Fatalf("decode artifact-update event: %v", err)
+	}
+	return a
+}
+
+// collectSSE parses the `data:`-framed JSON-RPC events from an SSE body.
+func collectSSE(t *testing.T, body string) []streamEvent {
+	t.Helper()
+	var events []streamEvent
+	for _, line := range strings.Split(strings.TrimSpace(body), "\n") {
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "data:"))
+		if line == "" {
+			continue
+		}
+		var e streamEvent
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("decode event %q: %v", line, err)
+		}
+		events = append(events, e)
+	}
+	return events
+}
+
 func TestMessageStreamChunksStoreFinalTask(t *testing.T) {
 	d := newDispatcher()
 	body := `{"jsonrpc":"2.0","id":1,"method":"message/stream","params":{"message":{"role":"user","parts":[{"kind":"text","text":"ping"}],"kind":"message"}}}`
@@ -351,47 +444,61 @@ func TestMessageStreamChunksStoreFinalTask(t *testing.T) {
 	if ct := rr.Result().Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
 		t.Fatalf("content-type = %q, want text/event-stream", ct)
 	}
-	var events []struct {
-		Result Task      `json:"result"`
-		Error  *rpcError `json:"error"`
+	events := collectSSE(t, rr.Body.String())
+	// Opening Task snapshot + one append artifact-update per chunk + terminal
+	// status-update.
+	if len(events) != 4 {
+		t.Fatalf("events = %d, want 4; body %s", len(events), rr.Body.String())
 	}
-	for _, line := range strings.Split(strings.TrimSpace(rr.Body.String()), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		line = strings.TrimPrefix(line, "data: ")
-		var event struct {
-			Result Task      `json:"result"`
-			Error  *rpcError `json:"error"`
-		}
-		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			t.Fatalf("decode event %q: %v", line, err)
-		}
-		events = append(events, event)
-	}
-	if len(events) != 3 {
-		t.Fatalf("events = %d, want 3; body %s", len(events), rr.Body.String())
-	}
-	for i, event := range events {
-		if event.Error != nil {
-			t.Fatalf("event %d error: %+v", i, event.Error)
-		}
-		if event.Result.ID != events[0].Result.ID || event.Result.ContextID != events[0].Result.ContextID {
-			t.Fatalf("event %d changed task identity: %+v vs %+v", i, event.Result, events[0].Result)
+	for i, e := range events {
+		if e.Error != nil {
+			t.Fatalf("event %d carried an error field: %+v", i, e.Error)
 		}
 	}
-	if events[0].Result.Status.State != stateWorking || textOf(events[0].Result.Artifacts[0].Parts) != "po" {
-		t.Fatalf("first event = %+v, want working po", events[0].Result)
+	if events[0].kind() != "task" {
+		t.Fatalf("first event kind = %q, want task", events[0].kind())
 	}
-	final := events[len(events)-1].Result
-	if final.Status.State != stateCompleted || textOf(final.Artifacts[0].Parts) != "pong" {
-		t.Fatalf("final event = %+v, want completed pong", final)
+	opening := events[0].task(t)
+	if opening.Status.State != stateWorking {
+		t.Fatalf("opening task state = %q, want working", opening.Status.State)
+	}
+	taskID := opening.ID
+
+	// The middle events are append artifact-updates carrying the chunk deltas.
+	var text strings.Builder
+	for _, e := range events[1:3] {
+		if e.kind() != "artifact-update" {
+			t.Fatalf("event kind = %q, want artifact-update", e.kind())
+		}
+		au := e.artifactUpdate(t)
+		if !au.Append {
+			t.Fatalf("artifact-update should be append: %+v", au)
+		}
+		if au.TaskID != taskID {
+			t.Fatalf("artifact-update taskId = %q, want %q", au.TaskID, taskID)
+		}
+		text.WriteString(textOf(au.Artifact.Parts))
+	}
+	if text.String() != "pong" {
+		t.Fatalf("accumulated artifact text = %q, want pong", text.String())
 	}
 
-	got := rpcTaskFromDispatcher(t, d, final.ID)
-	if got.ID != final.ID || got.Status.State != stateCompleted || textOf(got.Artifacts[0].Parts) != "pong" {
-		t.Fatalf("stored task = %+v, want final", got)
+	// The stream closes with a terminal status-update (final:true).
+	last := events[len(events)-1]
+	if last.kind() != "status-update" {
+		t.Fatalf("last event kind = %q, want status-update", last.kind())
+	}
+	su := last.status(t)
+	if !su.Final || su.Status.State != stateCompleted {
+		t.Fatalf("terminal event = %+v, want final completed", su)
+	}
+	if su.TaskID != taskID {
+		t.Fatalf("terminal taskId = %q, want %q", su.TaskID, taskID)
+	}
+
+	got := rpcTaskFromDispatcher(t, d, taskID)
+	if got.ID != taskID || got.Status.State != stateCompleted || textOf(got.Artifacts[0].Parts) != "pong" {
+		t.Fatalf("stored task = %+v, want final completed pong", got)
 	}
 }
 
@@ -432,37 +539,31 @@ func TestMessageStreamChunksPropagatesCancellationAndClosesStream(t *testing.T) 
 		t.Fatal("stream was not closed")
 	}
 
-	var events []struct {
-		Result Task      `json:"result"`
-		Error  *rpcError `json:"error"`
+	events := collectSSE(t, rr.Body.String())
+	// Opening Task snapshot, then a terminal failed status-update.
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2; body %s", len(events), rr.Body.String())
 	}
-	for _, line := range strings.Split(strings.TrimSpace(rr.Body.String()), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
+	// A streaming failure must be a failed status-update, never `result` and
+	// `error` set together in one response.
+	for i, e := range events {
+		if e.Error != nil {
+			t.Fatalf("event %d carried an error field (result+error not allowed): %+v", i, e.Error)
 		}
-		line = strings.TrimPrefix(line, "data: ")
-		var event struct {
-			Result Task      `json:"result"`
-			Error  *rpcError `json:"error"`
-		}
-		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			t.Fatalf("decode event %q: %v", line, err)
-		}
-		events = append(events, event)
 	}
-	if len(events) != 1 {
-		t.Fatalf("events = %d, want 1; body %s", len(events), rr.Body.String())
+	if events[0].kind() != "task" || events[0].task(t).Status.State != stateWorking {
+		t.Fatalf("first event = %s, want working task", string(events[0].Result))
 	}
-	event := events[0]
-	if event.Error == nil || event.Error.Code != errInternal || event.Error.Message != context.Canceled.Error() {
-		t.Fatalf("error = %+v, want context cancellation", event.Error)
+	last := events[1]
+	if last.kind() != "status-update" {
+		t.Fatalf("last event kind = %q, want status-update", last.kind())
 	}
-	if event.Result.Status.State != stateFailed || textOf(event.Result.Artifacts[0].Parts) != "error: context canceled" {
-		t.Fatalf("failed task = %+v, want context cancellation artifact", event.Result)
+	su := last.status(t)
+	if !su.Final || su.Status.State != stateFailed {
+		t.Fatalf("terminal event = %+v, want final failed", su)
 	}
 
-	got := rpcTaskFromDispatcher(t, d, event.Result.ID)
+	got := rpcTaskFromDispatcher(t, d, su.TaskID)
 	if got.Status.State != stateFailed || textOf(got.Artifacts[0].Parts) != "error: context canceled" {
 		t.Fatalf("stored task = %+v, want failed cancellation", got)
 	}
@@ -493,33 +594,24 @@ func TestMessageStreamChunksFallsBackWhenUnsupported(t *testing.T) {
 	if ct := rr.Result().Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
 		t.Fatalf("content-type = %q, want text/event-stream", ct)
 	}
-	var events []struct {
-		Result Task      `json:"result"`
-		Error  *rpcError `json:"error"`
+	events := collectSSE(t, rr.Body.String())
+	// The non-streaming fallback emits a completed Task snapshot then a terminal
+	// status-update.
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2; body %s", len(events), rr.Body.String())
 	}
-	for _, line := range strings.Split(strings.TrimSpace(rr.Body.String()), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
+	for i, e := range events {
+		if e.Error != nil {
+			t.Fatalf("fallback event %d error: %+v", i, e.Error)
 		}
-		line = strings.TrimPrefix(line, "data: ")
-		var event struct {
-			Result Task      `json:"result"`
-			Error  *rpcError `json:"error"`
-		}
-		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			t.Fatalf("decode event %q: %v", line, err)
-		}
-		events = append(events, event)
 	}
-	if len(events) != 1 {
-		t.Fatalf("events = %d, want 1; body %s", len(events), rr.Body.String())
+	task := events[0].task(t)
+	if task.Status.State != stateCompleted || textOf(task.Artifacts[0].Parts) != "pong" {
+		t.Fatalf("fallback task = %+v, want completed pong", task)
 	}
-	if events[0].Error != nil {
-		t.Fatalf("fallback event error: %+v", events[0].Error)
-	}
-	if events[0].Result.Status.State != stateCompleted || textOf(events[0].Result.Artifacts[0].Parts) != "pong" {
-		t.Fatalf("fallback task = %+v, want completed pong", events[0].Result)
+	su := events[1].status(t)
+	if !su.Final || su.Status.State != stateCompleted {
+		t.Fatalf("terminal event = %+v, want final completed", su)
 	}
 }
 
@@ -535,30 +627,34 @@ func TestMessageStreamFallbackDoesNotCompleteWithEmptyText(t *testing.T) {
 		return nil, fmt.Errorf("%w: test provider", ai.ErrStreamingUnsupported)
 	})
 
-	var event struct {
-		Result Task      `json:"result"`
-		Error  *rpcError `json:"error"`
-	}
-	for _, line := range strings.Split(strings.TrimSpace(rr.Body.String()), "\n") {
-		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "data: "))
-		if line == "" {
-			continue
+	events := collectSSE(t, rr.Body.String())
+	var task Task
+	var foundTask bool
+	for _, e := range events {
+		if e.Error != nil {
+			t.Fatalf("fallback event error: %+v", e.Error)
 		}
-		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			t.Fatalf("decode event %q: %v", line, err)
+		if e.kind() == "task" {
+			task = e.task(t)
+			foundTask = true
 		}
 	}
-	if event.Error != nil {
-		t.Fatalf("fallback event error: %+v", event.Error)
+	if !foundTask {
+		t.Fatalf("no task event in stream; body %s", rr.Body.String())
 	}
-	if event.Result.Status.State != stateFailed {
-		t.Fatalf("fallback state = %q, want failed", event.Result.Status.State)
+	if task.Status.State != stateFailed {
+		t.Fatalf("fallback state = %q, want failed", task.Status.State)
 	}
-	if got := textOf(event.Result.Artifacts[0].Parts); got == "" {
-		t.Fatalf("fallback artifact text is empty: %+v", event.Result.Artifacts)
+	if got := textOf(task.Artifacts[0].Parts); got == "" {
+		t.Fatalf("fallback artifact text is empty: %+v", task.Artifacts)
 	}
-	if got := textOf(event.Result.History[len(event.Result.History)-1].Parts); got == "" {
-		t.Fatalf("fallback history text is empty: %+v", event.Result.History)
+	if got := textOf(task.History[len(task.History)-1].Parts); got == "" {
+		t.Fatalf("fallback history text is empty: %+v", task.History)
+	}
+	// The stream still ends with a terminal marker.
+	last := events[len(events)-1]
+	if last.kind() != "status-update" || !last.status(t).Final {
+		t.Fatalf("stream must end with a final status-update; got %s", string(last.Result))
 	}
 }
 

--- a/internal/harness/a2a-streaming/main.go
+++ b/internal/harness/a2a-streaming/main.go
@@ -166,7 +166,9 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	if summary.WorkingEvents == 0 || summary.State != "completed" || !strings.Contains(summary.FinalText, "a2a-stream-ok") {
+	// Spec-shaped stream: at least one artifact-update carrying the reassembled
+	// answer, terminating in a completed status-update with final:true.
+	if summary.ArtifactEvents == 0 || summary.State != "completed" || !summary.Final || !strings.Contains(summary.FinalText, "a2a-stream-ok") {
 		fmt.Fprintf(os.Stderr, "unexpected stream summary: %+v\npayload:\n%s", summary, summary.Payload)
 		os.Exit(1)
 	}
@@ -174,14 +176,16 @@ func main() {
 		fmt.Fprintf(os.Stderr, "tool=%v runInfo=%v\n", sawTool, sawRunInfo)
 		os.Exit(1)
 	}
-	fmt.Println("\n\033[32m✓ A2A message/stream emitted incremental task updates and preserved tool/run metadata\033[0m")
+	fmt.Println("\n\033[32m✓ A2A message/stream emitted spec-shaped artifact/status updates and preserved tool/run metadata\033[0m")
 }
 
 type streamSummary struct {
-	Payload       string
-	State         string
-	FinalText     string
-	WorkingEvents int
+	Payload        string
+	State          string
+	FinalText      string
+	Final          bool
+	ArtifactEvents int
+	WorkingEvents  int
 }
 
 func readSSESummary(r io.Reader) (streamSummary, error) {
@@ -197,14 +201,23 @@ func readSSESummary(r io.Reader) (streamSummary, error) {
 		}
 		var envelope struct {
 			Result struct {
+				Kind   string `json:"kind"`
+				Final  bool   `json:"final"`
 				Status struct {
 					State string `json:"state"`
 				} `json:"status"`
+				// Task snapshots carry artifacts (plural)...
 				Artifacts []struct {
 					Parts []struct {
 						Text string `json:"text"`
 					} `json:"parts"`
 				} `json:"artifacts"`
+				// ...artifact-update events carry a single artifact.
+				Artifact struct {
+					Parts []struct {
+						Text string `json:"text"`
+					} `json:"parts"`
+				} `json:"artifact"`
 			} `json:"result"`
 			Error any `json:"error"`
 		}
@@ -216,15 +229,34 @@ func readSSESummary(r io.Reader) (streamSummary, error) {
 		}
 		seen = true
 		summary.Payload += data + "\n"
-		if envelope.Result.Status.State == "working" {
-			summary.WorkingEvents++
-		}
-		if envelope.Result.Status.State != "" {
-			summary.State = envelope.Result.Status.State
-		}
-		for _, artifact := range envelope.Result.Artifacts {
-			for _, part := range artifact.Parts {
-				summary.FinalText = part.Text
+		switch envelope.Result.Kind {
+		case "artifact-update":
+			// Incremental deltas: reassemble the streamed answer.
+			summary.ArtifactEvents++
+			for _, part := range envelope.Result.Artifact.Parts {
+				summary.FinalText += part.Text
+			}
+		case "status-update":
+			if envelope.Result.Status.State != "" {
+				summary.State = envelope.Result.Status.State
+			}
+			if envelope.Result.Final {
+				summary.Final = true
+			}
+		default: // "task" snapshot
+			if envelope.Result.Status.State == "working" {
+				summary.WorkingEvents++
+			}
+			if envelope.Result.Status.State != "" {
+				summary.State = envelope.Result.Status.State
+			}
+			// The non-streaming path carries the full text in the snapshot.
+			for _, artifact := range envelope.Result.Artifacts {
+				for _, part := range artifact.Parts {
+					if part.Text != "" {
+						summary.FinalText = part.Text
+					}
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Closes #4815.

The A2A gateway worked go-micro-to-go-micro, but a real external client (ADK / LangGraph / a2a-SDK) would not interoperate. Three spec gaps, all fixed here:

**1. Discovery path.** Served the Agent Card at `/.well-known/agent.json`, but A2A spec 0.3.0 discovers it at `/.well-known/agent-card.json` — standard discovery 404'd. Now served at **both**, `agent-card.json` canonical and `agent.json` a legacy alias, at the per-agent, per-skill, and single-agent top-level locations.

**2. Streaming event shape.** `message/stream` emitted repeated full `Task` snapshots. External SSE clients parse events by `kind` and stop on the one whose `final` is true — a `Task` snapshot carries neither, so strict clients never terminate. The stream now opens with a `Task` snapshot (so the client learns the ids), emits `TaskArtifactUpdateEvent` (`kind:"artifact-update"`, `append:true`) deltas as the model streams, and closes with a `TaskStatusUpdateEvent` (`kind:"status-update"`, `final:true`). The non-streaming and `tasks/resubscribe` paths also close with a terminal `final:true` marker.

**3. `result` + `error` together.** A streaming error set both `result` and `error` in one JSON-RPC response (a spec violation strict clients reject). Now a streaming failure is a failed `status-update` with `final:true` — never both fields.

Internal task storage (for `tasks/get` and push/resubscribe watchers) is unchanged; only the wire shape of the SSE stream changed.

### Tests
- `TestAgentCardCanonicalWellKnownPath` — card reachable at `agent-card.json` (canonical), `agent.json` (alias), and the per-skill canonical path.
- `TestMessageStreamChunksStoreFinalTask` — stream is `task` → `artifact-update`(append) × N → `status-update`(final, completed); deltas reassemble to the reply; stored task is the completed one.
- `TestMessageStreamChunksPropagatesCancellationAndClosesStream` — a failure ends in a `status-update`(final, failed) and **no event carries an `error` field alongside a result**.
- `TestMessageStreamChunksFallsBackWhenUnsupported` / `...FallbackDoesNotCompleteWithEmptyText` — the non-streaming fallback still ends with a terminal `status-update`.

`go build ./...`, `go test ./gateway/a2a/...`, and `golangci-lint run ./gateway/a2a/...` pass.

### Note
A follow-up (needs-human) is a real cross-framework conformance test against an actual third-party A2A SDK — none exists in-repo today, so interop is still self-certified against the spec shapes. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_