### PR TITLE
fix(website): serve blog posts at pretty URLs and restore old /blog/N redirects

### DIFF
--- a/internal/website/hugo.yaml
+++ b/internal/website/hugo.yaml
@@ -106,9 +106,15 @@ markup:
 # Everything below this are Site Params
 
 # Comment out if you don't want the "print entire section" link enabled.
+# Note: RSS is intentionally NOT in `page`. A per-page RSS feed is meaningless
+# (feeds belong to lists), and under uglyURLs it renders to `<slug>/index.xml`
+# while the page HTML renders to `<slug>.html`. That leaves the `<slug>/`
+# directory with index.xml as its only index, so a trailing-slash request
+# (e.g. /blog/.../post/) is served the XML feed instead of the post. Section
+# and home feeds (/blog/index.xml, /index.xml) are unaffected.
 outputs:
   home: [HTML, print, RSS, redirects, markdown, LLMS]
-  page: [HTML, print, RSS, markdown]
+  page: [HTML, print, markdown]
   section: [HTML, print, RSS, markdown]
 
 params:


### PR DESCRIPTION
## Problem

Two blog URL bugs from the Jekyll→Hugo migration:

1. **Trailing-slash blog URLs served XML, not the post.**
   ```
   curl -L https://go-micro.dev/blog/2026/03/04/building-the-ai-native-future-of-go-micro-with-claude/
   # → application/xml (an RSS feed)
   ```
   And it wasn't just a hand-typed variant — **post bodies cross-link each other in the trailing-slash form** (e.g. `<a href="/blog/2026/03/04/building-…/">MCP integration</a>`), so those in-content links hit the same broken path.

2. **Every old numbered blog URL (`/blog/1`…`/blog/35`) 404'd.** 35 posts carry `aliases: [/blog/N]` to preserve the old Jekyll URLs, but `disableAliases: true` (a migration default) suppressed all of them.

## Cause

Global `uglyURLs: true` was added to preserve the `/docs/*.html` scheme, but it also forced **blog posts** to `…/<slug>.html` — even though the blog `permalinks` config and the posts' own cross-links use the pretty `…/<slug>/` form. So the pretty URL pointed at a `…/<slug>/` directory whose only index file was the stray per-page RSS `index.xml`, which got served instead of the post. Separately, `disableAliases` defeated the old-URL redirects.

## Fix

1. **Scope `uglyURLs` to the `docs` section only** (`uglyURLs: {docs: true}`) — blog and other non-docs pages use clean pretty URLs, so the trailing-slash request and every author cross-link resolve to the post. Docs keep `.html`.
2. **Drop `RSS` from per-page outputs** (`page: [HTML, print, markdown]`) — a per-page feed is meaningless and was the mis-served file. Section/home feeds untouched.
3. **Re-enable aliases** (remove `disableAliases: true`) — Hugo now emits a redirect stub at each `/blog/N` pointing to the post's pretty URL.
4. **Pin `/support.html`** via `url` front matter so that one legacy root page doesn't regress.

## Verification

Local Hugo Extended build (`--minify --baseURL https://go-micro.dev/`):

| Surface | Result |
|---|---|
| Blog post output | `…/<slug>/index.html` ✓ (trailing slash serves the post) |
| Sitemap / feed / canonical / nav / in-content links | all `…/<slug>/` ✓ (consistent, resolve) |
| `/blog/1`…`/blog/35` | 35/35 redirect stubs → correct pretty post URL ✓ |
| Docs pages | `/docs/*.html` ✓ (unchanged) |
| `/support.html` | preserved ✓ |
| Stray per-post `index.xml` | none ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)