### PR TITLE
fix(ci): restrict hourly schedule to owner repo micro/go-micro

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -33,6 +33,7 @@ jobs:
   harness:
     name: Harnesses (mock LLM)
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository == 'micro/go-micro'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -51,7 +52,7 @@ jobs:
     # every push/PR, so changes don't quietly burn API credits. Trigger it
     # by hand (Actions → Harness → Run workflow) when changing the agent,
     # flow, or AI internals and you want a real-model check.
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'schedule' && github.repository == 'micro/go-micro') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
The hourly cron was triggering on all forks, burning CI minutes and potentially consuming API keys on fork variants with configured secrets.

Add github.repository checks so both harness jobs only run on schedule when the owner is micro/go-micro. Manual workflow_dispatch is unaffected.

**Verification:**
- `go build ./...`: pass
- `go test ./...`: pre-existing failures (unrelated YAML-only change)
- `golangci-lint run ./...`: pre-existing issues (unrelated)

Closes #issue