### PR TITLE
website: build at canonical root baseURL, not the Pages subpath

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -54,7 +54,14 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
       - name: Build site
-        run: hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+        # go-micro.dev is served by an nginx proxy that maps `/` to
+        # micro.github.io/go-micro/ (see the deploy nginx.conf). The site must
+        # therefore be built at its canonical ROOT baseURL — not the Pages
+        # project subpath from configure-pages (https://micro.github.io/go-micro/).
+        # Building at the subpath prefixes every asset/link with /go-micro/, which
+        # becomes /go-micro/go-micro/ through the proxy and 404s, leaving the site
+        # unstyled. hugo.yaml already declares baseURL: https://go-micro.dev/.
+        run: hugo --gc --minify --baseURL "https://go-micro.dev/"
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Fixes the unstyled live site after the Hugo/Docsy migration (#4858).

## Root cause
`go-micro.dev` is served by an **nginx proxy** that maps `/` → `micro.github.io/go-micro/` (per the deploy `nginx.conf`: `proxy_pass https://micro.github.io/go-micro/;`). The old Jekyll site was therefore built at **root** (`baseurl: ""`, `url: https://go-micro.dev`).

But the deploy workflow built Hugo with `--baseURL "${{ steps.pages.outputs.base_url }}/"`, which for this project repo resolves to `https://micro.github.io/go-micro/`. That bakes a `/go-micro/` prefix into every asset and link. The served `<head>` contains:

```html
<link href=/go-micro/scss/main.min.<hash>.css rel=stylesheet …>
```

Through the proxy, `go-micro.dev/go-micro/scss/…` maps to `micro.github.io/go-micro/**go-micro**/scss/…` → **404**, so no CSS loads and the site renders unstyled (same for favicons, the logo, nav links, and canonical/OG URLs).

## Verification (live)
| Request | Result |
|---|---|
| `micro.github.io/go-micro/scss/main…css` (asset exists) | **200** |
| `go-micro.dev/go-micro/scss/main…css` (current baked path via proxy) | **404** ← the bug |
| `go-micro.dev/scss/main…css` (what this fix produces) | **200** |

## Fix
Build at the canonical **root** baseURL `https://go-micro.dev/` (already declared in `hugo.yaml`) instead of the Pages project subpath. Assets then resolve as `/scss/…`, which the proxy maps to `micro.github.io/go-micro/scss/…` correctly. One-line change to the build step, with a comment explaining the proxy constraint so it isn't "helpfully" reverted to the Pages subpath later.

This corrects the stylesheet, favicons, logo, internal navigation, and the canonical/OG/RSS URLs in one go. The PR's build job runs Hugo (deploy is gated off PRs); merging to `master` redeploys the styled site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_