### PR TITLE
fix: preserve AtlasCloud conformance markers across text tool fallbacks

### DIFF
--- a/agent/conformance_test.go
+++ b/agent/conformance_test.go
@@ -846,7 +846,7 @@ func TestAgentExecutesTextToolCallFallbackAfterStructuredToolCall(t *testing.T) 
 			Input: map[string]any{"value": "agent-conformance"},
 		})
 		return &ai.Response{
-			Reply:  echo.Content + "\n<tool_call name=\"delegate\">{\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}</tool_call>",
+			Reply:  "<tool_call name=\"delegate\">{\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}</tool_call>",
 			Answer: echo.Content,
 			ToolCalls: []ai.ToolCall{
 				{ID: "structured-echo-1", Name: "conformance_echo", Input: map[string]any{"value": "agent-conformance"}, Result: echo.Content},
@@ -856,7 +856,7 @@ func TestAgentExecutesTextToolCallFallbackAfterStructuredToolCall(t *testing.T) 
 	defer func() { fakeGen = nil }()
 
 	var sawTool bool
-	var sawBlockedDelegate bool
+	var delegateCalls int
 	a := New(
 		Name("conformance-mixed-text-tool"),
 		Provider("fake"),
@@ -865,7 +865,7 @@ func TestAgentExecutesTextToolCallFallbackAfterStructuredToolCall(t *testing.T) 
 		WithMemory(NewInMemory(4)),
 		ApproveTool(func(tool string, input map[string]any) (bool, string) {
 			if tool == "delegate" {
-				sawBlockedDelegate = true
+				delegateCalls++
 				return false, "cross-provider conformance blocks delegate side effects"
 			}
 			return true, ""
@@ -885,8 +885,8 @@ func TestAgentExecutesTextToolCallFallbackAfterStructuredToolCall(t *testing.T) 
 	if !sawTool {
 		t.Fatal("structured conformance_echo did not execute")
 	}
-	if !sawBlockedDelegate {
-		t.Fatal("tagged text delegate fallback did not execute")
+	if delegateCalls != 1 {
+		t.Fatalf("tagged text delegate fallback calls = %d, want 1", delegateCalls)
 	}
 	if len(resp.ToolCalls) != 2 {
 		t.Fatalf("ToolCalls = %+v, want structured echo and text delegate", resp.ToolCalls)

--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -228,6 +228,9 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 						// it may contain a text-encoded tool call. The agent harness
 						// inspects Reply for text fallback calls after Generate returns.
 						resp.Reply = followUpResp.Reply
+						if len(toolResults) > 0 {
+							resp.Answer = strings.Join(toolResults, "\n")
+						}
 					} else {
 						resp.Answer = atlascloudAnswerWithRequiredToolMarkers(followUpResp.Reply, toolResults, allToolCalls)
 					}

--- a/ai/atlascloud/atlascloud_test.go
+++ b/ai/atlascloud/atlascloud_test.go
@@ -13,6 +13,27 @@ import (
 	"go-micro.dev/v6/ai"
 )
 
+type atlascloudRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn atlascloudRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func useAtlascloudJSONTransport(t *testing.T, handler func(*http.Request) string) {
+	t.Helper()
+	previous := http.DefaultTransport
+	http.DefaultTransport = atlascloudRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := handler(req)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = previous })
+}
+
 func TestProvider_String(t *testing.T) {
 	p := NewProvider()
 	if p.String() != "atlascloud" {
@@ -477,27 +498,26 @@ func TestProvider_GenerateExecutesMultiStepFollowUpToolCalls(t *testing.T) {
 
 func TestProvider_GeneratePreservesFollowUpTextToolCallInReply(t *testing.T) {
 	var bodies []map[string]any
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	useAtlascloudJSONTransport(t, func(r *http.Request) string {
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
 		bodies = append(bodies, body)
-		w.Header().Set("Content-Type", "application/json")
 		switch len(bodies) {
 		case 1:
-			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"","tool_calls":[{"id":"call-1","function":{"name":"conformance_echo","arguments":"{\"value\":\"agent-conformance\"}"}}]}}]}`))
+			return `{"choices":[{"message":{"content":"","tool_calls":[{"id":"call-1","function":{"name":"conformance_echo","arguments":"{\"value\":\"agent-conformance\"}"}}]}}]}`
 		case 2:
-			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"<tool_call name=\"delegate\">{\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}</tool_call>"}}]}`))
+			return `{"choices":[{"message":{"content":"<tool_call name=\"delegate\">{\"task\":\"summarize the conformance marker\",\"to\":\"blocked-reviewer\"}</tool_call>"}}]}`
 		default:
 			t.Fatalf("unexpected API call %d", len(bodies))
+			return ""
 		}
-	}))
-	defer ts.Close()
+	})
 
 	p := NewProvider(
 		ai.WithAPIKey("test-key"),
-		ai.WithBaseURL(ts.URL),
+		ai.WithBaseURL("https://atlascloud.test"),
 		ai.WithToolHandler(func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
 			if call.Name != "conformance_echo" {
 				t.Fatalf("unexpected structured tool call %+v", call)
@@ -518,8 +538,48 @@ func TestProvider_GeneratePreservesFollowUpTextToolCallInReply(t *testing.T) {
 	if !strings.Contains(resp.Reply, `<tool_call name="delegate">`) {
 		t.Fatalf("Reply = %q, want tagged delegate follow-up for agent text fallback", resp.Reply)
 	}
+	if !strings.Contains(resp.Answer, "agent-conformance-ok") {
+		t.Fatalf("Answer = %q, want structured tool result preserved separately", resp.Answer)
+	}
+}
+
+func TestProvider_GenerateFollowUpTextToolCallWithoutToolResultLeavesAnswerEmpty(t *testing.T) {
+	var calls int
+	useAtlascloudJSONTransport(t, func(r *http.Request) string {
+		calls++
+		switch calls {
+		case 1:
+			return `{"choices":[{"message":{"content":"","tool_calls":[{"id":"call-1","function":{"name":"conformance_echo","arguments":"{\"value\":\"agent-conformance\"}"}}]}}]}`
+		case 2:
+			return `{"choices":[{"message":{"content":"<tool_call name=\"delegate\">{\"task\":\"summarize\",\"to\":\"blocked-reviewer\"}</tool_call>"}}]}`
+		default:
+			t.Fatalf("unexpected API call %d", calls)
+			return ""
+		}
+	})
+
+	p := NewProvider(
+		ai.WithAPIKey("test-key"),
+		ai.WithBaseURL("https://atlascloud.test"),
+		ai.WithToolHandler(func(ctx context.Context, call ai.ToolCall) ai.ToolResult {
+			return ai.ToolResult{ID: call.ID}
+		}),
+	)
+	resp, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "run conformance",
+		Tools: []ai.Tool{
+			{Name: "conformance_echo", Description: "echo conformance marker", Properties: map[string]any{"value": map[string]any{"type": "string"}}},
+			{Name: "delegate", Description: "delegate work", Properties: map[string]any{"task": map[string]any{"type": "string"}, "to": map[string]any{"type": "string"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if !strings.Contains(resp.Reply, `<tool_call name="delegate">`) {
+		t.Fatalf("Reply = %q, want tagged delegate follow-up", resp.Reply)
+	}
 	if resp.Answer != "" {
-		t.Fatalf("Answer = %q, want follow-up text preserved only as Reply", resp.Answer)
+		t.Fatalf("Answer = %q, want no invented answer without structured tool content", resp.Answer)
 	}
 }
 


### PR DESCRIPTION
## Why

The live AtlasCloud agent conformance harness keeps failing with a missing conformance marker, even though the structured echo and the guarded delegate both run.

In `ai/atlascloud/atlascloud.go`, a follow-up response that carries a text-encoded tool call is correctly kept in `Reply` so the agent's text-fallback parser can find it. That branch does not, however, retain the results of structured tools the provider already executed. When AtlasCloud emits `conformance_echo` as a structured call and the `delegate` as tagged text, the echo result — the one containing `agent-conformance-ok` — is dropped at the structured-to-text transition, before `agent.askLocked` combines the reply, answer, and additional text-tool result. All four attempts then exhaust on a marker that was produced and thrown away.

Fixes #4729

## What changed

`ai/atlascloud/atlascloud.go`: when the follow-up response is kept for text-fallback parsing and structured tool results have accumulated, those results are now joined into `resp.Answer` instead of being discarded. `Reply` still carries only the executable markup, so the existing split between executable text and prior tool output is preserved and `agent.executeAdditionalTextToolCalls` behaves exactly as before.

`ai/atlascloud/atlascloud_test.go`: locks down both halves of that response contract — a structured `conformance_echo` followed by a tagged-text `delegate` must leave the tagged call in `Reply` and the earlier echo result in `Answer`.

`agent/conformance_test.go`: the fake provider now models the real AtlasCloud shape (tagged delegate in `Reply`, echo marker in `Answer`, structured echo in `ToolCalls`) rather than concatenating the echo into `Reply`. The delegate assertion moved from a boolean to an exact call count, so a regression that double-executes the fallback fails instead of passing.

## Testing

- The AtlasCloud provider test asserts the mixed-response contract directly: tagged call retained in `Reply`, echo result carried in `Answer`.
- The agent conformance test asserts the delegate executes exactly once, both tool calls are recorded, and the final reply still contains the marker.
- A follow-up with no accumulated structured-tool content does not invent an answer, and ordinary non-text follow-up answers continue through the existing normalization path untouched.
- The deterministic fake-provider conformance matrix still rejects genuinely missing markers, so this does not weaken the check it fixes.

I could not run the Go suite in this workspace, so CI is the authority on the full run.

## Scope

Three files, +76/-13, and the only non-test change is the `Answer` assignment guarded by `len(toolResults) > 0`. Providers other than AtlasCloud are untouched.

AI was used for assistance.
