### PR TITLE
fix(retract): preserve full phantom tag prefixes

### DIFF
--- a/retract-phantom.sh
+++ b/retract-phantom.sh
@@ -114,11 +114,17 @@ for b in V6 V5 V4 V0; do
 done
 
 # ── Sanity checks ───────────────────────────────────────────────────────────
+module_relative_path() {
+    local path="$1"
+    if [[ "$path" =~ ^go-micro\.dev/v[0-9]+/(.+)$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+    else
+        printf '%s\n' "${path#go-micro.dev/}"
+    fi
+}
+
 for p in "${PHANTOM_PATHS[@]}"; do
-    case "$p" in
-        go-micro.dev/v[0-9]*/*) rel="${p#go-micro.dev/v[0-9]*/}" ;;
-        *) rel="${p#go-micro.dev/}" ;;
-    esac
+    rel="$(module_relative_path "$p")"
     [[ -f "$rel/go.mod" ]] && { echo "ERROR: $p has go.mod on master — not a phantom"; exit 1; }
 done
 
@@ -203,10 +209,7 @@ for base_info in "v6:${#BASES_V6[@]}" "v5:${#BASES_V5[@]}" "v4:${#BASES_V4[@]}" 
         : > "$tmpdir/tags"
         n=0
         for p in "${ref[@]}"; do
-            case "$p" in
-                go-micro.dev/v[0-9]*/*) rel="${p#go-micro.dev/v[0-9]*/}" ;;
-                *) rel="${p#go-micro.dev/}" ;;
-            esac
+            rel="$(module_relative_path "$p")"
             tag="${rel}/${RETRACT_MAX}"
             if ! valid_tag_ref "$tag"; then
                 echo "  skip (invalid tag name): $tag" >&2


### PR DESCRIPTION
## Summary
- only strip an exact `/vN/` semantic-major directory from phantom module paths
- preserve lookalike prefixes such as `v2client`, `v4.0.0`, and `v5-plugins` when constructing retraction tags

## Testing
- `bash -n retract-phantom.sh`
- `./retract-phantom.sh --dry-run`
- `go build ./...`
- `go test ./...`

Follow-up to #4884.
Closes #4884