### PR TITLE
a2a: guard push-notification callbacks against SSRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ below is kept current between tags and rolled into the next version when it ship
 
 ### Security
 - **x402 spend-cap hardening** — the paying `Client` now refuses a 402 whose `maxAmountRequired` is not a positive integer (a swallowed parse error or negative amount previously bypassed the budget cap), and a new `Config.RequireSettlement` fails closed when a paid request is served by a verify-only facilitator that never captures funds. (`wrapper/x402/`)
+- **A2A push-notification SSRF guard** — the A2A gateway no longer delivers task push notifications to caller-supplied URLs that resolve to loopback, private, link-local (incl. cloud metadata), or unspecified addresses. Callbacks are validated when set and re-checked at dial time on the resolved IP (DNS-rebinding safe); non-http(s) schemes are rejected. `Options.AllowPushURL` (and `a2a.WithPushURLPolicy` for embedded handlers) lets operators authorize trusted in-cluster receivers. (`gateway/a2a/`)
 
 ---
 

--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -33,6 +33,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -64,6 +65,14 @@ type Options struct {
 	Client client.Client
 	// Logger for startup/debug output (defaults to log.Default()).
 	Logger *log.Logger
+	// AllowPushURL authorizes an outbound push-notification callback URL
+	// (tasks/pushNotificationConfig/set). Return a non-nil error to reject it.
+	// When nil, a default SSRF-safe policy applies: only http/https URLs whose
+	// host does not resolve to a loopback, private, link-local, or unspecified
+	// address are allowed, and the connection is pinned to that check at dial
+	// time (DNS-rebinding safe). Set this to permit a trusted in-cluster
+	// receiver, or to narrow delivery to an allowlist.
+	AllowPushURL func(*url.URL) error
 }
 
 // Gateway serves the A2A protocol over HTTP for the registry's agents.
@@ -87,7 +96,14 @@ func New(opts Options) *Gateway {
 		opts.BaseURL = "http://localhost" + opts.Address
 	}
 	opts.BaseURL = strings.TrimRight(opts.BaseURL, "/")
-	return &Gateway{opts: opts, disp: newDispatcher()}
+	g := &Gateway{opts: opts, disp: newDispatcher()}
+	if opts.AllowPushURL != nil {
+		// Operator owns the trust decision: use their policy and skip the
+		// built-in private-IP dial guard so trusted in-cluster hosts resolve.
+		g.disp.allowPushURL = opts.AllowPushURL
+		g.disp.guardPushDial = false
+	}
+	return g
 }
 
 // Invoke runs an agent for one message and returns its reply. It is the
@@ -98,12 +114,33 @@ type Invoke func(ctx context.Context, text string) (string, error)
 // StreamInvoke runs an agent for one message and returns streaming output chunks.
 type StreamInvoke func(ctx context.Context, text string) (ai.Stream, error)
 
+// AgentHandlerOption configures an embedded A2A agent handler.
+type AgentHandlerOption func(*dispatcher)
+
+// WithPushURLPolicy sets the push-notification callback URL policy for an
+// embedded agent handler (the analog of Options.AllowPushURL on the gateway).
+// Return a non-nil error to reject a URL. Without it, the default SSRF-safe
+// policy applies. Supplying a policy also disables the built-in private-IP dial
+// guard, so a trusted in-cluster receiver resolves.
+func WithPushURLPolicy(allow func(*url.URL) error) AgentHandlerOption {
+	return func(d *dispatcher) {
+		if allow == nil {
+			return
+		}
+		d.allowPushURL = allow
+		d.guardPushDial = false
+	}
+}
+
 // NewAgentHandler returns an http.Handler that serves the A2A protocol
 // for a single agent: its Agent Card at / and /.well-known/agent.json,
 // and the JSON-RPC endpoint at /. invoke runs the agent. This is what an
 // agent embeds to speak A2A directly, without a separate gateway.
-func NewAgentHandler(card AgentCard, invoke Invoke) http.Handler {
+func NewAgentHandler(card AgentCard, invoke Invoke, opts ...AgentHandlerOption) http.Handler {
 	d := newDispatcher()
+	for _, o := range opts {
+		o(d)
+	}
 	mux := http.NewServeMux()
 	card.URL = strings.TrimRight(card.URL, "/")
 	serveCard := func(w http.ResponseWriter, _ *http.Request) { writeJSON(w, http.StatusOK, card) }
@@ -118,8 +155,11 @@ func NewAgentHandler(card AgentCard, invoke Invoke) http.Handler {
 
 // NewAgentStreamHandler is like NewAgentHandler, but serves A2A message/stream
 // by forwarding model chunks as server-sent task updates when stream is non-nil.
-func NewAgentStreamHandler(card AgentCard, invoke Invoke, stream StreamInvoke) http.Handler {
+func NewAgentStreamHandler(card AgentCard, invoke Invoke, stream StreamInvoke, opts ...AgentHandlerOption) http.Handler {
 	d := newDispatcher()
+	for _, o := range opts {
+		o(d)
+	}
 	mux := http.NewServeMux()
 	card.URL = strings.TrimRight(card.URL, "/")
 	serveCard := func(w http.ResponseWriter, _ *http.Request) { writeJSON(w, http.StatusOK, card) }
@@ -510,10 +550,22 @@ type dispatcher struct {
 	pushConfigs map[string]PushNotificationConfig
 	watchers    map[string]map[chan *Task]struct{}
 	order       []string // task ids in insertion order, for bounded eviction
+
+	// allowPushURL authorizes an outbound push-notification callback URL; nil
+	// means the default SSRF-safe policy. guardPushDial applies the private-IP
+	// dial guard (on unless an operator supplied a custom policy).
+	allowPushURL  func(*url.URL) error
+	guardPushDial bool
 }
 
 func newDispatcher() *dispatcher {
-	return &dispatcher{tasks: map[string]*Task{}, pushConfigs: map[string]PushNotificationConfig{}, watchers: map[string]map[chan *Task]struct{}{}}
+	return &dispatcher{
+		tasks:         map[string]*Task{},
+		pushConfigs:   map[string]PushNotificationConfig{},
+		watchers:      map[string]map[chan *Task]struct{}{},
+		allowPushURL:  defaultPushURLPolicy,
+		guardPushDial: true,
+	}
 }
 
 func (d *dispatcher) serve(w http.ResponseWriter, r *http.Request, invoke Invoke) {
@@ -751,6 +803,11 @@ func (d *dispatcher) setPushConfig(w http.ResponseWriter, req rpcRequest) {
 		writeRPC(w, req.ID, nil, &rpcError{Code: errInvalidParams, Message: "invalid params"})
 		return
 	}
+	// Reject SSRF-unsafe callback targets before storing them.
+	if err := d.checkPushURL(p.PushNotificationConfig.URL); err != nil {
+		writeRPC(w, req.ID, nil, &rpcError{Code: errInvalidParams, Message: "push notification url not allowed"})
+		return
+	}
 	d.mu.Lock()
 	task := d.tasks[p.ID]
 	if task != nil {
@@ -919,6 +976,11 @@ func (d *dispatcher) deliverPush(taskID string, task *Task) {
 	if !ok || cfg.URL == "" || task == nil {
 		return
 	}
+	// Defense in depth: re-validate the callback URL at delivery time in case
+	// the policy tightened or the config was set before it applied.
+	if err := d.checkPushURL(cfg.URL); err != nil {
+		return
+	}
 	body, err := json.Marshal(task)
 	if err != nil {
 		return
@@ -933,7 +995,7 @@ func (d *dispatcher) deliverPush(taskID string, task *Task) {
 	if cfg.Token != "" {
 		req.Header.Set("Authorization", "Bearer "+cfg.Token)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := d.pushClient().Do(req)
 	if err == nil && resp.Body != nil {
 		_ = resp.Body.Close()
 	}

--- a/gateway/a2a/a2a_test.go
+++ b/gateway/a2a/a2a_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -223,6 +224,10 @@ func TestMessageSendContinuesExistingTask(t *testing.T) {
 
 func TestPushNotificationConfigDeliversTaskUpdates(t *testing.T) {
 	d := newDispatcher()
+	// The test receiver is a loopback httptest server; authorize it the way a
+	// deployment would authorize a trusted in-cluster push receiver.
+	d.allowPushURL = func(*url.URL) error { return nil }
+	d.guardPushDial = false
 	updates := make(chan Task, 2)
 	push := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer secret" {

--- a/gateway/a2a/client_test.go
+++ b/gateway/a2a/client_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -56,9 +57,11 @@ func TestClientSendAndCard(t *testing.T) {
 
 func TestClientContinuesTaskAndConfiguresPush(t *testing.T) {
 	card := Card("solo", "http://localhost:4000", "", []string{"task"})
+	// The push receiver below is a loopback test server; authorize it as a
+	// deployment would authorize its trusted push receiver.
 	h := NewAgentHandler(card, func(_ context.Context, text string) (string, error) {
 		return "echo:" + text, nil
-	})
+	}, WithPushURLPolicy(func(*url.URL) error { return nil }))
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 

--- a/gateway/a2a/pushsecurity.go
+++ b/gateway/a2a/pushsecurity.go
@@ -1,0 +1,131 @@
+package a2a
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"syscall"
+	"time"
+)
+
+// Push-notification callbacks are the one place the A2A gateway makes an
+// outbound HTTP request to an address chosen by a (possibly untrusted) caller:
+// tasks/pushNotificationConfig/set records a URL and deliverPush POSTs task
+// state to it. Without a guard that is a server-side request forgery vector —
+// a caller can aim the gateway at loopback, link-local (cloud metadata), or
+// private hosts it would otherwise never reach.
+//
+// The default policy allows only http/https callbacks whose host does not
+// resolve to a loopback, private, link-local, or unspecified address, and the
+// guarded HTTP client re-checks the *resolved* IP at dial time so a hostname
+// that passes validation cannot be rebound to an internal address before the
+// connection is made. Operators who need to reach a trusted in-cluster
+// receiver set Options.AllowPushURL to take over the policy.
+
+// pushLookupIP resolves a host to IPs; overridable in tests.
+var pushLookupIP = net.LookupIP
+
+// defaultPushURLPolicy is the SSRF-safe policy applied when no AllowPushURL is
+// configured. It rejects non-http(s) schemes and hosts that resolve to a
+// loopback, private, link-local, multicast, or unspecified address.
+func defaultPushURLPolicy(u *url.URL) error {
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return fmt.Errorf("push callback scheme %q not allowed (want http or https)", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("push callback url has no host")
+	}
+	ips, err := resolvePushHost(host)
+	if err != nil {
+		return fmt.Errorf("push callback host %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("push callback host %q did not resolve", host)
+	}
+	for _, ip := range ips {
+		if blockedPushIP(ip) {
+			return fmt.Errorf("push callback host %q resolves to a blocked address %s", host, ip)
+		}
+	}
+	return nil
+}
+
+func resolvePushHost(host string) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IP{ip}, nil
+	}
+	return pushLookupIP(host)
+}
+
+// blockedPushIP reports whether ip is one an outbound push callback must not
+// reach: loopback, private (RFC1918 / ULA), link-local (incl. 169.254.169.254
+// cloud metadata), multicast, or the unspecified address.
+func blockedPushIP(ip net.IP) bool {
+	return ip == nil ||
+		ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified()
+}
+
+// pushDialControl runs after DNS resolution, immediately before connect, on the
+// resolved address — so it blocks a host that passed URL validation but was
+// rebound to an internal IP (DNS rebinding).
+func pushDialControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("push callback: cannot parse dial address %q", address)
+	}
+	if blockedPushIP(ip) {
+		return fmt.Errorf("push callback: refusing to connect to blocked address %s", ip)
+	}
+	return nil
+}
+
+// pushGuardClient is the HTTP client used for default-policy push delivery. Its
+// dialer refuses connections to blocked addresses at connect time.
+var pushGuardClient = &http.Client{
+	Timeout: 10 * time.Second,
+	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout: 5 * time.Second,
+			Control: pushDialControl,
+		}).DialContext,
+	},
+}
+
+// checkPushURL validates a callback URL against the dispatcher's effective
+// policy (Options.AllowPushURL, or the default SSRF-safe policy).
+func (d *dispatcher) checkPushURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid push callback url: %w", err)
+	}
+	policy := d.allowPushURL
+	if policy == nil {
+		policy = defaultPushURLPolicy
+	}
+	return policy(u)
+}
+
+// pushClient is the HTTP client deliverPush uses: the guarded client under the
+// default policy, or the default client when an operator has taken over the
+// policy via Options.AllowPushURL (they own the trust decision then).
+func (d *dispatcher) pushClient() *http.Client {
+	if d.guardPushDial {
+		return pushGuardClient
+	}
+	return http.DefaultClient
+}

--- a/gateway/a2a/pushsecurity_test.go
+++ b/gateway/a2a/pushsecurity_test.go
@@ -1,0 +1,147 @@
+package a2a
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestDefaultPushURLPolicy(t *testing.T) {
+	// Resolve test hostnames deterministically without real DNS.
+	orig := pushLookupIP
+	pushLookupIP = func(host string) ([]net.IP, error) {
+		switch host {
+		case "internal.example":
+			return []net.IP{net.ParseIP("10.1.2.3")}, nil
+		case "public.example":
+			return []net.IP{net.ParseIP("93.184.216.34")}, nil
+		case "rebind.example":
+			// A host that resolves to both a public and an internal IP must be
+			// rejected — any blocked address is disqualifying.
+			return []net.IP{net.ParseIP("93.184.216.34"), net.ParseIP("127.0.0.1")}, nil
+		}
+		return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+	}
+	defer func() { pushLookupIP = orig }()
+
+	blocked := []string{
+		"http://127.0.0.1/hook",              // loopback
+		"http://169.254.169.254/latest/meta", // cloud metadata (link-local)
+		"http://10.0.0.5/hook",               // RFC1918
+		"http://[::1]/hook",                  // IPv6 loopback
+		"http://[fd00::1]/hook",              // IPv6 ULA (private)
+		"http://0.0.0.0/hook",                // unspecified
+		"http://internal.example/hook",       // hostname → private
+		"http://rebind.example/hook",         // one internal IP among many
+		"ftp://public.example/hook",          // non-http(s) scheme
+		"file:///etc/passwd",                 // scheme
+		"http:///nohost",                     // no host
+	}
+	for _, raw := range blocked {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("parse %q: %v", raw, err)
+		}
+		if err := defaultPushURLPolicy(u); err == nil {
+			t.Errorf("defaultPushURLPolicy(%q) = nil, want blocked", raw)
+		}
+	}
+
+	allowed := []string{
+		"http://93.184.216.34/hook",   // public literal IP
+		"https://public.example/hook", // hostname → public
+	}
+	for _, raw := range allowed {
+		u, _ := url.Parse(raw)
+		if err := defaultPushURLPolicy(u); err != nil {
+			t.Errorf("defaultPushURLPolicy(%q) = %v, want allowed", raw, err)
+		}
+	}
+}
+
+func TestPushDialControlBlocksPrivate(t *testing.T) {
+	blocked := []string{"127.0.0.1:80", "169.254.169.254:80", "10.0.0.1:443", "[::1]:80", "0.0.0.0:80"}
+	for _, addr := range blocked {
+		if err := pushDialControl("tcp", addr, nil); err == nil {
+			t.Errorf("pushDialControl(%q) = nil, want blocked", addr)
+		}
+	}
+	if err := pushDialControl("tcp", "8.8.8.8:443", nil); err != nil {
+		t.Errorf("pushDialControl(public) = %v, want allowed", err)
+	}
+}
+
+// TestSetPushConfigRejectsSSRFURL: an untrusted caller cannot register a
+// callback pointing at an internal address — it is refused and nothing stored.
+func TestSetPushConfigRejectsSSRFURL(t *testing.T) {
+	d := newDispatcher()
+	d.store(&Task{ID: "t1", ContextID: "c1", Status: TaskStatus{State: stateCompleted}})
+
+	params, _ := json.Marshal(map[string]any{
+		"id":                     "t1",
+		"pushNotificationConfig": map[string]any{"url": "http://169.254.169.254/latest/meta-data"},
+	})
+	rr := httptest.NewRecorder()
+	d.setPushConfig(rr, rpcRequest{JSONRPC: "2.0", ID: json.RawMessage("1"), Params: params})
+
+	var resp rpcResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Error == nil || resp.Error.Code != errInvalidParams {
+		t.Fatalf("response = %+v, want invalid-params rejection", resp)
+	}
+	d.mu.Lock()
+	_, stored := d.pushConfigs["t1"]
+	d.mu.Unlock()
+	if stored {
+		t.Error("SSRF callback url must not be stored")
+	}
+}
+
+// TestDeliverPushBlocksInternalByDefault: even if a config for an internal URL
+// slips into the map, deliverPush must not POST to it under the default policy.
+func TestDeliverPushBlocksInternalByDefault(t *testing.T) {
+	var hit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { hit = true }))
+	defer srv.Close() // srv.URL is http://127.0.0.1:PORT — loopback, must be blocked
+
+	d := newDispatcher()
+	task := &Task{ID: "t1", Status: TaskStatus{State: stateCompleted}}
+	d.pushConfigs["t1"] = PushNotificationConfig{URL: srv.URL}
+
+	d.deliverPush("t1", task)
+	if hit {
+		t.Error("deliverPush reached a loopback callback under the default policy")
+	}
+}
+
+// TestAllowPushURLOverrideDelivers: an operator policy can authorize a trusted
+// (here loopback) receiver, and delivery then goes through.
+func TestAllowPushURLOverrideDelivers(t *testing.T) {
+	done := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") == "application/json" {
+			done <- struct{}{}
+		}
+	}))
+	defer srv.Close()
+
+	g := New(Options{AllowPushURL: func(*url.URL) error { return nil }})
+	d := g.disp
+	if d.guardPushDial {
+		t.Fatal("custom AllowPushURL should disable the dial guard")
+	}
+	task := &Task{ID: "t1", Status: TaskStatus{State: stateCompleted}}
+	d.pushConfigs["t1"] = PushNotificationConfig{URL: srv.URL}
+
+	d.deliverPush("t1", task)
+	select {
+	case <-done:
+	default:
+		t.Error("operator-authorized callback was not delivered")
+	}
+}


### PR DESCRIPTION
Closes #4129.

## Problem
The A2A gateway's push-notification flow is the one place it makes an outbound HTTP request to a **caller-supplied** address: `tasks/pushNotificationConfig/set` records a URL and `deliverPush` POSTs task state to it via the default HTTP client. With no guard, an untrusted A2A caller can point the gateway at addresses it would otherwise never reach (loopback, link-local, private ranges) — a server-side request forgery vector, and the risk flagged in #4129.

## Fix
A default SSRF-safe policy, defense-in-depth at two layers:

- **Validated when set** — `setPushConfig` rejects a callback whose scheme isn't http/https, or whose host resolves to a loopback, private (RFC1918/ULA), link-local (incl. the cloud-metadata range), multicast, or unspecified address. The caller gets a clear `invalid params` rejection and nothing is stored.
- **Re-checked at delivery, pinned at dial time** — `deliverPush` re-validates, and the delivery client's dialer inspects the *resolved* IP immediately before connect and refuses blocked addresses. That closes the gap between name-validation and connection (DNS rebinding): a hostname that passed validation can't be swapped to an internal IP before the socket opens.

## Operator override
Legitimate deployments sometimes push to a trusted in-cluster receiver. `Options.AllowPushURL func(*url.URL) error` (gateway) and `a2a.WithPushURLPolicy(...)` (embedded `NewAgentHandler`/`NewAgentStreamHandler`) let the operator own the policy; supplying one hands them the trust decision and skips the built-in private-IP dial guard by design. Both are additive and backward-compatible (variadic option; default behavior unchanged for existing callers, except that unconfigured callbacks to internal IPs are now refused).

## Tests
- `TestDefaultPushURLPolicy` — blocked (loopback, metadata range, RFC1918, IPv6 loopback/ULA, unspecified, private-resolving hostname, mixed public+internal DNS, non-http(s) scheme, no-host) vs allowed (public literal IP, public hostname).
- `TestPushDialControlBlocksPrivate` — the dial-time guard rejects private/loopback/link-local/unspecified and permits public.
- `TestSetPushConfigRejectsSSRFURL` — an internal-target config is refused and not stored.
- `TestDeliverPushBlocksInternalByDefault` — a config that bypasses set-time validation still isn't delivered to a loopback target.
- `TestAllowPushURLOverrideDelivers` — an operator policy authorizes a trusted receiver and delivery proceeds.

`go build ./...`, `go test -race ./gateway/a2a/...`, `go vet`, and `golangci-lint run ./gateway/a2a/...` pass. No other in-repo caller configures push delivery, so nothing else is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_