### PR TITLE
fix(website): space the navbar brand and link the logo to root

### DIFF
--- a/internal/website/layouts/_partials/navbar.html
+++ b/internal/website/layouts/_partials/navbar.html
@@ -8,7 +8,7 @@
       {{- if $cover }} td-navbar-cover td-navbar-transparent {{- end }}"
       {{- if eq (.Param "ui.navbar_theme") "dark" }} data-bs-theme="dark" {{- end }}>
 <div class="td-navbar-container container flex-column flex-md-row">
-  <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
+  <a class="navbar-brand" href="{{ "/" | relLangURL }}">
     {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">
       {{- if ne .Site.Params.ui.navbar_logo false -}}
@@ -19,7 +19,7 @@
     </span>
     {{- /**/ -}}
     <span class="navbar-brand__name">
-      <span class="fw-bold fs-5"><span class="text-primary fw-bolder">Go</span>Micro</span>
+      <span class="fw-bold fs-5"><span class="text-primary fw-bolder">Go</span> Micro</span>
     </span>
     {{- /**/ -}}
   </a>


### PR DESCRIPTION
## What

Two header/navbar branding fixes, following on from the earlier "GoMicro" → "Go Micro" pass:

- **Brand text spacing.** The navbar brand hardcoded `Go</span>Micro` with no space (the `text-primary` styling colours "Go" but the two words ran together). Now renders **Go Micro**.
- **Logo link.** The brand link used `.Site.Home.RelPermalink`, which resolves to `/index.html` under `uglyURLs: true`. Pointed it at the site root `/` instead.

## Verification

Local Hugo Extended build (`--minify --baseURL https://go-micro.dev/`):
- Navbar brand renders `Go Micro`.
- `navbar-brand href=/` on both the home page and docs pages.
- No `href="…/index.html"` links remain in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_