### PR TITLE
test: update harness workflow contract for owner-only schedule

### DIFF
--- a/internal/harness/provider-conformance/workflow_test.go
+++ b/internal/harness/provider-conformance/workflow_test.go
@@ -21,7 +21,7 @@ func TestHarnessWorkflowSchedulesLiveProviderMatrix(t *testing.T) {
 		`cron: "17 * * * *"`,
 		`workflow_dispatch:`,
 		`harness-live:`,
-		`if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`,
+		`if: (github.event_name == 'schedule' && github.repository == 'micro/go-micro') || github.event_name == 'workflow_dispatch'`,
 		`ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`,
 		`OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}`,
 		`GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}`,


### PR DESCRIPTION
Fixes the failing `HarnessWorkflowSchedulesLiveProviderMatrix` unit test introduced by the owner-only schedule change in #4870.

The contract test still expected the old `if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'` condition; update it to match the merged owner-repo check.

**Verification:**
- `go test ./internal/harness/provider-conformance/ -run TestHarnessWorkflowSchedulesLiveProviderMatrix -v`: PASS
- `go build ./...`: pass

Refs #4870