### PR TITLE
fix(website): brand as "Go Micro" not "GoMicro"

### DIFF
--- a/internal/website/assets/icons/favicon-settings.json
+++ b/internal/website/assets/icons/favicon-settings.json
@@ -18,7 +18,7 @@
       },
       "backgroundColor": "#ffffff",
       "name": "Go Micro",
-      "shortName": "GoMicro",
+      "shortName": "Go Micro",
       "themeColor": "#ffffff"
     }
   },

--- a/internal/website/assets/icons/favicon/site.webmanifest
+++ b/internal/website/assets/icons/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
   "name": "Go Micro",
-  "short_name": "GoMicro",
+  "short_name": "Go Micro",
   "icons": [
     {
       "src": "/favicons/web-app-manifest-192x192.png",

--- a/internal/website/content/en/_index.md
+++ b/internal/website/content/en/_index.md
@@ -70,7 +70,7 @@ params:
 <!-- Text -->
 <div class="text-center mb-5">
     <h1 class="display-3 fw-bold mb-4">
-        <span class="gradient-text">GoMicro</span></br>
+        <span class="gradient-text">Go Micro</span></br>
         An Agent Harness for Go
     </h1>
     <p class="lead text-gray-custom mb-5 mx-auto">

--- a/internal/website/hugo.yaml
+++ b/internal/website/hugo.yaml
@@ -77,9 +77,9 @@ imaging:
 languages:
   en:
     label: English
-    title: GoMicro
+    title: Go Micro
     params:
-      description: Go-Micro
+      description: Go Micro
   # cSpell:disable
 
 markup:

--- a/internal/website/layouts/_partials/favicons.html
+++ b/internal/website/layouts/_partials/favicons.html
@@ -1,4 +1,4 @@
-<meta name="apple-mobile-web-app-title" content="GoMicro">
+<meta name="apple-mobile-web-app-title" content="Go Micro">
 <link rel="icon" type="image/png" href="{{ "favicons/favicon-96x96.png" | relURL }}" sizes="96x96">
 <link rel="icon" type="image/svg+xml" href="{{ "favicons/favicon.svg" | relURL }}">
 <link rel="shortcut icon" href="{{ "favicons/favicon.ico" | relURL }}">

--- a/internal/website/package.json
+++ b/internal/website/package.json
@@ -4,7 +4,7 @@
   "description": "Go-Micro Framework Documentation.",
   "repository": "github:micro/go-micro.dev",
   "homepage": "https://go-micro.dev",
-  "author": "GoMicro Team Authors",
+  "author": "Go Micro Team Authors",
   "license": "Apache-2.0",
   "bugs": "https://github.com/micro/go-micro.dev/issues",
   "spelling": "cSpell:ignore docsy hugo htmltest precheck postbuild rtlcss -",

--- a/internal/website/static/favicons/site.webmanifest
+++ b/internal/website/static/favicons/site.webmanifest
@@ -1,6 +1,6 @@
 {
   "name": "Go Micro",
-  "short_name": "GoMicro",
+  "short_name": "Go Micro",
   "icons": [
     {
       "src": "/favicons/web-app-manifest-192x192.png",


### PR DESCRIPTION
The site title, og:site_name, hero heading, PWA manifest, and package author read "GoMicro" with no space. Add the space everywhere it appears as a brand name.

Leaves the GoMicroToolkit Python class name in code samples untouched.