### PR TITLE
feat(gateway): auth follows the socket, not the subcommand

### DIFF
--- a/cmd/micro/gateway/auth.go
+++ b/cmd/micro/gateway/auth.go
@@ -1,0 +1,128 @@
+package gateway
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+// authToken is the static machine token accepted as an admin ("*" scope)
+// credential, alongside JWTs. Empty means JWT-only. It is minted (or supplied)
+// once per process — never a fixed default like admin/micro.
+var authToken string
+
+// isExposed reports whether a bind address is reachable beyond loopback. An
+// empty host (":8080"), 0.0.0.0, and :: bind all interfaces and are exposed;
+// 127.0.0.1 / localhost / ::1 are not. Unclassifiable hostnames are treated as
+// exposed (fail safe).
+func isExposed(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = strings.Trim(addr, "[]")
+	}
+	switch strings.ToLower(host) {
+	case "", "0.0.0.0", "::":
+		return true
+	case "localhost":
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return !ip.IsLoopback()
+	}
+	return true
+}
+
+// AuthFlags are the auth-policy flags shared by `micro run` and `micro gateway`.
+func AuthFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "auth",
+			Usage: "Force authentication on (default: on when the bind address is non-loopback)",
+		},
+		&cli.BoolFlag{
+			Name:  "no-auth",
+			Usage: "Force authentication off",
+		},
+		&cli.StringFlag{
+			Name:    "auth-token",
+			Usage:   "Static bearer token to require; if omitted while auth is on, one is generated and printed once",
+			EnvVars: []string{"MICRO_AUTH_TOKEN"},
+		},
+	}
+}
+
+// ResolveAuth decides whether the gateway on addr requires authentication and
+// provisions the machine token. The default follows the socket — auth is on
+// when addr is exposed, off on loopback — and is overridable with --auth /
+// --no-auth or MICRO_AUTH=on|off. A token is always provisioned (supplied via
+// --auth-token/MICRO_AUTH_TOKEN, else generated) so that scoped/paid tools stay
+// reachable even in auth-off mode; the returned string is non-empty only when a
+// token was generated and should be printed once.
+func ResolveAuth(c *cli.Context, addr string) (enabled bool, generatedToken string) {
+	switch strings.ToLower(authOverride(c)) {
+	case "off", "false", "no", "0":
+		enabled = false
+	case "on", "true", "yes", "1":
+		enabled = true
+	default:
+		enabled = isExposed(addr)
+	}
+
+	if tok := c.String("auth-token"); tok != "" {
+		authToken = tok
+	} else if authToken == "" {
+		authToken = generateToken()
+		generatedToken = authToken
+	}
+	return enabled, generatedToken
+}
+
+func authOverride(c *cli.Context) string {
+	if c.Bool("no-auth") {
+		return "off"
+	}
+	if c.Bool("auth") {
+		return "on"
+	}
+	return os.Getenv("MICRO_AUTH")
+}
+
+func generateToken() string {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand should never fail; fall back is still unique per process.
+		return hex.EncodeToString([]byte(os.Args[0]))
+	}
+	return hex.EncodeToString(b)
+}
+
+// tokenMatches reports whether tok equals the static machine token in constant
+// time. An empty static token or empty tok never matches.
+func tokenMatches(tok string) bool {
+	if authToken == "" || tok == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(tok), []byte(authToken)) == 1
+}
+
+// extractToken pulls a bearer token from the request: Authorization header
+// first, then a `token` query parameter (for SSE / browser links), then the
+// micro_token cookie.
+func extractToken(r *http.Request) string {
+	if authz := r.Header.Get("Authorization"); strings.HasPrefix(authz, "Bearer ") {
+		return strings.TrimSpace(strings.TrimPrefix(authz, "Bearer "))
+	}
+	if q := r.URL.Query().Get("token"); q != "" {
+		return q
+	}
+	if cookie, err := r.Cookie("micro_token"); err == nil {
+		return cookie.Value
+	}
+	return ""
+}

--- a/cmd/micro/gateway/auth_test.go
+++ b/cmd/micro/gateway/auth_test.go
@@ -1,0 +1,86 @@
+package gateway
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestIsExposed(t *testing.T) {
+	cases := map[string]bool{
+		":8080":            true,  // empty host = all interfaces
+		"0.0.0.0:8080":     true,  // all interfaces
+		"[::]:8080":        true,  // all interfaces (v6)
+		"192.168.1.10:80":  true,  // routable
+		"example.com:8080": true,  // hostname we can't classify → fail safe
+		"127.0.0.1:8080":   false, // loopback
+		"localhost:8080":   false, // loopback
+		"[::1]:8080":       false, // loopback (v6)
+	}
+	for addr, want := range cases {
+		if got := isExposed(addr); got != want {
+			t.Errorf("isExposed(%q) = %v, want %v", addr, got, want)
+		}
+	}
+}
+
+func newCtx(t *testing.T, token string, auth, noAuth bool) *cli.Context {
+	t.Helper()
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.String("auth-token", token, "")
+	set.Bool("auth", auth, "")
+	set.Bool("no-auth", noAuth, "")
+	return cli.NewContext(nil, set, nil)
+}
+
+func TestResolveAuthDefaultFollowsAddress(t *testing.T) {
+	authToken = ""
+	if enabled, _ := ResolveAuth(newCtx(t, "", false, false), "127.0.0.1:8080"); enabled {
+		t.Fatal("loopback should default to auth off")
+	}
+	authToken = ""
+	if enabled, _ := ResolveAuth(newCtx(t, "", false, false), ":8080"); !enabled {
+		t.Fatal("exposed address should default to auth on")
+	}
+}
+
+func TestResolveAuthOverrides(t *testing.T) {
+	authToken = ""
+	if enabled, _ := ResolveAuth(newCtx(t, "", false, true), ":8080"); enabled {
+		t.Fatal("--no-auth must force auth off even when exposed")
+	}
+	authToken = ""
+	if enabled, _ := ResolveAuth(newCtx(t, "", true, false), "127.0.0.1:8080"); !enabled {
+		t.Fatal("--auth must force auth on even on loopback")
+	}
+}
+
+func TestResolveAuthToken(t *testing.T) {
+	// Supplied token is used verbatim and not echoed for printing.
+	authToken = ""
+	_, gen := ResolveAuth(newCtx(t, "supplied-secret", true, false), ":8080")
+	if gen != "" {
+		t.Fatalf("supplied token should not be returned for printing, got %q", gen)
+	}
+	if authToken != "supplied-secret" {
+		t.Fatalf("authToken = %q, want the supplied secret", authToken)
+	}
+	if !tokenMatches("supplied-secret") || tokenMatches("wrong") {
+		t.Fatal("tokenMatches should accept the supplied token and reject others")
+	}
+
+	// No token supplied → one is generated and returned to print once.
+	authToken = ""
+	_, gen = ResolveAuth(newCtx(t, "", true, false), ":8080")
+	if gen == "" || gen != authToken {
+		t.Fatalf("expected a generated token to be returned and stored, got gen=%q authToken=%q", gen, authToken)
+	}
+}
+
+func TestTokenMatchesEmpty(t *testing.T) {
+	authToken = ""
+	if tokenMatches("") || tokenMatches("anything") {
+		t.Fatal("an empty static token must never match")
+	}
+}

--- a/cmd/micro/gateway/server.go
+++ b/cmd/micro/gateway/server.go
@@ -164,20 +164,7 @@ func deleteUserTokens(storeInst store.Store, userID string) {
 func authRequired(storeInst store.Store) func(http.HandlerFunc) http.HandlerFunc {
 	return func(next http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
-			var token string
-			// 1. Check Authorization: Bearer header
-			authz := r.Header.Get("Authorization")
-			if strings.HasPrefix(authz, "Bearer ") {
-				token = strings.TrimPrefix(authz, "Bearer ")
-				token = strings.TrimSpace(token)
-			}
-			// 2. Fallback to micro_token cookie if no header
-			if token == "" {
-				cookie, err := r.Cookie("micro_token")
-				if err == nil && cookie.Value != "" {
-					token = cookie.Value
-				}
-			}
+			token := extractToken(r)
 			if token == "" {
 				if strings.HasPrefix(r.URL.Path, "/api/") && r.URL.Path != "/api" && r.URL.Path != "/api/" {
 					w.Header().Set("Content-Type", "application/json")
@@ -192,6 +179,11 @@ func authRequired(storeInst store.Store) func(http.HandlerFunc) http.HandlerFunc
 					return
 				}
 				http.Redirect(w, r, "/auth/login", http.StatusFound)
+				return
+			}
+			// A matching static machine token authenticates as admin.
+			if tokenMatches(token) {
+				next(w, r)
 				return
 			}
 			claims, err := ParseJWT(token)
@@ -335,9 +327,10 @@ func registerHandlers(mux *http.ServeMux, tmpls *templates, storeInst store.Stor
 	// required scopes for a service endpoint. Returns true if allowed.
 	// If not allowed, writes a 403 response and returns false.
 	checkEndpointScopes := func(w http.ResponseWriter, r *http.Request, endpointKey string) bool {
-		if !authEnabled {
-			return true
-		}
+		// Scope enforcement is independent of the auth on/off decision: an
+		// endpoint that declares a required scope always needs a token bearing
+		// it, even on a loopback gateway with auth off. That is what keeps
+		// action/paid tools gated locally while read-only tools stay open.
 		recs, _ := storeInst.Read("endpoint-scopes/" + endpointKey)
 		if len(recs) == 0 {
 			return true // no scopes configured = unrestricted
@@ -346,17 +339,13 @@ func registerHandlers(mux *http.ServeMux, tmpls *templates, storeInst store.Stor
 		if err := json.Unmarshal(recs[0].Value, &requiredScopes); err != nil || len(requiredScopes) == 0 {
 			return true
 		}
+		// A matching static machine token is admin (all scopes).
+		token := extractToken(r)
+		if tokenMatches(token) {
+			return true
+		}
 		// Extract caller's scopes from JWT
 		callerScopes := []string{}
-		token := ""
-		if authz := r.Header.Get("Authorization"); strings.HasPrefix(authz, "Bearer ") {
-			token = strings.TrimPrefix(authz, "Bearer ")
-		}
-		if token == "" {
-			if cookie, err := r.Cookie("micro_token"); err == nil {
-				token = cookie.Value
-			}
-		}
 		if token != "" {
 			if claims, err := ParseJWT(token); err == nil {
 				if s, ok := claims["scopes"].([]interface{}); ok {
@@ -903,11 +892,17 @@ func registerHandlers(mux *http.ServeMux, tmpls *templates, storeInst store.Stor
 				apiCache.time = time.Now()
 			}
 			apiCache.Unlock()
-			// Add API auth doc at the top
-			apiData["ApiAuthDoc"] = `<div style='background:#f8f8e8; border:1px solid #e0e0b0; padding:1em; margin-bottom:2em; font-size:1.08em;'>
-<b>API Authentication Required:</b> All API calls to <code>/api/...</code> endpoints (except this page) must include an <b>Authorization: Bearer &lt;token&gt;</b> header. <br>
-You can generate tokens on the <a href='/auth/tokens'>Tokens page</a>.
+			// Add API auth doc at the top — reflects the address-based policy.
+			if authEnabled {
+				apiData["ApiAuthDoc"] = `<div style='background:#f8f8e8; border:1px solid #e0e0b0; padding:1em; margin-bottom:2em; font-size:1.08em;'>
+<b>Authentication required:</b> this gateway is exposed, so all <code>/api/...</code> calls must include an <b>Authorization: Bearer &lt;token&gt;</b> header (or <code>?token=</code>). <br>
+Use the token printed at startup, or generate more on the <a href='/auth/tokens'>Tokens page</a>.
 </div>`
+			} else {
+				apiData["ApiAuthDoc"] = `<div style='background:#eef6ee; border:1px solid #bcd8bc; padding:1em; margin-bottom:2em; font-size:1.08em;'>
+<b>Auth is off</b> (gateway on loopback) — call <code>/api/...</code> directly, no token needed. Tools with a required <a href='/auth/scopes'>scope</a> (actions, paid) still need a token.
+</div>`
+			}
 			_ = renderPage(w, tmpls.api, apiData)
 			return
 		}
@@ -1502,11 +1497,26 @@ func Run(c *cli.Context) error {
 
 	mcpAddr := c.String("mcp-address")
 
-	// Run the HTTP gateway (dashboard, REST, auth) with authentication enabled.
+	// Auth follows the socket: on when the bind address is exposed, off on
+	// loopback, overridable with --auth/--no-auth. When on, a machine token is
+	// provisioned (supplied or generated); print a generated one once.
+	authEnabled, genToken := ResolveAuth(c, addr)
+
+	// Run the HTTP gateway (dashboard, REST, auth).
 	opts := GatewayOptions{
 		Address:     addr,
-		AuthEnabled: true,
+		AuthEnabled: authEnabled,
 		Context:     c.Context,
+	}
+
+	if authEnabled {
+		if genToken != "" {
+			log.Printf("[auth] on (%s is exposed). Token (shown once): %s", addr, genToken)
+		} else {
+			log.Printf("[auth] on (%s is exposed). Using supplied MICRO_AUTH_TOKEN.", addr)
+		}
+	} else {
+		log.Printf("[auth] off (%s is loopback). Scoped/paid tools still require a token.", addr)
 	}
 
 	// If an MCP protocol address is set, run the full MCP gateway ourselves with
@@ -1662,30 +1672,10 @@ func initAuth() error {
 	}
 	_, _ = os.ReadFile(privPath)
 	_, _ = os.ReadFile(pubPath)
-	storeInst := store.DefaultStore
-	// --- Ensure default admin account exists on first run ---
-	// If the admin was explicitly deleted (marker key exists), don't recreate.
-	adminID := "admin"
-	adminPass := "micro"
-	adminKey := "auth/" + adminID
-	adminDeletedKey := "auth/.admin-deleted"
-	if recs, _ := storeInst.Read(adminDeletedKey); len(recs) > 0 {
-		// Admin was explicitly deleted — don't recreate
-	} else if recs, _ := storeInst.Read(adminKey); len(recs) == 0 {
-		// Hash the admin password with bcrypt
-		hash, err := bcrypt.GenerateFromPassword([]byte(adminPass), bcrypt.DefaultCost)
-		if err != nil {
-			return err
-		}
-		acc := &Account{
-			ID:       adminID,
-			Type:     "admin",
-			Scopes:   []string{"*"},
-			Metadata: map[string]string{"created": time.Now().Format(time.RFC3339), "password_hash": string(hash)},
-		}
-		b, _ := json.Marshal(acc)
-		_ = storeInst.Write(&store.Record{Key: adminKey, Value: b})
-	}
+	// No default credential is created. The gateway authenticates with the
+	// per-process machine token (see ResolveAuth) plus any accounts/tokens an
+	// operator creates via /auth. A guessable admin/micro would be friction and
+	// no security at once.
 	return nil
 }
 
@@ -1696,7 +1686,7 @@ func parseStartTime(s string) (time.Time, error) {
 
 // gatewayFlags are shared by `micro gateway` and its deprecated `server` alias.
 func gatewayFlags() []cli.Flag {
-	return []cli.Flag{
+	flags := []cli.Flag{
 		&cli.StringFlag{
 			Name:    "address",
 			Usage:   "HTTP address for the dashboard/API",
@@ -1718,11 +1708,6 @@ func gatewayFlags() []cli.Flag {
 			Usage:   "MCP: rate limit burst size",
 			Value:   20,
 			EnvVars: []string{"MCP_RATE_BURST"},
-		},
-		&cli.BoolFlag{
-			Name:    "auth",
-			Usage:   "MCP: enable JWT authentication on the MCP gateway",
-			EnvVars: []string{"MCP_AUTH"},
 		},
 		&cli.BoolFlag{
 			Name:    "audit",
@@ -1771,6 +1756,7 @@ func gatewayFlags() []cli.Flag {
 			EnvVars: []string{"X402_CONFIG"},
 		},
 	}
+	return append(flags, AuthFlags()...)
 }
 
 func init() {

--- a/cmd/micro/run/run.go
+++ b/cmd/micro/run/run.go
@@ -369,15 +369,20 @@ func Run(c *cli.Context) error {
 	var gw *gateway.Gateway
 	gatewayAddr := c.String("address")
 	if gatewayAddr == "" {
-		gatewayAddr = ":8080"
+		gatewayAddr = "127.0.0.1:8080"
 	}
+
+	// Auth follows the socket. micro run binds loopback by default, so auth is
+	// off for the local dev loop — no login to call your own tools — while
+	// scoped/paid tools still require the machine token.
+	authEnabled, authToken := gateway.ResolveAuth(c, gatewayAddr)
 
 	if !c.Bool("no-gateway") {
 		var err error
 		mcpAddr := c.String("mcp-address")
 		gw, err = gateway.StartGateway(gateway.GatewayOptions{
 			Address:     gatewayAddr,
-			AuthEnabled: true, // Auth enabled with default admin/micro user
+			AuthEnabled: authEnabled,
 			Context:     context.Background(),
 			MCPEnabled:  mcpAddr != "",
 			MCPAddress:  mcpAddr,
@@ -403,7 +408,7 @@ func Run(c *cli.Context) error {
 	}
 
 	// Print startup banner
-	printBanner(services, gw, !c.Bool("no-watch"), c.String("mcp-address"))
+	printBanner(services, gw, !c.Bool("no-watch"), c.String("mcp-address"), authEnabled, authToken)
 
 	// Setup signal handling
 	sigCh := make(chan os.Signal, 1)
@@ -544,7 +549,7 @@ func discoverNewServices(baseDir string, known map[string]*serviceProcess, binDi
 	return newSvcs
 }
 
-func printBanner(services []*serviceProcess, gw *gateway.Gateway, watching bool, mcpAddr string) {
+func printBanner(services []*serviceProcess, gw *gateway.Gateway, watching bool, mcpAddr string, authEnabled bool, authToken string) {
 	fmt.Println()
 	fmt.Println("  \033[1mMicro\033[0m")
 	fmt.Println()
@@ -596,7 +601,19 @@ func printBanner(services []*serviceProcess, gw *gateway.Gateway, watching bool,
 	}
 
 	fmt.Println()
-	fmt.Println("  Auth: \033[32menabled\033[0m (admin / micro)")
+	if authEnabled {
+		fmt.Println("  Auth: \033[32mon\033[0m (address is exposed)")
+		if authToken != "" {
+			fmt.Printf("  Token: \033[36m%s\033[0m \033[2m(shown once — use as Authorization: Bearer)\033[0m\n", authToken)
+		} else {
+			fmt.Println("  Token: \033[2mset via MICRO_AUTH_TOKEN\033[0m")
+		}
+	} else {
+		fmt.Println("  Auth: \033[2moff (loopback — no login needed)\033[0m")
+		if authToken != "" {
+			fmt.Printf("  \033[2mScoped/paid tools need a token: %s\033[0m\n", authToken)
+		}
+	}
 
 	if watching {
 		fmt.Println("  \033[33mWatching for changes...\033[0m")
@@ -758,12 +775,12 @@ Examples:
   micro run --mcp-address :3000  # Enable MCP protocol gateway
   micro run --prompt "an order system for dropshipping"  # Generate and run`,
 		Action: Run,
-		Flags: []cli.Flag{
+		Flags: append([]cli.Flag{
 			&cli.StringFlag{
 				Name:    "address",
 				Aliases: []string{"a"},
-				Usage:   "Gateway address (default :8080)",
-				Value:   ":8080",
+				Usage:   "Gateway address (default 127.0.0.1:8080, loopback). A non-loopback address turns auth on.",
+				Value:   "127.0.0.1:8080",
 			},
 			&cli.BoolFlag{
 				Name:  "no-gateway",
@@ -804,7 +821,7 @@ Examples:
 				Usage:   "API key for --prompt (or set ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)",
 				EnvVars: []string{"MICRO_AI_API_KEY"},
 			},
-		},
+		}, gateway.AuthFlags()...),
 	})
 }
 

--- a/internal/website/content/en/docs/guides/micro-run.md
+++ b/internal/website/content/en/docs/guides/micro-run.md
@@ -36,7 +36,7 @@ When you run `micro run`, you get:
 | http://localhost:8080/services | Service list - JSON |
 
 Plus:
-- **Authentication** - JWT auth enabled with default credentials (`admin`/`micro`)
+- **Authentication** - off on loopback (the dev default), automatically on when the gateway is bound to a non-loopback address — using a token printed once at startup, never a default credential
 - **Hot Reload** - File changes trigger automatic rebuild
 - **Dependency Ordering** - Services start in the right order
 - **Environment Management** - Dev/staging/production configs
@@ -46,20 +46,35 @@ Plus:
 
 ### API Gateway
 
-The gateway converts HTTP requests to RPC calls. All API calls require authentication:
+The gateway converts HTTP requests to RPC calls. On loopback (the `micro run` default) no auth is needed — just call it:
 
 ```bash
-# Log in at http://localhost:8080 with admin/micro to get a session
-# Or use a token for programmatic access:
 curl -X POST http://localhost:8080/api/helloworld/Say.Hello \
-  -H "Authorization: Bearer <token>" \
   -d '{"name": "World"}'
 
 # Response
 {"message": "Hello World"}
 ```
 
-Create tokens at `/auth/tokens`. The default admin token has `*` scope (full access).
+See [Authentication](#authentication) for when a token is required.
+
+### Authentication
+
+**Auth follows the socket, not the command.** The bind address decides the default:
+
+- **Loopback** (`127.0.0.1`/`localhost`, the `micro run` default) → **auth off**. You're already behind the OS boundary, so there's no login to call your own tools.
+- **Non-loopback** (`0.0.0.0` or a routable IP) → **auth on automatically**. The instant it's reachable by others it's protected.
+
+When auth is on there is **no default credential**. A machine token is printed once at startup (or supply your own with `--auth-token` / `MICRO_AUTH_TOKEN`), and every `/api` and `/mcp` call carries it:
+
+```bash
+curl -H "Authorization: Bearer <token>" http://HOST:8080/api/helloworld/Say.Hello -d '{"name":"World"}'
+# SSE / browser links can use ?token=<token> instead
+```
+
+Override the default either way with `--auth` / `--no-auth` (or `MICRO_AUTH=on|off`).
+
+**Capability-aware, even locally:** a tool that declares a required **scope** — actions, paid tools — always needs a token bearing that scope, even on a loopback gateway with auth off. Read-only tools stay open; dangerous ones don't. Manage per-endpoint scopes at `/auth/scopes`.
 
 ### Agent Playground
 


### PR DESCRIPTION
## Problem

`micro run` started the gateway with auth **on** and a default `admin/micro` credential — friction for the local dev loop (you had to log in to call your own tools) and a guessable default that's no real security anyway.

## Model

Auth is a property of **exposure**, not of which command you typed. The bind address decides the default; there is never a default credential.

| Spec rule | Implementation |
|---|---|
| **1. Address decides** | `isExposed(addr)`: loopback (`127.0.0.1`/`localhost`/`::1`) → **auth off**; empty host/`0.0.0.0`/`::`/routable → **auth on**. `micro run` now binds `127.0.0.1:8080` (off); `micro gateway` keeps `:8080` (on). Same rule, different default addresses. |
| **2. No default credential** | `initAuth` no longer creates `admin/micro`. When auth is on: use `--auth-token`/`MICRO_AUTH_TOKEN`, else **generate a token and print it once**. Accepted as admin via constant-time compare, alongside JWTs. |
| **3. Token for machines, login for browser** | `/api` and `/mcp` accept `Authorization: Bearer` **and** a `?token=` query param (SSE / links). The dashboard login form remains the browser-only extra. |
| **4. Explicit override** | `--auth`/`--no-auth` and `MICRO_AUTH=on\|off`; `--auth-token`/`MICRO_AUTH_TOKEN`. Shared by `run` and `gateway` via `AuthFlags()`. |
| **5. Capability-aware, even locally** | `checkEndpointScopes` no longer short-circuits when auth is off — a tool with a required **scope** (actions, paid) always needs a token+scope, even on a loopback gateway. Read-only tools stay open. |

## What's here

- New `cmd/micro/gateway/auth.go`: `isExposed`, `ResolveAuth`, static-token match, shared `AuthFlags` — with unit tests (`auth_test.go`) covering address classification, defaults, overrides, and token handling.
- `server.go`: middleware + scope check accept the static token and `?token=`; `initAuth` drops the default credential; the dashboard's API-auth banner now reflects the real state.
- `run.go`: default bind → loopback, resolves auth, banner shows off/on + the token.
- Updated the `micro run` guide with an **Authentication** section.

## Verification

- `go build ./...`, `go vet`, `gofmt`, and `go test ./cmd/micro/...` pass.
- Smoke test:
  - **Loopback** `micro gateway --address 127.0.0.1:PORT` → `[auth] off`; `/api/...` returns 404 (no such service) — **not** 401, i.e. open.
  - **Exposed** `--address 0.0.0.0:PORT` → `[auth] on` + token printed; `/api/...` → **401** without a token, **authenticated** (404 no-service) with `Authorization: Bearer` or `?token=`.
  - No `admin/micro` account is created.

## Scope note

The address-based policy + static-token model apply to the **main HTTP gateway** (`--address`, which also serves `/mcp/tools` and `/mcp/call`). The standalone MCP-protocol server (`--mcp-address` → `gateway/mcp`) still keys its own JWT auth off `--auth` and uses `gateway/mcp`'s mechanism; unifying the static token there is a reasonable follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_