### PR TITLE
ai: add configurable reasoning controls

### DIFF
--- a/ai/anthropic/anthropic.go
+++ b/ai/anthropic/anthropic.go
@@ -84,6 +84,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		"system":     req.SystemPrompt,
 		"messages":   threadAnthropicMessages(req),
 	}
+	applyReasoningOptions(apiReq, p.opts)
 
 	if len(anthropicTools) > 0 {
 		apiReq["tools"] = anthropicTools
@@ -131,6 +132,7 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 			"system":     req.SystemPrompt,
 			"messages":   messages,
 		}
+		applyReasoningOptions(followUpReq, p.opts)
 		if len(anthropicTools) > 0 {
 			followUpReq["tools"] = anthropicTools
 		}
@@ -168,6 +170,7 @@ func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.Gener
 		"messages":   threadAnthropicMessages(req),
 		"stream":     true,
 	}
+	applyReasoningOptions(apiReq, p.opts)
 	reqBody, err := json.Marshal(apiReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal stream request: %w", err)
@@ -214,8 +217,9 @@ func (s *streamReader) Recv() (*ai.Response, error) {
 		var chunk struct {
 			Type  string `json:"type"`
 			Delta struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
+				Type       string `json:"type"`
+				Text       string `json:"text"`
+				StopReason string `json:"stop_reason"`
 			} `json:"delta"`
 			Message struct {
 				Usage struct {
@@ -241,8 +245,12 @@ func (s *streamReader) Recv() (*ai.Response, error) {
 				return &ai.Response{Usage: usage(chunk.Message.Usage.InputTokens, chunk.Message.Usage.OutputTokens)}, nil
 			}
 		case "message_delta":
-			if chunk.Usage != nil {
-				return &ai.Response{Usage: usage(chunk.Usage.InputTokens, chunk.Usage.OutputTokens)}, nil
+			if chunk.Delta.StopReason != "" || chunk.Usage != nil {
+				response := &ai.Response{StopReason: chunk.Delta.StopReason}
+				if chunk.Usage != nil {
+					response.Usage = usage(chunk.Usage.InputTokens, chunk.Usage.OutputTokens)
+				}
+				return response, nil
 			}
 		case "message_stop":
 			return nil, io.EOF
@@ -296,7 +304,10 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 	defer httpResp.Body.Close()
 
 	// Read response
-	respBody, _ := io.ReadAll(httpResp.Body)
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read response: %w", err)
+	}
 	if httpResp.StatusCode != http.StatusOK {
 		return nil, nil, ai.NewHTTPError(httpResp, respBody)
 	}
@@ -317,7 +328,7 @@ func (p *Provider) callAPI(ctx context.Context, req map[string]any) (*ai.Respons
 		return nil, nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	response := &ai.Response{}
+	response := &ai.Response{StopReason: anthropicResp.StopReason}
 
 	// Extract text reply
 	var replyParts []string
@@ -394,4 +405,13 @@ func anthropicMaxTokens(o ai.Options) int {
 		return o.MaxTokens
 	}
 	return 8192
+}
+
+func applyReasoningOptions(req map[string]any, opts ai.Options) {
+	if opts.Thinking != "" {
+		req["thinking"] = map[string]any{"type": string(opts.Thinking)}
+	}
+	if opts.Effort != "" {
+		req["output_config"] = map[string]any{"effort": opts.Effort}
+	}
 }

--- a/ai/anthropic/anthropic_test.go
+++ b/ai/anthropic/anthropic_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -11,6 +12,34 @@ import (
 
 	"go-micro.dev/v6/ai"
 )
+
+func TestProvider_GenerateReasoningOptionsAndStopReason(t *testing.T) {
+	var body map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"done"}],"stop_reason":"max_tokens"}`))
+	}))
+	defer ts.Close()
+
+	p := NewProvider(ai.WithAPIKey("test-key"), ai.WithBaseURL(ts.URL),
+		ai.WithThinking(ai.ThinkingAdaptive), ai.WithEffort("low"))
+	resp, err := p.Generate(context.Background(), &ai.Request{Prompt: "Hello"})
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if got := body["thinking"].(map[string]any)["type"]; got != "adaptive" {
+		t.Fatalf("thinking type = %v, want adaptive", got)
+	}
+	if got := body["output_config"].(map[string]any)["effort"]; got != "low" {
+		t.Fatalf("effort = %v, want low", got)
+	}
+	if resp.StopReason != "max_tokens" {
+		t.Fatalf("stop reason = %q, want max_tokens", resp.StopReason)
+	}
+}
 
 func TestProvider_String(t *testing.T) {
 	p := NewProvider()
@@ -109,7 +138,7 @@ func TestProvider_Stream(t *testing.T) {
 		_, _ = w.Write([]byte("event: content_block_delta\n"))
 		_, _ = w.Write([]byte(`data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"lo"}}` + "\n\n"))
 		_, _ = w.Write([]byte("event: message_delta\n"))
-		_, _ = w.Write([]byte(`data: {"type":"message_delta","usage":{"output_tokens":3}}` + "\n\n"))
+		_, _ = w.Write([]byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}` + "\n\n"))
 		_, _ = w.Write([]byte("event: message_stop\n"))
 		_, _ = w.Write([]byte(`data: {"type":"message_stop"}` + "\n\n"))
 	}))
@@ -129,6 +158,7 @@ func TestProvider_Stream(t *testing.T) {
 
 	var reply strings.Builder
 	var usage ai.Usage
+	var stopReason string
 	for {
 		chunk, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
@@ -141,11 +171,17 @@ func TestProvider_Stream(t *testing.T) {
 		if chunk.Usage.TotalTokens > 0 {
 			usage = chunk.Usage
 		}
+		if chunk.StopReason != "" {
+			stopReason = chunk.StopReason
+		}
 	}
 	if got := reply.String(); got != "hello" {
 		t.Fatalf("reply = %q, want hello", got)
 	}
 	if usage.TotalTokens != 3 {
 		t.Fatalf("usage = %+v, want total 3", usage)
+	}
+	if stopReason != "end_turn" {
+		t.Fatalf("stop reason = %q, want end_turn", stopReason)
 	}
 }

--- a/ai/internal/openaiapi/stream.go
+++ b/ai/internal/openaiapi/stream.go
@@ -31,6 +31,9 @@ func Stream(ctx context.Context, opts ai.Options, req *ai.Request, basePath stri
 	if opts.MaxTokens > 0 {
 		apiReq["max_tokens"] = opts.MaxTokens
 	}
+	if opts.Effort != "" {
+		apiReq["reasoning_effort"] = opts.Effort
+	}
 	reqBody, err := json.Marshal(apiReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal stream request: %w", err)

--- a/ai/model.go
+++ b/ai/model.go
@@ -66,6 +66,8 @@ type Response struct {
 	Answer string
 	// Usage contains provider token usage when available.
 	Usage Usage
+	// StopReason describes why the provider stopped generating, when available.
+	StopReason string
 }
 
 // ToolCall represents a request to call a tool and its result

--- a/ai/openai/openai.go
+++ b/ai/openai/openai.go
@@ -102,6 +102,9 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 	if p.opts.MaxTokens > 0 {
 		apiReq["max_tokens"] = p.opts.MaxTokens
 	}
+	if p.opts.Effort != "" {
+		apiReq["reasoning_effort"] = p.opts.Effort
+	}
 
 	if len(openaiTools) > 0 {
 		apiReq["tools"] = openaiTools
@@ -140,6 +143,9 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 			"model":    p.opts.Model,
 			"messages": followUpMessages,
 		}
+		if p.opts.Effort != "" {
+			followUpReq["reasoning_effort"] = p.opts.Effort
+		}
 
 		// Make follow-up API call
 		followUpResp, _, err := p.callAPI(ctx, followUpReq)
@@ -170,6 +176,9 @@ func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.Gener
 	}
 	if p.opts.MaxTokens > 0 {
 		apiReq["max_tokens"] = p.opts.MaxTokens
+	}
+	if p.opts.Effort != "" {
+		apiReq["reasoning_effort"] = p.opts.Effort
 	}
 	reqBody, err := json.Marshal(apiReq)
 	if err != nil {

--- a/ai/openai/openai_test.go
+++ b/ai/openai/openai_test.go
@@ -86,6 +86,26 @@ func TestProvider_Generate_NoAPIKey(t *testing.T) {
 	}
 }
 
+func TestProvider_GenerateReasoningEffort(t *testing.T) {
+	var body map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"done"}}]}`))
+	}))
+	defer ts.Close()
+
+	p := NewProvider(ai.WithAPIKey("test-key"), ai.WithBaseURL(ts.URL), ai.WithEffort("high"))
+	if _, err := p.Generate(context.Background(), &ai.Request{Prompt: "Hello"}); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if got := body["reasoning_effort"]; got != "high" {
+		t.Fatalf("reasoning_effort = %v, want high", got)
+	}
+}
+
 func TestProvider_Stream(t *testing.T) {
 	var sawStream bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/ai/options.go
+++ b/ai/options.go
@@ -18,7 +18,20 @@ type Options struct {
 	ToolHandler ToolHandler
 	// MaxTokens caps the length of the response (0 = provider default)
 	MaxTokens int
+	// Thinking controls Anthropic's extended-thinking mode. Empty leaves the
+	// provider default in place.
+	Thinking ThinkingMode
+	// Effort controls reasoning depth for providers that support it.
+	Effort string
 }
+
+// ThinkingMode controls whether a reasoning-capable model uses extended thinking.
+type ThinkingMode string
+
+const (
+	ThinkingAdaptive ThinkingMode = "adaptive"
+	ThinkingDisabled ThinkingMode = "disabled"
+)
 
 // GenerateOptions for generate call
 type GenerateOptions struct {
@@ -99,5 +112,20 @@ func WithTools(t *Tools) Option {
 func WithMaxTokens(n int) Option {
 	return func(o *Options) {
 		o.MaxTokens = n
+	}
+}
+
+// WithThinking sets the extended-thinking mode for providers that support it.
+func WithThinking(mode ThinkingMode) Option {
+	return func(o *Options) {
+		o.Thinking = mode
+	}
+}
+
+// WithEffort sets the reasoning effort for providers that support it. An empty
+// value leaves the provider default in place.
+func WithEffort(effort string) Option {
+	return func(o *Options) {
+		o.Effort = effort
 	}
 }


### PR DESCRIPTION
## Summary
- add provider-level thinking and reasoning-effort options
- map reasoning settings to Anthropic and OpenAI requests, including streams and tool follow-ups
- expose Anthropic stop reasons and propagate response-body read failures
- add coverage for request mappings and stop reasons

## Testing
- `go build ./...`
- `go test ./...`
- `go test ./ai/anthropic ./ai/openai`
- `golangci-lint run ./...` *(blocked: installed golangci-lint was built with Go 1.24, below the repository target Go 1.25.12)*

Closes #4892