### PR TITLE
loop: pause automatic runs while we do focused fixes

### DIFF
--- a/.github/workflows/loop-builder.yml
+++ b/.github/workflows/loop-builder.yml
@@ -14,8 +14,11 @@ name: "Loop: Builder"
 
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: "29 * * * *"
+  # PAUSED 2026-07-12: automatic schedule disabled while the team does focused
+  # 1:1 fixes. Still runnable on demand via workflow_dispatch. Re-enable by
+  # uncommenting the schedule below.
+  # schedule:
+  #   - cron: "29 * * * *"
 
 permissions:
   issues: write

--- a/.github/workflows/loop-coherence.yml
+++ b/.github/workflows/loop-coherence.yml
@@ -14,8 +14,11 @@ name: "Loop: Coherence"
 
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: "0 7 * * *"
+  # PAUSED 2026-07-12: automatic schedule disabled while the team does focused
+  # 1:1 fixes. Still runnable on demand via workflow_dispatch. Re-enable by
+  # uncommenting the schedule below.
+  # schedule:
+  #   - cron: "0 7 * * *"
 
 permissions:
   issues: write

--- a/.github/workflows/loop-planner.yml
+++ b/.github/workflows/loop-planner.yml
@@ -14,8 +14,11 @@ name: "Loop: Planner"
 
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: "59 * * * *"
+  # PAUSED 2026-07-12: automatic schedule disabled while the team does focused
+  # 1:1 fixes. Still runnable on demand via workflow_dispatch. Re-enable by
+  # uncommenting the schedule below.
+  # schedule:
+  #   - cron: "59 * * * *"
 
 permissions:
   issues: write

--- a/.github/workflows/loop-release.yml
+++ b/.github/workflows/loop-release.yml
@@ -12,8 +12,11 @@ name: "Loop: Release"
 
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: "0 23 * * *"
+  # PAUSED 2026-07-12: automatic nightly release disabled while the team does
+  # focused 1:1 fixes. Cut a release on demand via workflow_dispatch. Re-enable
+  # by uncommenting the schedule below.
+  # schedule:
+  #   - cron: "0 23 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/loop-security.yml
+++ b/.github/workflows/loop-security.yml
@@ -14,8 +14,11 @@ name: "Loop: Security"
 
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: "0 6 * * 1"
+  # PAUSED 2026-07-12: automatic schedule disabled while the team does focused
+  # 1:1 fixes. Still runnable on demand via workflow_dispatch. Re-enable by
+  # uncommenting the schedule below.
+  # schedule:
+  #   - cron: "0 6 * * 1"
 
 permissions:
   issues: write

--- a/.github/workflows/loop-triage.yml
+++ b/.github/workflows/loop-triage.yml
@@ -7,9 +7,13 @@ name: "Loop: Triage"
 # failures become fixes with no human in the middle. Gated on CODEX_TRIGGER_TOKEN.
 
 on:
-  workflow_run:
-    workflows: ["Harness (E2E)", "Lint", "Run Tests", "govulncheck"]
-    types: [completed]
+  workflow_dispatch: {}
+  # PAUSED 2026-07-12: automatic CI-failure dispatch disabled while the team
+  # does focused 1:1 fixes, so failures don't auto-spawn agent tasks. Re-enable
+  # by uncommenting the workflow_run trigger below.
+  # workflow_run:
+  #   workflows: ["Harness (E2E)", "Lint", "Run Tests", "govulncheck"]
+  #   types: [completed]
 
 permissions:
   issues: write


### PR DESCRIPTION
Pauses the autonomous loop while we land the current round of fixes 1:1, so it stops generating work and can't collide with our branches.

Comments out the automatic triggers on every loop workflow:

| Workflow | Was | Now |
|----------|-----|-----|
| planner | hourly `59 * * * *` | manual only |
| builder | hourly `29 * * * *` | manual only |
| coherence | daily `0 7 * * *` | manual only |
| security | weekly `0 6 * * 1` | manual only |
| release | nightly `0 23 * * *` | manual only |
| triage | `workflow_run` on CI completion (auto-dispatches agent tasks on failure) | manual only |

Each keeps `workflow_dispatch`, so any loop can still be **run on demand**, and re-enabling is just uncommenting the trigger. No prompts, tokens, or job logic changed — only *when* the workflows fire.

**Note:** scheduled / `workflow_run` triggers run from the **default branch**, so this pause only takes effect once merged to `master`. (For an instant, zero-code pause, a repo admin can also just toggle each workflow off in the Actions tab — this PR is the durable, in-repo version.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_