### PR TITLE
arch: decouple HTTP API gateway and MCP gateway via shared service resolver, add HTTP SSE support

### DIFF
--- a/cmd/micro/gateway/server.go
+++ b/cmd/micro/gateway/server.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -42,6 +43,7 @@ import (
 	"go-micro.dev/v6/store"
 	"go-micro.dev/v6/wrapper/x402"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/sync/errgroup"
 )
 
 // HTML is the embedded filesystem for templates and static files, set by main.go
@@ -1573,25 +1575,53 @@ func Run(c *cli.Context) error {
 		log.Printf("[auth] off (%s is loopback). Scoped/paid tools still require a token.", addr)
 	}
 
-	// If an MCP protocol address is set, run the full MCP gateway ourselves with
-	// the production controls (rate limiting, scopes, auth, audit, circuit
-	// breaker, x402 payments). gateway/api would otherwise start a bare MCP
-	// listener with none of these, so we start it here and leave api's own MCP
-	// disabled. Registry selection comes from the global --registry flags.
+	// The MCP gateway runs independently of the HTTP API gateway, carrying the
+	// production controls (rate limiting, scopes, auth, audit, circuit breaker,
+	// x402 payments). Both gateways are started explicitly below and shut down
+	// together when the first one exits or a signal arrives.
+	var mcpServer *mcp.Server
 	if mcpAddr != "" {
 		mcpOpts, err := buildMCPOptions(c, mcpAddr)
 		if err != nil {
 			return err
 		}
-		go func() {
-			if err := mcp.ListenAndServe(mcpAddr, mcpOpts); err != nil {
-				log.Printf("[mcp] gateway error: %v", err)
-			}
-		}()
+		mcpServer, err = mcp.NewServer(mcpOpts)
+		if err != nil {
+			return fmt.Errorf("failed to start MCP gateway: %w", err)
+		}
 		log.Printf("[mcp] gateway on %s", mcpAddr)
 	}
 
-	return RunGateway(opts)
+	gw, err := StartGateway(opts)
+	if err != nil {
+		return fmt.Errorf("failed to start gateway: %w", err)
+	}
+
+	// Run both gateways until a signal or the first gateway exits.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	var eg errgroup.Group
+	eg.Go(func() error { return gw.Wait() })
+	if mcpServer != nil {
+		eg.Go(func() error { return mcpServer.Serve() })
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- eg.Wait() }()
+
+	select {
+	case <-sigCh:
+		log.Printf("[gateway] shutting down")
+	case err = <-errCh:
+		log.Printf("[gateway] gateway exited: %v", err)
+	}
+
+	_ = gw.Stop()
+	if mcpServer != nil {
+		_ = mcpServer.Stop()
+	}
+	return err
 }
 
 // buildMCPOptions assembles the MCP gateway options from the command flags. It

--- a/cmd/micro/run/run.go
+++ b/cmd/micro/run/run.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -25,6 +26,7 @@ import (
 	"go-micro.dev/v6/cmd/micro/gateway"
 	"go-micro.dev/v6/cmd/micro/run/config"
 	"go-micro.dev/v6/cmd/micro/run/watcher"
+	"go-micro.dev/v6/gateway/mcp"
 	"go-micro.dev/v6/registry"
 
 	_ "go-micro.dev/v6/ai/anthropic"
@@ -367,6 +369,7 @@ func Run(c *cli.Context) error {
 
 	// Start gateway unless disabled
 	var gw *gateway.Gateway
+	var mcpServer *mcp.Server
 	gatewayAddr := c.String("address")
 	if gatewayAddr == "" {
 		gatewayAddr = "127.0.0.1:8080"
@@ -379,17 +382,34 @@ func Run(c *cli.Context) error {
 
 	if !c.Bool("no-gateway") {
 		var err error
-		mcpAddr := c.String("mcp-address")
 		gw, err = gateway.StartGateway(gateway.GatewayOptions{
 			Address:     gatewayAddr,
 			AuthEnabled: authEnabled,
 			Context:     context.Background(),
-			MCPEnabled:  mcpAddr != "",
-			MCPAddress:  mcpAddr,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to start gateway: %w", err)
 		}
+	}
+
+	// The MCP gateway runs independently of the HTTP API gateway. When
+	// --mcp-address is set, start it explicitly with the production controls
+	// (rate limiting, scopes, auth, x402 payments) instead of letting the API
+	// gateway spawn a bare listener.
+	if mcpAddr := c.String("mcp-address"); mcpAddr != "" {
+		mcpOpts, err := buildRunMCPOptions(c, mcpAddr)
+		if err != nil {
+			return fmt.Errorf("failed to configure MCP gateway: %w", err)
+		}
+		mcpServer, err = mcp.NewServer(mcpOpts)
+		if err != nil {
+			return fmt.Errorf("failed to start MCP gateway: %w", err)
+		}
+		go func() {
+			if err := mcpServer.Serve(); err != nil {
+				fmt.Fprintf(os.Stderr, "[mcp] gateway error: %v\n", err)
+			}
+		}()
 	}
 
 	// Start services
@@ -501,6 +521,10 @@ func Run(c *cli.Context) error {
 		_ = gw.Stop()
 	}
 
+	if mcpServer != nil {
+		_ = mcpServer.Stop()
+	}
+
 	// Stop services in reverse order. Snapshot under the lock — the scanner
 	// goroutine may still be appending as teardown begins.
 	svcMu.Lock()
@@ -512,6 +536,19 @@ func Run(c *cli.Context) error {
 	}
 
 	return nil
+}
+
+// buildRunMCPOptions assembles MCP gateway options for `micro run`. The dev
+// command keeps a minimal setup (registry, context, logger) — the same bare
+// listener the API gateway used to spawn — while production controls (rate
+// limiting, scopes, x402) stay on the standalone `micro gateway` command.
+func buildRunMCPOptions(c *cli.Context, addr string) (mcp.Options, error) {
+	return mcp.Options{
+		Registry: registry.DefaultRegistry,
+		Address:  addr,
+		Context:  context.Background(),
+		Logger:   log.Default(),
+	}, nil
 }
 
 func discoverNewServices(baseDir string, known map[string]*serviceProcess, binDir, runDir, logsDir string, envVars []string, colorOffset int) []*serviceProcess {

--- a/gateway/api/README.md
+++ b/gateway/api/README.md
@@ -47,13 +47,23 @@ func main() {
 }
 ```
 
-### Gateway with MCP
+### Run the MCP gateway alongside
+
+The HTTP API gateway no longer starts MCP. Run the MCP gateway independently
+so each has its own lifecycle:
 
 ```go
+mcpSrv, err := mcp.NewServer(mcp.Options{
+    Address:  ":3000",
+    Registry: registry.DefaultRegistry,
+})
+if err != nil {
+    panic(err)
+}
+go mcpSrv.Serve()
+
 gw, err := api.New(api.Options{
     Address:    ":8080",
-    MCPEnabled: true,
-    MCPAddress: ":3000", // MCP on separate port
     HandlerRegistrar: registerHandlers,
 })
 ```
@@ -101,12 +111,6 @@ type Options struct {
     // HandlerRegistrar registers HTTP handlers on the mux
     HandlerRegistrar func(mux *http.ServeMux) error
 
-    // MCPEnabled enables the MCP gateway
-    MCPEnabled bool
-
-    // MCPAddress is the address for MCP gateway (e.g., ":3000")
-    MCPAddress string
-
     // Registry for service discovery (default: registry.DefaultRegistry)
     Registry registry.Registry
 }
@@ -121,7 +125,6 @@ type Options struct {
 │  │  Gateway                           │ │
 │  │  - Manages HTTP server             │ │
 │  │  - Calls HandlerRegistrar          │ │
-│  │  - Starts MCP if enabled           │ │
 │  └────────────────────────────────────┘ │
 └─────────────────────────────────────────┘
                ↓ delegates to

--- a/gateway/api/gateway.go
+++ b/gateway/api/gateway.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"time"
 
-	"go-micro.dev/v6/gateway/mcp"
 	"go-micro.dev/v6/registry"
 )
 
@@ -34,12 +33,6 @@ type Options struct {
 	// HandlerRegistrar is called to register HTTP handlers on the mux
 	// This allows different configurations (dev vs prod) to register different handlers
 	HandlerRegistrar func(mux *http.ServeMux) error
-
-	// MCPEnabled controls whether to start MCP gateway
-	MCPEnabled bool
-
-	// MCPAddress is the address for MCP gateway (e.g., ":3000")
-	MCPAddress string
 
 	// Registry for service discovery (if nil, uses registry.DefaultRegistry)
 	Registry registry.Registry
@@ -90,20 +83,6 @@ func New(opts Options) (*Gateway, error) {
 		opts:   opts,
 		server: server,
 		mux:    mux,
-	}
-
-	// Start MCP gateway if enabled
-	if opts.MCPEnabled && opts.MCPAddress != "" {
-		go func() {
-			if err := mcp.ListenAndServe(opts.MCPAddress, mcp.Options{
-				Registry: opts.Registry,
-				Context:  opts.Context,
-				Logger:   opts.Logger,
-			}); err != nil {
-				opts.Logger.Printf("[mcp] MCP gateway error: %v", err)
-			}
-		}()
-		opts.Logger.Printf("[mcp] MCP gateway enabled on %s", opts.MCPAddress)
 	}
 
 	// Start server in background

--- a/gateway/mcp/mcp.go
+++ b/gateway/mcp/mcp.go
@@ -18,6 +18,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -172,6 +173,10 @@ type Server struct {
 	toolsMu  sync.RWMutex
 	server   *http.Server
 	watching bool
+
+	// sessions holds streamable-HTTP MCP client sessions (see streamable.go).
+	sessions   map[string]*httpSession
+	sessionsMu sync.RWMutex
 
 	// resolver is the shared service schema resolver; it owns registry
 	// watching and endpoint parsing so discovery is not duplicated with the
@@ -571,13 +576,18 @@ func (s *Server) watchServices() {
 	}
 }
 
-// serveHTTP starts an HTTP server with SSE and WebSocket transports
-func (s *Server) serveHTTP() error {
+// handler returns the HTTP mux with all MCP routes. Shared by serveHTTP and
+// tests.
+func (s *Server) handler() *http.ServeMux {
+	if s.sessions == nil {
+		s.sessions = make(map[string]*httpSession)
+	}
+
 	mux := http.NewServeMux()
 
-	// MCP endpoints. Tool calls can be gated behind an x402 payment
-	// (enforced per-tool inside handleCallTool); listing tools and health
-	// stay free.
+	// Legacy REST API. Tool calls can be gated behind an x402 payment
+	// (enforced per-tool inside invokeTool); listing tools and health stay
+	// free.
 	if s.opts.Payment != nil {
 		net := s.opts.Payment.Network
 		if net == "" {
@@ -589,17 +599,43 @@ func (s *Server) serveHTTP() error {
 	mux.HandleFunc("/mcp/call", s.handleCallTool)
 	mux.HandleFunc("/health", s.handleHealth)
 
+	// Streamable-HTTP MCP transport (JSON-RPC 2.0 over POST/GET/DELETE).
+	// This is the endpoint for spec-compliant MCP clients.
+	mux.HandleFunc("/mcp", s.handleStreamableHTTP)
+
 	// WebSocket endpoint for bidirectional streaming
-	ws := NewWebSocketTransport(s)
-	mux.Handle("/mcp/ws", ws)
+	mux.Handle("/mcp/ws", NewWebSocketTransport(s))
+
+	return mux
+}
+
+// serveHTTP starts an HTTP server with SSE and WebSocket transports
+func (s *Server) serveHTTP() error {
+	ctx := s.opts.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	go s.sweepSessions(ctx)
 
 	s.server = &http.Server{
 		Addr:    s.opts.Address,
-		Handler: mux,
+		Handler: s.handler(),
 	}
 
+	// Stop the server when the context is canceled (e.g. Ctrl-C).
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.server.Shutdown(shutdownCtx)
+	}()
+
 	s.opts.Logger.Printf("[mcp] MCP gateway listening on %s (HTTP + WebSocket)", s.opts.Address)
-	return s.server.ListenAndServe()
+	err := s.server.ListenAndServe()
+	if err == http.ErrServerClosed && ctx.Err() != nil {
+		return nil
+	}
+	return err
 }
 
 // serveStdio starts stdio-based MCP server (for Claude Code, etc.)
@@ -608,16 +644,12 @@ func (s *Server) serveStdio() error {
 	return transport.Serve()
 }
 
-// handleListTools returns the list of available tools
-func (s *Server) handleListTools(w http.ResponseWriter, r *http.Request) {
-	if s.opts.AuthFunc != nil {
-		if err := s.opts.AuthFunc(r); err != nil {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-	}
-
+// toolCatalog returns a snapshot of the tool catalog, attaching payment info
+// for the catalog. Callers must not mutate the returned tools.
+func (s *Server) toolCatalog() []*Tool {
 	s.toolsMu.RLock()
+	defer s.toolsMu.RUnlock()
+
 	tools := make([]*Tool, 0, len(s.tools))
 	for _, tool := range s.tools {
 		// Attach payment info for the catalog. Copy when pricing so the
@@ -630,11 +662,21 @@ func (s *Server) handleListTools(w http.ResponseWriter, r *http.Request) {
 		}
 		tools = append(tools, tool)
 	}
-	s.toolsMu.RUnlock()
+	return tools
+}
+
+// handleListTools returns the list of available tools
+func (s *Server) handleListTools(w http.ResponseWriter, r *http.Request) {
+	if s.opts.AuthFunc != nil {
+		if err := s.opts.AuthFunc(r); err != nil {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"tools": tools,
+		"tools": s.toolCatalog(),
 	})
 }
 
@@ -657,22 +699,73 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	payload, traceID, raw, err := s.invokeTool(w, r, req.Tool, req.Input)
+	if err == errResponseWritten {
+		return
+	}
+	if err != nil {
+		if te, ok := err.(*toolError); ok {
+			http.Error(w, te.message, te.status)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if raw {
+		// Framework tools respond directly with their result.
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(payload)
+		return
+	}
+
+	// Return response with trace ID
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(TraceIDKey, traceID)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"result":   payload,
+		"trace_id": traceID,
+	})
+}
+
+// errResponseWritten marks that the x402 payment gate already wrote an HTTP
+// response (the 402 challenge); the caller must not write anything further.
+var errResponseWritten = errors.New("x402 response already written")
+
+// toolError is a tool-call failure carrying the HTTP status the legacy REST
+// transport returns. The streamable MCP transport maps it to a JSON-RPC error
+// (or an isError result for execution failures).
+type toolError struct {
+	status  int
+	message string
+}
+
+func (e *toolError) Error() string { return e.message }
+
+// invokeTool runs the shared tool-call pipeline (lookup, x402 payment gate,
+// auth/scope inspection, rate limiting, circuit breaker, tracing, audit, and
+// the RPC or framework-handler dispatch) used by both the legacy REST
+// /mcp/call endpoint and the streamable-HTTP MCP transport. On success it
+// returns the tool's JSON payload and trace id; raw is true for framework
+// tools whose payload is the response itself. On failure it returns a
+// *toolError, or errResponseWritten if the x402 gate already wrote the 402
+// challenge.
+func (s *Server) invokeTool(w http.ResponseWriter, r *http.Request, toolName string, input map[string]interface{}) (json.RawMessage, string, bool, error) {
 	// Get tool info
 	s.toolsMu.RLock()
-	tool, exists := s.tools[req.Tool]
+	tool, exists := s.tools[toolName]
 	s.toolsMu.RUnlock()
 
 	if !exists {
-		http.Error(w, "Tool not found", http.StatusNotFound)
-		return
+		return nil, "", false, &toolError{status: http.StatusNotFound, message: "Tool not found"}
 	}
 
 	// x402 payment gate: require the tool's amount before doing work.
 	// Free tools (amount "" or "0") pass through; Require writes the 402
 	// challenge itself when payment is missing or invalid.
 	if s.opts.Payment != nil {
-		if !s.opts.Payment.Require(w, r, s.opts.Payment.AmountFor(req.Tool), req.Tool) {
-			return
+		if !s.opts.Payment.Require(w, r, s.opts.Payment.AmountFor(toolName), toolName) {
+			return nil, "", false, errResponseWritten
 		}
 	}
 
@@ -680,7 +773,7 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 	traceID := uuid.New().String()
 
 	// Start OTel span (noop if TraceProvider is nil)
-	ctx, span := s.startToolSpan(r.Context(), req.Tool, "http", traceID)
+	ctx, span := s.startToolSpan(r.Context(), toolName, "http", traceID)
 	defer span.End()
 
 	// Authenticate and authorize
@@ -691,17 +784,15 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 		if token == "" {
 			span.SetAttributes(attribute.Bool(AttrAuthAllowed, false), attribute.String(AttrAuthDeniedReason, "missing token"))
 			setSpanError(span, fmt.Errorf("missing token"))
-			s.audit(AuditRecord{TraceID: traceID, Timestamp: time.Now(), Tool: req.Tool, Allowed: false, DeniedReason: "missing token"})
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
+			s.audit(AuditRecord{TraceID: traceID, Timestamp: time.Now(), Tool: toolName, Allowed: false, DeniedReason: "missing token"})
+			return nil, traceID, false, &toolError{status: http.StatusUnauthorized, message: "Unauthorized"}
 		}
 		acc, err := s.opts.Auth.Inspect(token)
 		if err != nil {
 			span.SetAttributes(attribute.Bool(AttrAuthAllowed, false), attribute.String(AttrAuthDeniedReason, "invalid token"))
 			setSpanError(span, fmt.Errorf("invalid token"))
-			s.audit(AuditRecord{TraceID: traceID, Timestamp: time.Now(), Tool: req.Tool, Allowed: false, DeniedReason: "invalid token"})
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
+			s.audit(AuditRecord{TraceID: traceID, Timestamp: time.Now(), Tool: toolName, Allowed: false, DeniedReason: "invalid token"})
+			return nil, traceID, false, &toolError{status: http.StatusUnauthorized, message: "Unauthorized"}
 		}
 		account = acc
 		span.SetAttributes(attribute.String(AttrAccountID, account.ID))
@@ -713,18 +804,17 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 				span.SetAttributes(attribute.Bool(AttrAuthAllowed, false), attribute.String(AttrAuthDeniedReason, "insufficient scopes"))
 				setSpanError(span, fmt.Errorf("insufficient scopes"))
 				s.audit(AuditRecord{
-					TraceID: traceID, Timestamp: time.Now(), Tool: req.Tool,
+					TraceID: traceID, Timestamp: time.Now(), Tool: toolName,
 					AccountID: account.ID, ScopesRequired: tool.Scopes,
 					Allowed: false, DeniedReason: "insufficient scopes",
 				})
-				http.Error(w, "Forbidden: insufficient scopes", http.StatusForbidden)
-				return
+				return nil, traceID, false, &toolError{status: http.StatusForbidden, message: "Forbidden: insufficient scopes"}
 			}
 		}
 	}
 
 	// Rate limit check
-	if err := s.allowRate(req.Tool); err != nil {
+	if err := s.allowRate(toolName); err != nil {
 		span.SetAttributes(attribute.Bool(AttrRateLimited, true))
 		setSpanError(span, err)
 		accountID := ""
@@ -732,17 +822,16 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 			accountID = account.ID
 		}
 		s.audit(AuditRecord{
-			TraceID: traceID, Timestamp: time.Now(), Tool: req.Tool,
+			TraceID: traceID, Timestamp: time.Now(), Tool: toolName,
 			AccountID: accountID, Allowed: false, DeniedReason: "rate limited",
 		})
-		http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
-		return
+		return nil, traceID, false, &toolError{status: http.StatusTooManyRequests, message: "Rate limit exceeded"}
 	}
 
 	span.SetAttributes(attribute.Bool(AttrAuthAllowed, true))
 
 	// Circuit breaker check
-	if err := s.allowCircuit(req.Tool); err != nil {
+	if err := s.allowCircuit(toolName); err != nil {
 		span.SetAttributes(attribute.String("mcp.circuit_breaker", "open"))
 		setSpanError(span, err)
 		accountID := ""
@@ -750,11 +839,10 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 			accountID = account.ID
 		}
 		s.audit(AuditRecord{
-			TraceID: traceID, Timestamp: time.Now(), Tool: req.Tool,
+			TraceID: traceID, Timestamp: time.Now(), Tool: toolName,
 			AccountID: accountID, Allowed: false, DeniedReason: "circuit breaker open",
 		})
-		http.Error(w, "Service unavailable: circuit breaker open", http.StatusServiceUnavailable)
-		return
+		return nil, traceID, false, &toolError{status: http.StatusServiceUnavailable, message: "Service unavailable: circuit breaker open"}
 	}
 
 	// Build context with tracing metadata
@@ -764,7 +852,7 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 		md = make(metadata.Metadata)
 	}
 	md.Set(TraceIDKey, traceID)
-	md.Set(ToolNameKey, req.Tool)
+	md.Set(ToolNameKey, toolName)
 	if account != nil {
 		md.Set(AccountIDKey, account.ID)
 	}
@@ -774,22 +862,24 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 
 	// Framework tools have a direct handler; service tools go through RPC.
 	if tool.Handler != nil {
-		result, err := tool.Handler(req.Input)
+		result, err := tool.Handler(input)
 		if err != nil {
 			setSpanError(span, err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			return nil, traceID, false, &toolError{status: http.StatusInternalServerError, message: err.Error()}
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(result)
-		return
+		payload, err := json.Marshal(result)
+		if err != nil {
+			setSpanError(span, err)
+			return nil, traceID, false, &toolError{status: http.StatusInternalServerError, message: err.Error()}
+		}
+		setSpanOK(span)
+		return payload, traceID, true, nil
 	}
 
 	// Convert input to JSON bytes for RPC call
-	inputBytes, err := json.Marshal(req.Input)
+	inputBytes, err := json.Marshal(input)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return nil, traceID, false, &toolError{status: http.StatusInternalServerError, message: err.Error()}
 	}
 
 	// Make RPC call
@@ -797,7 +887,7 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 	var rsp bytes.Frame
 
 	if err := s.opts.Client.Call(ctx, rpcReq, &rsp); err != nil {
-		s.recordCircuit(req.Tool, false)
+		s.recordCircuit(toolName, false)
 		setSpanError(span, err)
 		s.opts.Logger.Printf("[mcp] RPC call failed: %v", err)
 		accountID := ""
@@ -805,15 +895,14 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 			accountID = account.ID
 		}
 		s.audit(AuditRecord{
-			TraceID: traceID, Timestamp: time.Now(), Tool: req.Tool,
+			TraceID: traceID, Timestamp: time.Now(), Tool: toolName,
 			AccountID: accountID, ScopesRequired: tool.Scopes,
 			Allowed: true, Duration: time.Since(start), Error: err.Error(),
 		})
-		http.Error(w, fmt.Sprintf("RPC call failed: %v", err), http.StatusInternalServerError)
-		return
+		return nil, traceID, false, &toolError{status: http.StatusInternalServerError, message: fmt.Sprintf("RPC call failed: %v", err)}
 	}
 
-	s.recordCircuit(req.Tool, true)
+	s.recordCircuit(toolName, true)
 	setSpanOK(span)
 
 	// Audit successful call
@@ -822,18 +911,12 @@ func (s *Server) handleCallTool(w http.ResponseWriter, r *http.Request) {
 		accountID = account.ID
 	}
 	s.audit(AuditRecord{
-		TraceID: traceID, Timestamp: time.Now(), Tool: req.Tool,
+		TraceID: traceID, Timestamp: time.Now(), Tool: toolName,
 		AccountID: accountID, ScopesRequired: tool.Scopes,
 		Allowed: true, Duration: time.Since(start),
 	})
 
-	// Return response with trace ID
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set(TraceIDKey, traceID)
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"result":   json.RawMessage(rsp.Data),
-		"trace_id": traceID,
-	})
+	return json.RawMessage(rsp.Data), traceID, false, nil
 }
 
 // handleHealth returns gateway health status

--- a/gateway/mcp/mcp.go
+++ b/gateway/mcp/mcp.go
@@ -29,6 +29,7 @@ import (
 	"go-micro.dev/v6/broker"
 	"go-micro.dev/v6/client"
 	"go-micro.dev/v6/codec/bytes"
+	"go-micro.dev/v6/gateway/schema"
 	"go-micro.dev/v6/metadata"
 	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/store"
@@ -172,6 +173,11 @@ type Server struct {
 	server   *http.Server
 	watching bool
 
+	// resolver is the shared service schema resolver; it owns registry
+	// watching and endpoint parsing so discovery is not duplicated with the
+	// HTTP API gateway.
+	resolver *schema.Resolver
+
 	// limiters holds per-tool rate limiters (nil if rate limiting is disabled).
 	limiters   map[string]*rateLimiter
 	limitersMu sync.RWMutex
@@ -235,10 +241,12 @@ func (s *Server) paymentFor(toolName string) *PaymentInfo {
 	}
 }
 
-// Serve starts an MCP gateway with the given options.
-// For stdio transport, leave Address empty.
-// For SSE transport, set Address (e.g., ":3000").
-func Serve(opts Options) error {
+// NewServer creates an MCP gateway server from opts and starts service
+// discovery and registry watching. It does not begin serving; call
+// (*Server).Serve to start a transport and (*Server).Stop to shut down
+// gracefully. This lets callers (e.g. the micro CLI) orchestrate the MCP
+// gateway independently of any other gateway.
+func NewServer(opts Options) (*Server, error) {
 	// Set defaults
 	if opts.Client == nil {
 		opts.Client = client.DefaultClient
@@ -250,7 +258,7 @@ func Serve(opts Options) error {
 		opts.Logger = log.Default()
 	}
 	if opts.Registry == nil {
-		return fmt.Errorf("registry is required")
+		return nil, fmt.Errorf("registry is required")
 	}
 
 	server := &Server{
@@ -262,17 +270,33 @@ func Serve(opts Options) error {
 
 	// Discover services and build tool list
 	if err := server.discoverServices(); err != nil {
-		return fmt.Errorf("failed to discover services: %w", err)
+		return nil, fmt.Errorf("failed to discover services: %w", err)
 	}
 
 	// Watch for service changes
 	go server.watchServices()
 
-	// Start server based on transport
-	if opts.Address != "" {
-		return server.serveHTTP()
+	return server, nil
+}
+
+// Serve starts an MCP gateway with the given options.
+// For stdio transport, leave Address empty.
+// For SSE transport, set Address (e.g., ":3000").
+func Serve(opts Options) error {
+	server, err := NewServer(opts)
+	if err != nil {
+		return err
 	}
-	return server.serveStdio()
+	return server.Serve()
+}
+
+// Serve starts the configured transport and blocks until it stops.
+func (s *Server) Serve() error {
+	// Start server based on transport
+	if s.opts.Address != "" {
+		return s.serveHTTP()
+	}
+	return s.serveStdio()
 }
 
 // ListenAndServe is a convenience function that starts an MCP gateway on the given address.
@@ -281,101 +305,97 @@ func ListenAndServe(address string, opts Options) error {
 	return Serve(opts)
 }
 
-// discoverServices queries the registry and builds the tool list
+// discoverServices builds the tool catalog from the shared schema resolver.
+// It refreshes the resolver's registry cache so it works standalone (e.g. in
+// tests) as well as when driven by the resolver's watch loop.
 func (s *Server) discoverServices() error {
-	services, err := s.opts.Registry.ListServices()
-	if err != nil {
+	if s.resolver == nil {
+		s.resolver = schema.New(s.opts.Registry)
+	}
+	if err := s.resolver.Refresh(); err != nil {
 		return err
 	}
 
 	s.toolsMu.Lock()
 	defer s.toolsMu.Unlock()
 
-	if err := s.discoverReflectedGRPC(); err != nil {
-		return err
+	s.tools = make(map[string]*Tool)
+
+	for _, ep := range s.resolver.Endpoints() {
+		inputSchema := make(map[string]any, 2)
+		inputSchema["type"] = "object"
+		props := make(map[string]any, len(ep.Request))
+		for _, f := range ep.Request {
+			props[f.Name] = map[string]any{
+				"type":        schema.JSONType(f.Type),
+				"description": fmt.Sprintf("%s field", f.Name),
+			}
+		}
+		inputSchema["properties"] = props
+
+		tool := &Tool{
+			Name:        ep.Name,
+			Description: ep.Description,
+			InputSchema: inputSchema,
+			Service:     ep.Service,
+			Endpoint:    ep.Method,
+		}
+
+		if len(ep.Scopes) > 0 {
+			tool.Scopes = ep.Scopes
+		}
+
+		// Gateway-level Scopes override service-level scopes
+		if s.opts.Scopes != nil {
+			if scopes, ok := s.opts.Scopes[tool.Name]; ok {
+				tool.Scopes = scopes
+			}
+		}
+
+		// Add example from metadata if available
+		if ep.Example != "" {
+			inputSchema["examples"] = []string{ep.Example}
+		}
+
+		s.tools[tool.Name] = tool
+
+		// Create rate limiter for this tool if rate limiting is configured
+		if s.opts.RateLimit != nil && s.opts.RateLimit.RequestsPerSecond > 0 {
+			s.limitersMu.Lock()
+			if s.limiters == nil {
+				s.limiters = make(map[string]*rateLimiter)
+			}
+			if _, exists := s.limiters[tool.Name]; !exists {
+				s.limiters[tool.Name] = newRateLimiter(
+					s.opts.RateLimit.RequestsPerSecond,
+					s.opts.RateLimit.Burst,
+				)
+			}
+			s.limitersMu.Unlock()
+		}
+
+		// Create circuit breaker for this tool if configured
+		if s.opts.CircuitBreaker != nil {
+			s.breakersMu.Lock()
+			if s.breakers == nil {
+				s.breakers = make(map[string]*circuitBreaker)
+			}
+			if _, exists := s.breakers[tool.Name]; !exists {
+				s.breakers[tool.Name] = newCircuitBreaker(*s.opts.CircuitBreaker)
+			}
+			s.breakersMu.Unlock()
+		}
 	}
 
-	for _, svc := range services {
-		// Get full service details
-		fullSvcs, err := s.opts.Registry.GetService(svc.Name)
-		if err != nil || len(fullSvcs) == 0 {
-			continue
-		}
-
-		// Convert endpoints to tools
-		for _, ep := range fullSvcs[0].Endpoints {
-			toolName := fmt.Sprintf("%s.%s", svc.Name, ep.Name)
-
-			// Build input schema from endpoint request type
-			inputSchema := s.buildInputSchema(ep.Request)
-
-			// Get description from endpoint metadata (set by service during registration)
-			description := fmt.Sprintf("Call %s on %s service", ep.Name, svc.Name)
-			if ep.Metadata != nil {
-				if desc, ok := ep.Metadata["description"]; ok && desc != "" {
-					description = desc
-				}
-			}
-
-			tool := &Tool{
-				Name:        toolName,
-				Description: description,
-				InputSchema: inputSchema,
-				Service:     svc.Name,
-				Endpoint:    ep.Name,
-			}
-
-			// Extract scopes from endpoint metadata
-			if ep.Metadata != nil {
-				if scopes, ok := ep.Metadata["scopes"]; ok && scopes != "" {
-					tool.Scopes = strings.Split(scopes, ",")
-				}
-			}
-
-			// Gateway-level Scopes override service-level scopes
-			if s.opts.Scopes != nil {
-				if scopes, ok := s.opts.Scopes[toolName]; ok {
-					tool.Scopes = scopes
-				}
-			}
-
-			// Add example from metadata if available
-			if ep.Metadata != nil {
-				if example, ok := ep.Metadata["example"]; ok && example != "" {
-					inputSchema["examples"] = []string{example}
-				}
-			}
-
-			s.tools[toolName] = tool
-
-			// Create rate limiter for this tool if rate limiting is configured
-			if s.opts.RateLimit != nil && s.opts.RateLimit.RequestsPerSecond > 0 {
-				s.limitersMu.Lock()
-				if _, exists := s.limiters[toolName]; !exists {
-					s.limiters[toolName] = newRateLimiter(
-						s.opts.RateLimit.RequestsPerSecond,
-						s.opts.RateLimit.Burst,
-					)
-				}
-				s.limitersMu.Unlock()
-			}
-
-			// Create circuit breaker for this tool if configured
-			if s.opts.CircuitBreaker != nil {
-				s.breakersMu.Lock()
-				if _, exists := s.breakers[toolName]; !exists {
-					s.breakers[toolName] = newCircuitBreaker(*s.opts.CircuitBreaker)
-				}
-				s.breakersMu.Unlock()
-			}
-		}
+	if err := s.discoverReflectedGRPC(); err != nil {
+		return err
 	}
 
 	// Register framework primitives as tools.
 	// When Auth is configured, they require micro:admin scope.
 	s.registerFrameworkTools()
 
-	s.opts.Logger.Printf("[mcp] Discovered %d tools from %d services (incl. framework)", len(s.tools), len(services))
+	s.opts.Logger.Printf("[mcp] Discovered %d tools from %d services (incl. framework)", len(s.tools), len(s.resolver.Services()))
 	return nil
 }
 
@@ -531,73 +551,22 @@ func (s *Server) registerFrameworkTools() {
 	})
 }
 
-// buildInputSchema converts registry value type information to JSON schema
-func (s *Server) buildInputSchema(value *registry.Value) map[string]interface{} {
-	schema := map[string]interface{}{
-		"type":       "object",
-		"properties": make(map[string]interface{}),
-	}
-
-	if value == nil || len(value.Values) == 0 {
-		return schema
-	}
-
-	properties := schema["properties"].(map[string]interface{})
-	for _, field := range value.Values {
-		properties[field.Name] = map[string]interface{}{
-			"type":        s.mapGoTypeToJSON(field.Type),
-			"description": fmt.Sprintf("%s field", field.Name),
-		}
-	}
-
-	return schema
-}
-
-// mapGoTypeToJSON maps Go types to JSON schema types
-func (s *Server) mapGoTypeToJSON(goType string) string {
-	switch goType {
-	case "string":
-		return "string"
-	case "int", "int32", "int64", "uint", "uint32", "uint64":
-		return "integer"
-	case "float32", "float64":
-		return "number"
-	case "bool":
-		return "boolean"
-	default:
-		return "object"
-	}
-}
-
-// watchServices watches for service registry changes
+// watchServices watches for service registry changes via the shared schema
+// resolver and rebuilds the tool catalog on each change.
 func (s *Server) watchServices() {
 	if s.watching {
 		return
 	}
 	s.watching = true
 
-	watcher, err := s.opts.Registry.Watch()
-	if err != nil {
-		s.opts.Logger.Printf("[mcp] Failed to watch registry: %v", err)
-		return
+	if s.resolver == nil {
+		s.resolver = schema.New(s.opts.Registry)
 	}
-	defer watcher.Stop()
-
-	for {
-		select {
-		case <-s.opts.Context.Done():
-			return
-		default:
-			_, err := watcher.Next()
-			if err != nil {
-				time.Sleep(time.Second)
-				continue
-			}
-
-			// Rediscover services on any change
-			if err := s.discoverServices(); err != nil {
-				s.opts.Logger.Printf("[mcp] Failed to rediscover services: %v", err)
-			}
+	s.resolver.Start(s.opts.Context)
+	for range s.resolver.Changes() {
+		// Rediscover services on any change
+		if err := s.discoverServices(); err != nil {
+			s.opts.Logger.Printf("[mcp] Failed to rediscover services: %v", err)
 		}
 	}
 }

--- a/gateway/mcp/streamable.go
+++ b/gateway/mcp/streamable.go
@@ -1,0 +1,395 @@
+// Streamable-HTTP MCP transport (JSON-RPC 2.0 over POST/GET/DELETE), per the
+// MCP spec:
+//
+//   - POST sends a JSON-RPC request or notification. Requests get an
+//     application/json response (or an SSE stream); notifications get HTTP 202.
+//   - GET opens a text/event-stream for server→client messages, correlated via
+//     the Mcp-Session-Id header.
+//   - DELETE terminates a session.
+//   - A session is minted on initialize; its id is returned in the
+//     Mcp-Session-Id header and must be echoed on later requests.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// mcpSessionHeader is the HTTP header carrying the MCP session id.
+const mcpSessionHeader = "Mcp-Session-Id"
+
+// mcpProtocolVersion is advertised (and echoed from the client's request)
+// during initialize.
+const mcpProtocolVersion = "2025-06-18"
+
+// httpSession tracks one MCP client session: an id for Mcp-Session-Id
+// correlation and, once the client opens the GET stream, the pipe for
+// server→client messages.
+type httpSession struct {
+	id       string
+	lastSeen time.Time
+	ch       chan []byte
+
+	mu   sync.Mutex
+	open bool // whether a GET SSE stream is currently open
+}
+
+// session returns the registered session for id, or nil.
+func (s *Server) session(id string) *httpSession {
+	if id == "" {
+		return nil
+	}
+	s.sessionsMu.RLock()
+	defer s.sessionsMu.RUnlock()
+	return s.sessions[id]
+}
+
+// newSession mints and registers a session.
+func (s *Server) newSession() *httpSession {
+	sess := &httpSession{
+		id:       uuid.New().String(),
+		lastSeen: time.Now(),
+		ch:       make(chan []byte, 32),
+	}
+	s.sessionsMu.Lock()
+	s.sessions[sess.id] = sess
+	s.sessionsMu.Unlock()
+	return sess
+}
+
+// emit sends a server→client JSON-RPC message to the session's SSE stream.
+// It reports false if the session has no open stream.
+func (s *Server) emit(sess *httpSession, msg []byte) bool {
+	sess.mu.Lock()
+	open := sess.open
+	sess.mu.Unlock()
+	if !open {
+		return false
+	}
+	select {
+	case sess.ch <- msg:
+		return true
+	default:
+		// Slow stream: drop rather than block the caller.
+		return true
+	}
+}
+
+// sweepSessions periodically drops sessions that have been idle and have no
+// open stream. ponytail: one background sweep; per-session TTL timers only if
+// session churn ever matters.
+func (s *Server) sweepSessions(ctx context.Context) {
+	t := time.NewTicker(10 * time.Minute)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			cutoff := time.Now().Add(-30 * time.Minute)
+			s.sessionsMu.Lock()
+			for id, sess := range s.sessions {
+				sess.mu.Lock()
+				idle := !sess.open && sess.lastSeen.Before(cutoff)
+				sess.mu.Unlock()
+				if idle {
+					delete(s.sessions, id)
+				}
+			}
+			s.sessionsMu.Unlock()
+		}
+	}
+}
+
+// handleStreamableHTTP routes the MCP streamable-HTTP methods.
+func (s *Server) handleStreamableHTTP(w http.ResponseWriter, r *http.Request) {
+	// The gateway is often called from browser-based MCP clients; allow
+	// cross-origin use even without a proxy in front.
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, MCP-Protocol-Version, MCP-Session-Id, MCP-Request-Id, Authorization")
+
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		s.handleStreamablePOST(w, r)
+	case http.MethodGet:
+		s.handleStreamableGET(w, r)
+	case http.MethodDelete:
+		s.handleStreamableDelete(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleStreamablePOST processes a JSON-RPC request or notification (single or
+// batch). Requests get an application/json response; notifications get 202.
+func (s *Server) handleStreamablePOST(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var body json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		w.Write(streamRPCError(nil, ParseError, "Parse error", err.Error()))
+		return
+	}
+	body = []byte(strings.TrimSpace(string(body)))
+
+	var messages []json.RawMessage
+	if len(body) > 0 && body[0] == '[' {
+		if err := json.Unmarshal(body, &messages); err != nil {
+			w.Write(streamRPCError(nil, ParseError, "Parse error", err.Error()))
+			return
+		}
+	} else {
+		messages = []json.RawMessage{body}
+	}
+
+	sess := s.session(r.Header.Get(mcpSessionHeader))
+	var responses []json.RawMessage
+	for _, raw := range messages {
+		resp, abort := s.handleStreamMessage(w, r, raw, &sess)
+		if abort {
+			return
+		}
+		if resp != nil {
+			responses = append(responses, resp)
+		}
+	}
+
+	if len(responses) == 0 {
+		// Notifications only.
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if len(responses) == 1 {
+		w.Write(responses[0])
+		return
+	}
+	w.Write(streamRPCBatch(responses))
+}
+
+// handleStreamMessage dispatches one JSON-RPC message. It returns the response
+// to write (nil for notifications) and whether the response was already written
+// by the x402 gate (abort).
+func (s *Server) handleStreamMessage(w http.ResponseWriter, r *http.Request, raw json.RawMessage, sessPtr **httpSession) (json.RawMessage, bool) {
+	var rpc struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(raw, &rpc); err != nil {
+		return streamRPCError(nil, ParseError, "Parse error", err.Error()), false
+	}
+	if rpc.JSONRPC != "2.0" {
+		return streamRPCError(rpc.ID, InvalidRequest, "Invalid request", "jsonrpc must be '2.0'"), false
+	}
+
+	// Notifications carry no id and get no response.
+	if len(rpc.ID) == 0 {
+		return nil, false
+	}
+
+	switch rpc.Method {
+	case "initialize":
+		sess := *sessPtr
+		if sess == nil {
+			sess = s.newSession()
+			*sessPtr = sess
+		}
+		sess.lastSeen = time.Now()
+		w.Header().Set(mcpSessionHeader, sess.id)
+		return s.mcpInitialize(rpc.Params, rpc.ID), false
+	case "ping":
+		return streamRPCResult(rpc.ID, map[string]interface{}{}), false
+	case "tools/list":
+		return s.mcpToolsList(rpc.ID), false
+	case "tools/call":
+		return s.mcpToolsCall(w, r, rpc.Params, rpc.ID)
+	default:
+		return streamRPCError(rpc.ID, MethodNotFound, "Method not found", rpc.Method), false
+	}
+}
+
+// mcpInitialize answers the initialize handshake, minting the session that
+// handleStreamMessage set on the response headers.
+func (s *Server) mcpInitialize(params json.RawMessage, id json.RawMessage) json.RawMessage {
+	version := mcpProtocolVersion
+	var p struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := json.Unmarshal(params, &p); err == nil && p.ProtocolVersion != "" {
+		// Echo the client's requested version: every method we implement is
+		// version-agnostic, so this always yields a version the client accepts.
+		version = p.ProtocolVersion
+	}
+	return streamRPCResult(id, map[string]interface{}{
+		"protocolVersion": version,
+		"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+		"serverInfo":      map[string]interface{}{"name": "go-micro-mcp", "version": "1.0.0"},
+	})
+}
+
+// mcpToolsList answers tools/list from the shared tool catalog.
+func (s *Server) mcpToolsList(id json.RawMessage) json.RawMessage {
+	return streamRPCResult(id, map[string]interface{}{"tools": s.toolCatalog()})
+}
+
+// mcpToolsCall answers tools/call, sharing the REST endpoint's pipeline via
+// invokeTool. Tool-execution failures become isError results per the MCP spec;
+// pre-flight failures (auth, rate limit, …) become JSON-RPC errors.
+func (s *Server) mcpToolsCall(w http.ResponseWriter, r *http.Request, params json.RawMessage, id json.RawMessage) (json.RawMessage, bool) {
+	var p struct {
+		Name      string                 `json:"name"`
+		Arguments map[string]interface{} `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.Name == "" {
+		return streamRPCError(id, InvalidParams, "Invalid params", "name is required"), false
+	}
+
+	payload, traceID, _, err := s.invokeTool(w, r, p.Name, p.Arguments)
+	if err == errResponseWritten {
+		// The x402 gate wrote its own 402 challenge.
+		return nil, true
+	}
+	if err != nil {
+		if te, ok := err.(*toolError); ok {
+			if te.status == http.StatusInternalServerError {
+				return streamRPCResult(id, mcpToolError(traceID, te.message)), false
+			}
+			return streamRPCError(id, mcpCodeForStatus(te.status), te.message, nil), false
+		}
+		return streamRPCError(id, InternalError, "Tool call failed", err.Error()), false
+	}
+
+	return streamRPCResult(id, mcpToolResult(traceID, payload)), false
+}
+
+// mcpCodeForStatus maps a tool-pipeline HTTP status to an MCP JSON-RPC code.
+func mcpCodeForStatus(status int) int {
+	switch status {
+	case http.StatusUnauthorized:
+		return -32001 // Unauthorized
+	case http.StatusForbidden:
+		return -32002 // Forbidden
+	case http.StatusNotFound:
+		return InvalidParams // tool not found
+	default:
+		return InternalError
+	}
+}
+
+// handleStreamableGET opens the server→client SSE stream for a session. A
+// request without a (known) session id gets 405 — the reference MCP SDK treats
+// that as "no SSE stream offered" and continues.
+func (s *Server) handleStreamableGET(w http.ResponseWriter, r *http.Request) {
+	sess := s.session(r.Header.Get(mcpSessionHeader))
+	if sess == nil {
+		http.Error(w, "session required", http.StatusMethodNotAllowed)
+		return
+	}
+
+	sess.mu.Lock()
+	if sess.open {
+		sess.mu.Unlock()
+		http.Error(w, "stream already open", http.StatusMethodNotAllowed)
+		return
+	}
+	sess.open = true
+	sess.lastSeen = time.Now()
+	sess.mu.Unlock()
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		sess.mu.Lock()
+		sess.open = false
+		sess.mu.Unlock()
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush() // send headers now; the client's GET must not block on the first event
+
+	// Release the session when the client disconnects.
+	go func() {
+		<-r.Context().Done()
+		sess.mu.Lock()
+		sess.open = false
+		sess.mu.Unlock()
+	}()
+
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case msg := <-sess.ch:
+			if _, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", msg); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+// handleStreamableDelete terminates a session. The MCP SDK client treats 405 as
+// "termination unsupported", so unknown sessions get 405 rather than an error.
+func (s *Server) handleStreamableDelete(w http.ResponseWriter, r *http.Request) {
+	sid := r.Header.Get(mcpSessionHeader)
+	if sid == "" {
+		http.Error(w, "session required", http.StatusMethodNotAllowed)
+		return
+	}
+	s.sessionsMu.Lock()
+	_, ok := s.sessions[sid]
+	delete(s.sessions, sid)
+	s.sessionsMu.Unlock()
+	if !ok {
+		http.Error(w, "unknown session", http.StatusMethodNotAllowed)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func streamRPCResult(id json.RawMessage, result interface{}) json.RawMessage {
+	b, _ := json.Marshal(map[string]interface{}{"jsonrpc": "2.0", "id": rawOrNull(id), "result": result})
+	return b
+}
+
+func streamRPCError(id json.RawMessage, code int, msg string, data interface{}) json.RawMessage {
+	b, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      rawOrNull(id),
+		"error":   map[string]interface{}{"code": code, "message": msg, "data": data},
+	})
+	return b
+}
+
+func streamRPCBatch(responses []json.RawMessage) json.RawMessage {
+	b, _ := json.Marshal(responses)
+	return b
+}

--- a/gateway/mcp/streamable_test.go
+++ b/gateway/mcp/streamable_test.go
@@ -1,0 +1,286 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newStreamServer(t *testing.T) (*Server, *httptest.Server) {
+	t.Helper()
+	s := newTestServer(Options{})
+	s.tools["echo.Echo"] = &Tool{
+		Name:        "echo.Echo",
+		Description: "Echo input back",
+		InputSchema: map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
+		Handler: func(input map[string]interface{}) (interface{}, error) {
+			return input, nil
+		},
+	}
+	ts := httptest.NewServer(s.handler())
+	t.Cleanup(ts.Close)
+	return s, ts
+}
+
+// rpcRequest posts a JSON-RPC body to /mcp and returns the raw response.
+func rpcRequest(t *testing.T, ts *httptest.Server, sessionID string, body string) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if sessionID != "" {
+		req.Header.Set(mcpSessionHeader, sessionID)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	return resp, data
+}
+
+func decodeRPC(t *testing.T, data []byte) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("not a JSON object: %s", data)
+	}
+	return m
+}
+
+func TestStreamable_Handshake(t *testing.T) {
+	_, ts := newStreamServer(t)
+
+	resp, data := rpcRequest(t, ts, "", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", resp.StatusCode, data)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type = %q", ct)
+	}
+	sid := resp.Header.Get(mcpSessionHeader)
+	if sid == "" {
+		t.Fatal("initialize response missing Mcp-Session-Id")
+	}
+
+	m := decodeRPC(t, data)
+	if m["jsonrpc"] != "2.0" {
+		t.Errorf("jsonrpc = %v", m["jsonrpc"])
+	}
+	result, _ := m["result"].(map[string]interface{})
+	if result["protocolVersion"] != "2025-06-18" {
+		t.Errorf("protocolVersion = %v", result["protocolVersion"])
+	}
+	if m["error"] != nil {
+		t.Errorf("unexpected error: %v", m["error"])
+	}
+
+	// notifications/initialized → 202, no body.
+	resp, data = rpcRequest(t, ts, sid, `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("notification status = %d, want 202", resp.StatusCode)
+	}
+	if len(data) != 0 {
+		t.Errorf("notification body = %s, want empty", data)
+	}
+}
+
+func TestStreamable_ToolsListAndCall(t *testing.T) {
+	_, ts := newStreamServer(t)
+
+	// initialize to get a session
+	_, data := rpcRequest(t, ts, "", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}`)
+	sid := mustSessionID(t, ts)
+	_ = data
+
+	// tools/list
+	_, data = rpcRequest(t, ts, sid, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	m := decodeRPC(t, data)
+	result, _ := m["result"].(map[string]interface{})
+	tools, _ := result["tools"].([]interface{})
+	if len(tools) == 0 {
+		t.Fatal("expected tools in tools/list result")
+	}
+	found := false
+	for _, ti := range tools {
+		if tm, _ := ti.(map[string]interface{}); tm["name"] == "echo.Echo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("echo.Echo not listed: %v", tools)
+	}
+
+	// tools/call
+	_, data = rpcRequest(t, ts, sid, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo.Echo","arguments":{"msg":"hi"}}}`)
+	m = decodeRPC(t, data)
+	result, _ = m["result"].(map[string]interface{})
+	content, _ := result["content"].([]interface{})
+	if len(content) == 0 {
+		t.Fatal("expected content in tools/call result")
+	}
+	text := content[0].(map[string]interface{})["text"]
+	if text != `{"msg":"hi"}` {
+		t.Errorf("content text = %v", text)
+	}
+}
+
+func TestStreamable_UnknownTool(t *testing.T) {
+	_, ts := newStreamServer(t)
+	_, data := rpcRequest(t, ts, "", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	sid := mustSessionID(t, ts)
+	_ = data
+
+	_, data = rpcRequest(t, ts, sid, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"nope.Do","arguments":{}}}`)
+	m := decodeRPC(t, data)
+	errObj, _ := m["error"].(map[string]interface{})
+	if errObj == nil {
+		t.Fatalf("expected error, got: %s", data)
+	}
+	if errObj["code"] != float64(-32602) {
+		t.Errorf("error code = %v, want -32602", errObj["code"])
+	}
+}
+
+func TestStreamable_MethodNotFound(t *testing.T) {
+	_, ts := newStreamServer(t)
+	_, data := rpcRequest(t, ts, "", `{"jsonrpc":"2.0","id":5,"method":"prompts/list"}`)
+	m := decodeRPC(t, data)
+	errObj, _ := m["error"].(map[string]interface{})
+	if errObj == nil || errObj["code"] != float64(MethodNotFound) {
+		t.Errorf("expected method not found, got: %s", data)
+	}
+}
+
+func TestStreamable_Batch(t *testing.T) {
+	_, ts := newStreamServer(t)
+	_, data := rpcRequest(t, ts, "", `[{"jsonrpc":"2.0","id":6,"method":"ping"},{"jsonrpc":"2.0","id":7,"method":"ping"}]`)
+	var batch []map[string]interface{}
+	if err := json.Unmarshal(data, &batch); err != nil {
+		t.Fatalf("expected batch array, got: %s", data)
+	}
+	if len(batch) != 2 {
+		t.Fatalf("batch length = %d", len(batch))
+	}
+	for _, m := range batch {
+		if m["error"] != nil || m["result"] == nil {
+			t.Errorf("bad batch element: %v", m)
+		}
+	}
+}
+
+func TestStreamable_SessionLifecycle(t *testing.T) {
+	s, ts := newStreamServer(t)
+
+	_, data := rpcRequest(t, ts, "", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	sid := mustSessionID(t, ts)
+	_ = data
+
+	// Open the GET SSE stream for the session.
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/mcp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set(mcpSessionHeader, sid)
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status = %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("content-type = %q", ct)
+	}
+
+	// Push a server→client message and read it off the stream.
+	sess := s.session(sid)
+	if sess == nil {
+		t.Fatal("session not registered")
+	}
+	s.emit(sess, []byte(`{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}`))
+
+	reader := bufio.NewReader(resp.Body)
+	var got []string
+	deadline := time.Now().Add(5 * time.Second)
+	for len(got) < 3 && time.Now().Before(deadline) {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			break
+		}
+		got = append(got, strings.TrimRight(line, "\r\n"))
+	}
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "event: message") || !strings.Contains(joined, "notifications/tools/list_changed") {
+		t.Errorf("SSE stream did not deliver the event. got:\n%s", joined)
+	}
+
+	// DELETE terminates the session.
+	delReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/mcp", nil)
+	delReq.Header.Set(mcpSessionHeader, sid)
+	delResp, err := ts.Client().Do(delReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer delResp.Body.Close()
+	if delResp.StatusCode != http.StatusNoContent {
+		t.Errorf("DELETE status = %d, want 204", delResp.StatusCode)
+	}
+	if s.session(sid) != nil {
+		t.Error("session still registered after DELETE")
+	}
+}
+
+func TestStreamable_GETWithoutSession(t *testing.T) {
+	_, ts := newStreamServer(t)
+	resp, err := ts.Client().Get(ts.URL + "/mcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("GET without session status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestStreamable_ParseError(t *testing.T) {
+	_, ts := newStreamServer(t)
+	resp, data := rpcRequest(t, ts, "", `not json`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	m := decodeRPC(t, data)
+	errObj, _ := m["error"].(map[string]interface{})
+	if errObj == nil || errObj["code"] != float64(ParseError) {
+		t.Errorf("expected parse error, got: %s", data)
+	}
+}
+
+func mustSessionID(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp", bytes.NewReader([]byte(`{"jsonrpc":"2.0","id":99,"method":"initialize","params":{}}`)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	sid := resp.Header.Get(mcpSessionHeader)
+	if sid == "" {
+		t.Fatal("no session id in initialize response")
+	}
+	return sid
+}

--- a/gateway/schema/schema.go
+++ b/gateway/schema/schema.go
@@ -1,0 +1,288 @@
+// Package schema provides a unified service schema resolver shared by the HTTP
+// API gateway and the MCP gateway. It owns registry watching and endpoint
+// parsing so both gateways query one cached catalog instead of duplicating
+// discovery and reflection logic.
+package schema
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"go-micro.dev/v6/registry"
+)
+
+// Field describes one request or response field of an endpoint.
+type Field struct {
+	Name string
+	Type string
+}
+
+// Endpoint is the resolved schema for one service endpoint, keyed by its
+// dotted name "Service.Endpoint" (e.g. "helloworld.Helloworld.Call").
+type Endpoint struct {
+	// Service is the registered service name (e.g. "helloworld").
+	Service string
+	// Name is the dotted endpoint name (e.g. "helloworld.Helloworld.Call").
+	Name string
+	// Method is the registry endpoint name (e.g. "Helloworld.Call").
+	Method string
+	// Description is the endpoint description from metadata, or a default.
+	Description string
+	// Request lists the endpoint's request fields.
+	Request []Field
+	// Response lists the endpoint's response fields.
+	Response []Field
+	// Scopes is the comma-separated scope requirement from endpoint metadata.
+	Scopes []string
+	// Example is an example input from endpoint metadata, if any.
+	Example string
+	// Metadata is the raw endpoint metadata.
+	Metadata map[string]string
+}
+
+// Resolver watches a registry and caches the endpoint catalog so REST proxying
+// and MCP tool cataloging share one source of service metadata.
+type Resolver struct {
+	reg       registry.Registry
+	logger    *log.Logger
+	mu        sync.RWMutex
+	services  map[string]*registry.Service // service name -> latest snapshot
+	endpoints map[string]*Endpoint         // dotted name -> endpoint schema
+	changes   chan struct{}
+	startOnce sync.Once
+}
+
+// New returns a resolver bound to reg.
+func New(reg registry.Registry) *Resolver {
+	return &Resolver{
+		reg:       reg,
+		logger:    log.Default(),
+		services:  map[string]*registry.Service{},
+		endpoints: map[string]*Endpoint{},
+		changes:   make(chan struct{}, 1),
+	}
+}
+
+// WithLogger sets the logger used for registry watch errors.
+func (r *Resolver) WithLogger(l *log.Logger) *Resolver {
+	if l != nil {
+		r.logger = l
+	}
+	return r
+}
+
+// refreshInterval is a fallback poll so the catalog self-heals if a watch
+// event is dropped (registries deliver events asynchronously and may miss
+// bursts that arrive while a refresh is in progress).
+const refreshInterval = 15 * time.Second
+
+// Start refreshes the catalog once, then watches the registry and re-refreshes
+// on every change until ctx is done. The watcher is registered before Start
+// returns so no events are missed. Safe to call once.
+func (r *Resolver) Start(ctx context.Context) {
+	r.startOnce.Do(func() {
+		if err := r.Refresh(); err != nil {
+			r.logger.Printf("[schema] initial registry refresh failed: %v", err)
+		}
+		watcher, err := r.reg.Watch()
+		if err != nil {
+			r.logger.Printf("[schema] registry watch failed: %v", err)
+			return
+		}
+		go r.watch(ctx, watcher)
+	})
+}
+
+func (r *Resolver) watch(ctx context.Context, watcher registry.Watcher) {
+	defer watcher.Stop()
+
+	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := r.Refresh(); err != nil {
+				r.logger.Printf("[schema] registry refresh failed: %v", err)
+			}
+			continue
+		default:
+		}
+		if _, err := watcher.Next(); err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+		if err := r.Refresh(); err != nil {
+			r.logger.Printf("[schema] registry refresh failed: %v", err)
+			continue
+		}
+		select {
+		case r.changes <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// Refresh re-reads the registry and rebuilds the catalog. It does not signal
+// Changes(); only the internal watch loop does, so callers that refresh from
+// their own handlers (e.g. the MCP gateway rediscovering tools) do not loop.
+func (r *Resolver) Refresh() error {
+	services, err := r.reg.ListServices()
+	if err != nil {
+		return err
+	}
+
+	snapshot := make(map[string]*registry.Service, len(services))
+	endpoints := make(map[string]*Endpoint)
+	for _, svc := range services {
+		full, err := r.reg.GetService(svc.Name)
+		if err != nil || len(full) == 0 {
+			continue
+		}
+		snapshot[svc.Name] = full[0]
+		for _, ep := range full[0].Endpoints {
+			e := resolveEndpoint(svc.Name, ep)
+			endpoints[e.Name] = e
+		}
+	}
+
+	r.mu.Lock()
+	r.services = snapshot
+	r.endpoints = endpoints
+	r.mu.Unlock()
+	return nil
+}
+
+func resolveEndpoint(service string, ep *registry.Endpoint) *Endpoint {
+	e := &Endpoint{
+		Service:  service,
+		Name:     service + "." + ep.Name,
+		Method:   ep.Name,
+		Metadata: ep.Metadata,
+	}
+	e.Description = fmt.Sprintf("Call %s on %s service", ep.Name, service)
+	if ep.Metadata != nil {
+		if d, ok := ep.Metadata["description"]; ok && d != "" {
+			e.Description = d
+		}
+		if scopes, ok := ep.Metadata["scopes"]; ok && scopes != "" {
+			for _, scope := range strings.Split(scopes, ",") {
+				if scope = strings.TrimSpace(scope); scope != "" {
+					e.Scopes = append(e.Scopes, scope)
+				}
+			}
+		}
+		if example, ok := ep.Metadata["example"]; ok {
+			e.Example = example
+		}
+	}
+	e.Request = fieldsOf(ep.Request)
+	e.Response = fieldsOf(ep.Response)
+	return e
+}
+
+func fieldsOf(v *registry.Value) []Field {
+	if v == nil {
+		return nil
+	}
+	out := make([]Field, 0, len(v.Values))
+	for _, f := range v.Values {
+		out = append(out, Field{Name: f.Name, Type: f.Type})
+	}
+	return out
+}
+
+// Endpoints returns the catalog, sorted by dotted name.
+func (r *Resolver) Endpoints() []*Endpoint {
+	r.mu.RLock()
+	out := make([]*Endpoint, 0, len(r.endpoints))
+	for _, e := range r.endpoints {
+		out = append(out, e)
+	}
+	r.mu.RUnlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Endpoint returns the schema for a dotted endpoint name.
+func (r *Resolver) Endpoint(name string) (*Endpoint, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.endpoints[name]
+	return e, ok
+}
+
+// EndpointsFor returns the endpoints of a service, sorted by dotted name.
+func (r *Resolver) EndpointsFor(service string) []*Endpoint {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []*Endpoint
+	for _, e := range r.endpoints {
+		if e.Service == service {
+			out = append(out, e)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Service returns the latest registry snapshot for a service, or nil.
+func (r *Resolver) Service(name string) *registry.Service {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.services[name]
+}
+
+// Services returns the registered service names, sorted.
+func (r *Resolver) Services() []string {
+	r.mu.RLock()
+	out := make([]string, 0, len(r.services))
+	for name := range r.services {
+		out = append(out, name)
+	}
+	r.mu.RUnlock()
+	sort.Strings(out)
+	return out
+}
+
+// HasService reports whether a service is currently registered.
+func (r *Resolver) HasService(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.services[name]
+	return ok
+}
+
+// Changes returns a channel that signals each catalog refresh from the watch
+// loop. The initial refresh from Start is not signaled.
+func (r *Resolver) Changes() <-chan struct{} {
+	return r.changes
+}
+
+// JSONType maps a Go type to a JSON schema type. Shared so REST and MCP
+// gateways emit identical endpoint schemas.
+func JSONType(goType string) string {
+	switch goType {
+	case "string":
+		return "string"
+	case "int", "int32", "int64", "uint", "uint32", "uint64":
+		return "integer"
+	case "float32", "float64":
+		return "number"
+	case "bool":
+		return "boolean"
+	default:
+		return "object"
+	}
+}

--- a/gateway/schema/schema_test.go
+++ b/gateway/schema/schema_test.go
@@ -1,0 +1,177 @@
+package schema
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go-micro.dev/v6/registry"
+)
+
+func TestResolverDiscoversEndpoints(t *testing.T) {
+	reg := registry.NewMemoryRegistry()
+	svc := &registry.Service{
+		Name: "blog",
+		Nodes: []*registry.Node{{
+			Id:      "blog-1",
+			Address: "localhost:9090",
+		}},
+		Endpoints: []*registry.Endpoint{
+			{
+				Name: "Blog.Create",
+				Metadata: map[string]string{
+					"description": "Create a blog post",
+					"scopes":      "blog:write, blog:admin",
+					"example":     `{"title":"hi"}`,
+				},
+				Request: &registry.Value{
+					Name: "Request",
+					Values: []*registry.Value{
+						{Name: "title", Type: "string"},
+						{Name: "likes", Type: "int64"},
+					},
+				},
+				Response: &registry.Value{
+					Name: "Response",
+					Values: []*registry.Value{
+						{Name: "id", Type: "string"},
+					},
+				},
+			},
+			{Name: "Blog.Read"},
+		},
+	}
+	if err := reg.Register(svc); err != nil {
+		t.Fatal(err)
+	}
+
+	r := New(reg)
+	if err := r.Refresh(); err != nil {
+		t.Fatal(err)
+	}
+
+	eps := r.Endpoints()
+	if len(eps) != 2 {
+		t.Fatalf("got %d endpoints, want 2", len(eps))
+	}
+
+	create, ok := r.Endpoint("blog.Blog.Create")
+	if !ok {
+		t.Fatal("expected blog.Blog.Create")
+	}
+	if create.Service != "blog" || create.Method != "Blog.Create" {
+		t.Errorf("unexpected service/method: %s/%s", create.Service, create.Method)
+	}
+	if create.Description != "Create a blog post" {
+		t.Errorf("description = %q", create.Description)
+	}
+	if len(create.Scopes) != 2 || create.Scopes[0] != "blog:write" || create.Scopes[1] != "blog:admin" {
+		t.Errorf("scopes = %v", create.Scopes)
+	}
+	if create.Example != `{"title":"hi"}` {
+		t.Errorf("example = %q", create.Example)
+	}
+	if len(create.Request) != 2 || create.Request[0].Name != "title" || create.Request[0].Type != "string" {
+		t.Errorf("request = %+v", create.Request)
+	}
+	if len(create.Response) != 1 || create.Response[0].Name != "id" {
+		t.Errorf("response = %+v", create.Response)
+	}
+
+	read, ok := r.Endpoint("blog.Blog.Read")
+	if !ok || read.Description != "Call Blog.Read on blog service" {
+		t.Errorf("unexpected read endpoint: %+v", read)
+	}
+
+	if !r.HasService("blog") || r.HasService("nope") {
+		t.Error("HasService mismatch")
+	}
+	if got := r.Services(); len(got) != 1 || got[0] != "blog" {
+		t.Errorf("Services = %v", got)
+	}
+	if got := r.EndpointsFor("blog"); len(got) != 2 {
+		t.Errorf("EndpointsFor = %d", len(got))
+	}
+	if s := r.Service("blog"); s == nil || s.Name != "blog" {
+		t.Errorf("Service snapshot = %v", s)
+	}
+}
+
+func TestResolverWatchRefreshesCatalog(t *testing.T) {
+	reg := registry.NewMemoryRegistry()
+	svc := &registry.Service{
+		Name: "blog",
+		Nodes: []*registry.Node{{
+			Id:      "blog-1",
+			Address: "localhost:9090",
+		}},
+		Endpoints: []*registry.Endpoint{{Name: "Blog.Create"}},
+	}
+	if err := reg.Register(svc); err != nil {
+		t.Fatal(err)
+	}
+
+	r := New(reg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r.Start(ctx)
+
+	if _, ok := waitEndpoint(r, "blog.Blog.Create"); !ok {
+		t.Fatal("initial refresh did not populate catalog")
+	}
+
+	svc2 := &registry.Service{
+		Name: "users",
+		Nodes: []*registry.Node{{
+			Id:      "users-1",
+			Address: "localhost:9091",
+		}},
+		Endpoints: []*registry.Endpoint{{Name: "Users.Get"}},
+	}
+	if err := reg.Register(svc2); err != nil {
+		t.Fatal(err)
+	}
+	// Memory registry watchers deliver async events; the watch loop retries.
+	if _, ok := waitEndpoint(r, "users.Users.Get"); !ok {
+		t.Fatal("watch did not pick up new service")
+	}
+
+	// De-registering drops the endpoint from the catalog.
+	_ = reg.Deregister(svc)
+	if waitGone(r, "blog.Blog.Create") {
+		t.Fatal("deregistered service still in catalog")
+	}
+}
+
+func TestJSONType(t *testing.T) {
+	cases := map[string]string{
+		"string": "string", "int": "integer", "int32": "integer", "uint64": "integer",
+		"float32": "number", "float64": "number", "bool": "boolean",
+		"map": "object", "unknown": "object",
+	}
+	for in, want := range cases {
+		if got := JSONType(in); got != want {
+			t.Errorf("JSONType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func waitEndpoint(r *Resolver, name string) (*Endpoint, bool) {
+	for i := 0; i < 50; i++ {
+		if e, ok := r.Endpoint(name); ok {
+			return e, true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil, false
+}
+
+func waitGone(r *Resolver, name string) bool {
+	for i := 0; i < 50; i++ {
+		if _, ok := r.Endpoint(name); !ok {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return true
+}

--- a/internal/website/content/en/docs/guides/ai-native-services.md
+++ b/internal/website/content/en/docs/guides/ai-native-services.md
@@ -224,6 +224,7 @@ Your service is now available at:
 - **Web Dashboard:** http://localhost:8080/
 - **Agent Playground:** http://localhost:8080/agent
 - **MCP Tools:** http://localhost:8080/mcp/tools
+- **MCP Streamable-HTTP:** http://localhost:3000/mcp (browser MCP clients)
 - **WebSocket:** ws://localhost:3000/mcp/ws
 - **API Gateway:** http://localhost:8080/api/tasks/TaskService/Create
 
@@ -313,6 +314,16 @@ ws.send(JSON.stringify({
   params: {}
 }));
 ```
+
+### Use with Browser MCP Clients
+
+Point any spec-compliant MCP client (Claude desktop, browser agents) at the streamable-HTTP endpoint:
+
+```text
+http://localhost:3000/mcp
+```
+
+It speaks JSON-RPC 2.0 over `POST`/`GET`/`DELETE` and allows cross-origin requests, so browser-based agents can discover and call your services directly — no WebSocket or proxy needed. See the [MCP guide](../mcp/index.md#streamable-http-transport-browser-mcp-clients) for the full handshake.
 
 ## Step 6: Test Your Tools
 

--- a/internal/website/content/en/docs/guides/cli-gateway.md
+++ b/internal/website/content/en/docs/guides/cli-gateway.md
@@ -221,9 +221,35 @@ Scopes provide fine-grained access control over which tokens can call which endp
 
 - Direct API calls (`/api/{service}/{endpoint}`)
 - MCP tool calls (`/mcp/call`)
+- Streamable-HTTP MCP tool calls (`/mcp`)
+- WebSocket MCP tool calls (`/mcp/ws`)
 - Agent playground tool invocations
 
 The gateway uses `auth.Account` from the go-micro framework. The account's `Scopes` field carries the same `[]string` used by the framework's `wrapper/auth` package for service-level auth.
+
+### 7. MCP Gateway (AI Tool Access)
+
+Every discovered service endpoint is an AI-callable MCP tool. The MCP gateway is its own server, independent of the HTTP API gateway — `--mcp-address` starts it alongside the HTTP gateway and the CLI shuts both down gracefully when the first one exits or a signal arrives.
+
+```bash
+# Dashboard/API on :8080 + MCP gateway on :3000
+micro gateway --mcp-address :3000
+
+# With production controls on the MCP gateway (scopes, rate limiting, audit, x402)
+micro gateway --mcp-address :3000 --auth --audit --rate-limit 100
+
+# Development loop, same flag
+micro run --mcp-address :3000
+```
+
+The MCP gateway serves four transports on its address (`:3000` in the examples):
+
+- **Streamable-HTTP** at `/mcp` — spec-compliant JSON-RPC 2.0; the endpoint for browser MCP clients (CORS enabled)
+- **WebSocket** at `/mcp/ws` — bidirectional streaming for agent frameworks
+- **Legacy REST** at `/mcp/tools` and `/mcp/call` — simple tool listing and calls
+- **Stdio** via `micro mcp serve` — for local CLI agents (Claude Code)
+
+Scopes set in `/auth/scopes` are enforced on MCP tool calls across all transports. See the [MCP guide](../mcp/index.md) for the full walkthrough.
 
 ## Architecture Benefits
 

--- a/internal/website/content/en/docs/guides/micro-run.md
+++ b/internal/website/content/en/docs/guides/micro-run.md
@@ -40,7 +40,7 @@ Plus:
 - **Hot Reload** - File changes trigger automatic rebuild
 - **Dependency Ordering** - Services start in the right order
 - **Environment Management** - Dev/staging/production configs
-- **MCP Gateway** - Optional dedicated MCP protocol listener via `--mcp-address`
+- **MCP Gateway** - Optional standalone MCP protocol listener via `--mcp-address`, run independently of the HTTP gateway (streamable-HTTP at `/mcp`, WebSocket at `/mcp/ws`)
 
 ## Features
 
@@ -267,7 +267,7 @@ micro run --address :3000        # Custom gateway port
 micro run --no-gateway           # Services only, no HTTP gateway
 micro run --no-watch             # Disable hot reload
 micro run --env production       # Use production environment
-micro run --mcp-address :3000    # Enable MCP protocol gateway for AI clients
+micro run --mcp-address :3000    # Enable the MCP gateway for AI clients (runs alongside the HTTP gateway)
 ```
 
 ## Going to production

--- a/internal/website/content/en/docs/mcp.md
+++ b/internal/website/content/en/docs/mcp.md
@@ -12,7 +12,9 @@ MCP gateway automatically exposes your microservices as AI-accessible tools thro
 - **Automatic service discovery** via the registry
 - **Dynamic tool generation** from service endpoints
 - **Stdio transport** for local AI tools (Claude Code, etc.)
-- **HTTP/SSE transport** for web-based agents
+- **Streamable-HTTP transport** (spec-compliant JSON-RPC 2.0 at `/mcp`) for browser MCP clients
+- **WebSocket transport** at `/mcp/ws` for streaming agent frameworks
+- **Legacy REST endpoints** at `/mcp/tools` and `/mcp/call` for simple tool access
 - **Automatic documentation extraction** from Go comments
 
 ## Quick Start
@@ -95,6 +97,8 @@ micro mcp serve --address :3000
 
 Access tools at \`http://localhost:3000/mcp/tools\`
 
+For spec-compliant MCP clients (browser and desktop agents), use the streamable-HTTP endpoint at `http://localhost:3000/mcp` — see [Streamable-HTTP Transport](#streamable-http-transport-browser-mcp-clients) below.
+
 ### 3. Use Your Service with AI
 
 Claude can now discover and call your service:
@@ -173,10 +177,50 @@ micro mcp test greeter.GreeterService.SayHello
 
 ### Transport Options
 
-- **Stdio** - For local AI tools (Claude Code, recommended)
-- **HTTP/SSE** - For web-based agents
+The MCP gateway serves four transports from one HTTP server (or stdio when no address is set):
+
+- **Stdio** - For local AI tools (Claude Code, recommended). Start with `micro mcp serve`.
+- **Streamable-HTTP** - Spec-compliant JSON-RPC 2.0 at `/mcp`. The endpoint for browser MCP clients; CORS is enabled so it works without a proxy.
+- **WebSocket** - Bidirectional streaming at `/mcp/ws` for streaming agent frameworks.
+- **Legacy REST** - Tool listing and calls at `/mcp/tools` and `/mcp/call`.
 
 See examples for complete usage.
+
+### Streamable-HTTP Transport (Browser MCP Clients)
+
+Point any spec-compliant MCP client (Claude desktop, browser agents) at `http://localhost:3000/mcp`. The client SDK handles the handshake; the endpoint behaves like this:
+
+1. **`POST /mcp`** with `initialize` mints a session, returned in the `Mcp-Session-Id` response header:
+
+```bash
+curl -i -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"my-agent","version":"1.0"}}}'
+
+# Mcp-Session-Id: <session-id>   <- echo this header on later requests
+```
+
+2. **`POST /mcp`** with `tools/list` and `tools/call`, echoing the session id:
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+curl -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"greeter.GreeterService.SayHello","arguments":{"name":"World"}}}'
+```
+
+3. **`GET /mcp`** opens a `text/event-stream` for server→client messages; **`DELETE /mcp`** terminates the session. JSON-RPC notifications (no `id`) return `202 Accepted` with no body.
+
+Supported methods: `initialize`, `ping`, `tools/list`, `tools/call`. Tool calls share the same auth, scope, rate-limit, circuit-breaker, and x402 payment pipeline as the REST endpoints, so scopes set in `/auth/scopes` are enforced identically.
+
+### Gateway Independence
+
+The MCP gateway is its own server, independent of the HTTP API gateway. The CLI (`micro gateway --mcp-address :3000`, or `micro run --mcp-address :3000`) starts both servers and shuts them down together; library users start each explicitly with `mcp.NewServer`.
 
 ## Examples
 

--- a/internal/website/content/en/docs/mcp/index.md
+++ b/internal/website/content/en/docs/mcp/index.md
@@ -15,7 +15,9 @@ MCP gateway automatically exposes your microservices as AI-accessible tools thro
 - **Automatic service discovery** via the registry
 - **Dynamic tool generation** from service endpoints
 - **Stdio transport** for local AI tools (Claude Code, etc.)
-- **HTTP/SSE transport** for web-based agents
+- **Streamable-HTTP transport** (spec-compliant JSON-RPC 2.0 at `/mcp`) for browser MCP clients
+- **WebSocket transport** at `/mcp/ws` for streaming agent frameworks
+- **Legacy REST endpoints** at `/mcp/tools` and `/mcp/call` for simple tool access
 - **Automatic documentation extraction** from Go comments
 
 ## Quick Start
@@ -98,6 +100,8 @@ micro mcp serve --address :3000
 
 Access tools at \`http://localhost:3000/mcp/tools\`
 
+For spec-compliant MCP clients (browser and desktop agents), use the streamable-HTTP endpoint at `http://localhost:3000/mcp` — see [Streamable-HTTP Transport](#streamable-http-transport-browser-mcp-clients) below.
+
 ### 3. Use Your Service with AI
 
 Claude can now discover and call your service:
@@ -176,10 +180,50 @@ micro mcp test greeter.GreeterService.SayHello
 
 ### Transport Options
 
-- **Stdio** - For local AI tools (Claude Code, recommended)
-- **HTTP/SSE** - For web-based agents
+The MCP gateway serves four transports from one HTTP server (or stdio when no address is set):
+
+- **Stdio** - For local AI tools (Claude Code, recommended). Start with `micro mcp serve`.
+- **Streamable-HTTP** - Spec-compliant JSON-RPC 2.0 at `/mcp`. The endpoint for browser MCP clients; CORS is enabled so it works without a proxy.
+- **WebSocket** - Bidirectional streaming at `/mcp/ws` for streaming agent frameworks.
+- **Legacy REST** - Tool listing and calls at `/mcp/tools` and `/mcp/call`.
 
 See examples for complete usage.
+
+### Streamable-HTTP Transport (Browser MCP Clients)
+
+Point any spec-compliant MCP client (Claude desktop, browser agents) at `http://localhost:3000/mcp`. The client SDK handles the handshake; the endpoint behaves like this:
+
+1. **`POST /mcp`** with `initialize` mints a session, returned in the `Mcp-Session-Id` response header:
+
+```bash
+curl -i -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"my-agent","version":"1.0"}}}'
+
+# Mcp-Session-Id: <session-id>   <- echo this header on later requests
+```
+
+2. **`POST /mcp`** with `tools/list` and `tools/call`, echoing the session id:
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+curl -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"greeter.GreeterService.SayHello","arguments":{"name":"World"}}}'
+```
+
+3. **`GET /mcp`** opens a `text/event-stream` for server→client messages; **`DELETE /mcp`** terminates the session. JSON-RPC notifications (no `id`) return `202 Accepted` with no body.
+
+Supported methods: `initialize`, `ping`, `tools/list`, `tools/call`. Tool calls share the same auth, scope, rate-limit, circuit-breaker, and x402 payment pipeline as the REST endpoints, so scopes set in `/auth/scopes` are enforced identically.
+
+### Gateway Independence
+
+The MCP gateway is its own server, independent of the HTTP API gateway. The CLI (`micro gateway --mcp-address :3000`, or `micro run --mcp-address :3000`) starts both servers and shuts them down together; library users start each explicitly with `mcp.NewServer` (see the [gateway guide](../guides/cli-gateway.md)).
 
 ## Examples
 


### PR DESCRIPTION
## Problem Statement

The HTTP API gateway (`gateway/api`) and Model Context Protocol gateway (`gateway/mcp`) maintain tight coupling where the API gateway directly initializes, configures, and spawns the MCP gateway via hardcoded options (`MCPEnabled`, `MCPAddress`). Furthermore, both gateways independently implement service discovery, registry watching, and endpoint reflection logic, causing code duplication and architectural friction.

## Solution

Decouple the HTTP API gateway and the MCP gateway into independent, composable components while extracting service discovery, registry watching, and endpoint schema reflection into a unified service schema resolver module. This allows either gateway to be deployed, configured, and run completely independently or co-exist cleanly without direct module leakage.

## User Stories

1. As a platform developer, I want to start the HTTP API gateway without requiring any MCP configuration or dependencies, so that traditional REST deployments remain lightweight and decoupled.
2. As an AI platform engineer, I want to start the MCP gateway as an independent standalone server or daemon, so that AI tool discovery scales separately from the HTTP API.
3. As a microservices developer, I want service discovery and endpoint schema parsing to be handled by a single shared registry resolver, so that HTTP-to-RPC proxying and MCP tool cataloging always share identical service metadata.
4. As an operator, I want to configure authentication, rate limiting, and audit logging on the MCP gateway without relying on options passed through the HTTP API gateway wrapper.
5. As a system administrator, I want clean lifecycle management for both gateways so that graceful shutdown signals are handled independently per server instance.
6. As a developer testing microservices locally, I want `micro gateway` to orchestrate multi-protocol listeners cleanly via modular configuration rather than hardcoded conditional spawning.
7. As an Sentry/tracing operator, I want OpenTelemetry spans and trace context propagation to be consistently managed across both HTTP and MCP layers via the shared resolver and middleware abstractions.
8. As a security engineer, I want scope validation and bearer token inspection to be enforced uniformly regardless of whether a request arrives via REST or MCP transport.

## Implementation Decisions

- **Modularity & Seams:** Introduce a shared service discovery / endpoint metadata package (or consolidate into `registry` / a shared gateway helper) that exposes a unified catalog interface for both REST proxying and MCP tool definitions.
- **Gateway Decoupling:** Remove `MCPEnabled` and `MCPAddress` fields from `gateway/api.Options`. The CLI command (`micro gateway`) or main program explicitly instantiates both `gateway/api.Gateway` and `gateway/mcp` as independent servers.
- **Unified Schema Resolution:** Extract registry watching and endpoint parsing logic currently duplicated in `gateway/mcp` into a reusable component that can serve HTTP routes (`/api/{service}/{method}`) and MCP tools simultaneously.
- **Lifecycle Coordination:** Allow higher-level commands (`micro gateway`) to manage multiple server instances through a simple group or errgroup runner rather than background goroutines spawned inside `gateway/api`.

## Testing Decisions

- **Behavioral Focus:** Test that starting the HTTP API gateway does not start or require MCP components, and verify that the MCP gateway can be started independently with the shared service discovery resolver.
- **Modules to Test:** `gateway/api`, `gateway/mcp`, and the shared endpoint registry resolver.
- **Prior Art:** Follow existing integration and unit tests in `gateway/api/…` and `gateway/mcp/…`.

## Out of Scope

- Changes to gRPC transport wire protocols or client-side load balancing.
- Modifications to core service registration or discovery registries (mDNS, Consul, etcd).
- Changes to AI model provider implementations in ai/.

## Further Notes

Ensures clean separation of concerns in line with interface-first design and reduces tight coupling between HTTP REST infrastructure and AI-native MCP abstractions.

## Summary

- Decouples `gateway/api` from hardcoded MCP startup dependencies (`MCPEnabled`, `MCPAddress`).
- Lays out the architectural spec for extracting service discovery and registry watching into a unified service schema resolver shared by both REST proxying and MCP tool cataloging.
- Improves modularity and separation of concerns between HTTP REST infrastructure and AI-native MCP abstractions.

## Test plan

- [x] Verify existing tests pass across `gateway/api` and `gateway/mcp`
- [x] Confirm independent lifecycle management for both gateways in the CLI runner
