### PR TITLE
a2a: verify inbound AP2 mandates into the paid path (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ below is kept current between tags and rolled into the next version when it ship
 - **Model retry jitter controls** — model retry behavior can now use jitter controls to reduce synchronized retry bursts. (`ai/`, `agent/`)
 - **Compacted memory summaries** — agent memory now exposes compacted run summaries for easier inspection and recovery. (`agent/`)
 - **CLI input resume for agent runs** — the CLI can resume agent runs that require additional user input. (`cmd/micro/`, `agent/`)
+- **A2A inbound AP2 mandate verification (opt-in)** — set `Options.AP2PublicKey` (or `a2a.WithPushURLPolicy`'s sibling `a2a.WithAP2PublicKey` for embedded handlers) and the gateway verifies AP2 payment/checkout mandates carried on incoming messages — signature and task/context binding — recording the outcome in each task's `ap2Verifications`, with the x402 settlement rail carried through for the paid path. Off by default; mandates are otherwise carried unverified. (`gateway/a2a/`)
 
 ### Changed
 - **Remote agent chat streaming** — `micro chat` now streams replies from remote agents instead of waiting for the full response. (`cmd/micro/`, `agent/`)

--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -27,6 +27,7 @@ package a2a
 
 import (
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -73,6 +74,12 @@ type Options struct {
 	// time (DNS-rebinding safe). Set this to permit a trusted in-cluster
 	// receiver, or to narrow delivery to an allowlist.
 	AllowPushURL func(*url.URL) error
+	// AP2PublicKey, when set, verifies AP2 payment/checkout mandates carried on
+	// incoming A2A messages against this Ed25519 key and records the outcome in
+	// each task's ap2Verifications (signature + task/context binding). When
+	// unset, mandates are carried through unverified. This is opt-in so the
+	// default flow stays free of a payment trust decision.
+	AP2PublicKey ed25519.PublicKey
 }
 
 // Gateway serves the A2A protocol over HTTP for the registry's agents.
@@ -103,6 +110,12 @@ func New(opts Options) *Gateway {
 		g.disp.allowPushURL = opts.AllowPushURL
 		g.disp.guardPushDial = false
 	}
+	if len(opts.AP2PublicKey) > 0 {
+		pub := opts.AP2PublicKey
+		g.disp.ap2Verify = func(s AP2SignedMandate, task Task) AP2Verification {
+			return VerifyAP2ForTask(s, pub, task, nil)
+		}
+	}
 	return g
 }
 
@@ -129,6 +142,21 @@ func WithPushURLPolicy(allow func(*url.URL) error) AgentHandlerOption {
 		}
 		d.allowPushURL = allow
 		d.guardPushDial = false
+	}
+}
+
+// WithAP2PublicKey verifies AP2 mandates carried on incoming messages against
+// pub (the embedded-handler analog of Options.AP2PublicKey), recording the
+// outcome in each task's ap2Verifications. Without it, mandates are carried
+// unverified.
+func WithAP2PublicKey(pub ed25519.PublicKey) AgentHandlerOption {
+	return func(d *dispatcher) {
+		if len(pub) == 0 {
+			return
+		}
+		d.ap2Verify = func(s AP2SignedMandate, task Task) AP2Verification {
+			return VerifyAP2ForTask(s, pub, task, nil)
+		}
 	}
 }
 
@@ -556,6 +584,10 @@ type dispatcher struct {
 	// dial guard (on unless an operator supplied a custom policy).
 	allowPushURL  func(*url.URL) error
 	guardPushDial bool
+
+	// ap2Verify, when non-nil, verifies each AP2 mandate carried on a task and
+	// records the result in the task's AP2Verifications. Nil = carry unverified.
+	ap2Verify func(AP2SignedMandate, Task) AP2Verification
 }
 
 func newDispatcher() *dispatcher {
@@ -863,6 +895,15 @@ func (g *Gateway) callAgent(ctx context.Context, name, message string) (string, 
 // ---------------------------------------------------------------------------
 
 func (d *dispatcher) store(t *Task) {
+	// Verify any AP2 mandates carried on the task (opt-in) and surface the
+	// outcome so a downstream paid path can trust — or reject — the mandate.
+	if d.ap2Verify != nil && len(t.AP2Mandates) > 0 && len(t.AP2Verifications) == 0 {
+		v := make([]AP2Verification, 0, len(t.AP2Mandates))
+		for _, m := range t.AP2Mandates {
+			v = append(v, d.ap2Verify(m, *t))
+		}
+		t.AP2Verifications = v
+	}
 	d.mu.Lock()
 	_, exists := d.tasks[t.ID]
 	d.tasks[t.ID] = t

--- a/gateway/a2a/ap2_test.go
+++ b/gateway/a2a/ap2_test.go
@@ -1,7 +1,10 @@
 package a2a
 
 import (
+	"context"
 	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +50,83 @@ func TestAP2PaymentMandateX402RailReference(t *testing.T) {
 	got := VerifyAP2ForTask(signed, pub, task, &rail)
 	if !got.Verified {
 		t.Fatalf("expected x402 rail to verify, got %+v", got)
+	}
+}
+
+// TestAP2GatewayVerifiesInboundPaymentMandate drives a real A2A message/send
+// carrying a signed x402 payment mandate through the gateway and asserts the
+// mandate is verified (and the x402 rail carried) into the task a paid path
+// consults — and that a tampered mandate is surfaced as unverified.
+func TestAP2GatewayVerifiesInboundPaymentMandate(t *testing.T) {
+	pub, priv := testAP2Key(t)
+	d := newDispatcher()
+	d.ap2Verify = func(s AP2SignedMandate, task Task) AP2Verification {
+		return VerifyAP2ForTask(s, pub, task, nil)
+	}
+	invoke := func(context.Context, string) (string, error) { return "fetched", nil }
+
+	send := func(t *testing.T, mandate AP2SignedMandate) Task {
+		t.Helper()
+		msg := AP2AttachMandate(
+			Message{Role: "user", Kind: "message", MessageID: "m1", Parts: []Part{{Kind: "text", Text: "pay and fetch"}}},
+			mandate,
+		)
+		params, err := json.Marshal(sendParams{Message: msg})
+		if err != nil {
+			t.Fatal(err)
+		}
+		body := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"message/send","params":%s}`, params)
+		return rpcTaskFromBody(t, d, body, invoke)
+	}
+
+	rail := X402AP2Rail("payreq_777")
+	good, err := SignAP2Mandate(AP2Mandate{ID: "pay-1", Kind: AP2PaymentMandate, Rail: &rail, IssuedAt: time.Unix(1, 0).UTC()}, "k", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	task := send(t, good)
+	if len(task.AP2Verifications) != 1 || !task.AP2Verifications[0].Verified {
+		t.Fatalf("inbound payment mandate not verified: %+v", task.AP2Verifications)
+	}
+	if task.AP2Verifications[0].Kind != string(AP2PaymentMandate) {
+		t.Errorf("verification kind = %q, want payment", task.AP2Verifications[0].Kind)
+	}
+	if len(task.AP2Mandates) != 1 || task.AP2Mandates[0].Mandate.Rail == nil ||
+		task.AP2Mandates[0].Mandate.Rail.Type != "x402" || task.AP2Mandates[0].Mandate.Rail.Reference != "payreq_777" {
+		t.Fatalf("x402 settlement rail not carried onto task: %+v", task.AP2Mandates)
+	}
+
+	tampered := good
+	tampered.Mandate.Amount = "999.00"
+	bad := send(t, tampered)
+	if len(bad.AP2Verifications) != 1 || bad.AP2Verifications[0].Verified {
+		t.Fatalf("tampered mandate should be unverified: %+v", bad.AP2Verifications)
+	}
+	if !strings.Contains(bad.AP2Verifications[0].Error, "signature") {
+		t.Errorf("tampered verification error = %q, want signature failure", bad.AP2Verifications[0].Error)
+	}
+}
+
+// TestAP2CarriedUnverifiedWithoutKey confirms the default (no configured key)
+// is unchanged: mandates are carried but not verified.
+func TestAP2CarriedUnverifiedWithoutKey(t *testing.T) {
+	_, priv := testAP2Key(t)
+	d := newDispatcher() // no ap2Verify configured
+	rail := X402AP2Rail("payreq_1")
+	signed, err := SignAP2Mandate(AP2Mandate{ID: "pay-1", Kind: AP2PaymentMandate, Rail: &rail, IssuedAt: time.Unix(1, 0).UTC()}, "k", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := AP2AttachMandate(Message{Role: "user", Kind: "message", MessageID: "m1", Parts: []Part{{Kind: "text", Text: "x"}}}, signed)
+	params, _ := json.Marshal(sendParams{Message: msg})
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"message/send","params":%s}`, params)
+	task := rpcTaskFromBody(t, d, body, func(context.Context, string) (string, error) { return "ok", nil })
+	if len(task.AP2Mandates) != 1 {
+		t.Fatalf("mandate should still be carried: %+v", task.AP2Mandates)
+	}
+	if len(task.AP2Verifications) != 0 {
+		t.Errorf("no verifications without a configured key, got %+v", task.AP2Verifications)
 	}
 }
 


### PR DESCRIPTION
Addresses the remaining gap in #4841.

## State before this PR
The AP2 foundation (`gateway/a2a/ap2.go`) already existed and is well-tested — so **criterion #1 of #4841 was already met**:
- Checkout + Payment mandate types, `NewAP2Keypair` / `SignAP2Mandate` / `VerifyAP2Mandate` (Ed25519), `X402AP2Rail` for the x402 rail reference, `AP2AttachMandate` to carry a mandate on an A2A message, and distinct tamper failures (signature / task-binding / rail) in `ap2_test.go`.

The gap was **criterion #2** ("an A2A request carrying mandate metadata into a paid-tool path"): the dispatcher only *carried* mandates onto the task (`AP2Mandates`) and **never verified them** — `AP2Verifications` was never populated and there was no verifier hook, so a downstream paid path had no trust signal and a forged mandate was accepted as readily as a real one.

## Change
Opt-in inbound verification:
- `Options.AP2PublicKey ed25519.PublicKey` (gateway) and `a2a.WithAP2PublicKey(pub)` (embedded `NewAgentHandler`/`NewAgentStreamHandler`). When set, each mandate carried on a task is verified (signature + task/context binding) as the task flows through `store`, and the outcome is recorded in `task.AP2Verifications`. The x402 settlement rail rides along on the mandate for the paid path to consult.
- **Off by default** — with no key configured, mandates are carried unverified exactly as before, so no payment trust decision enters the default flow.

## Tests
- `TestAP2GatewayVerifiesInboundPaymentMandate` — a real `message/send` carrying a signed x402 payment mandate is verified end-to-end (`ap2Verifications[0].Verified`, kind `payment`, x402 rail `payreq_777` carried onto the task); a tampered copy is surfaced as **unverified** with a signature error, not silently accepted.
- `TestAP2CarriedUnverifiedWithoutKey` — default path unchanged: mandate carried, no verifications.

`go build ./...`, `go test ./gateway/a2a/...`, `go vet`, `golangci-lint` pass.

## Deferred (flagging for your call on whether #4841 fully closes)
This wires verification *through the A2A request* and surfaces the verified x402 rail on the task. Actually **driving an x402 settlement from that verified rail** inside a tool call belongs with the buyer/agent wiring (#4786 territory) — I left it out to keep this focused and the default flow unchanged. If you'd like #4841 to encompass that settlement step, I'll do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_