### PR TITLE
docs(readme): lead with the demo, declutter the front door

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS = -X $(GIT_IMPORT).BuildDate=$(BUILD_DATE) -X $(GIT_IMPORT).GitCommit=$(
 # GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser-cross:v1.25.7
 GORELEASER_DOCKER_IMAGE = ghcr.io/goreleaser/goreleaser:latest
 
-.PHONY: test test-race test-coverage harness zero-to-hero-transcript inner-loop cli-wayfinding docs-wayfinding install-smoke provider-conformance-mock provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
+.PHONY: test test-race test-coverage harness demo-gif zero-to-hero-transcript inner-loop cli-wayfinding docs-wayfinding install-smoke provider-conformance-mock provider-conformance lint fmt install-tools proto clean help gorelease-dry-run gorelease-dry-run-docker
 
 # Default target
 help:
@@ -19,6 +19,7 @@ help:
 	@echo "  make test-coverage - Run tests with coverage"
 	@echo "  make lint          - Run linter"
 	@echo "  make harness       - Run deterministic getting-started and end-to-end harnesses"
+	@echo "  make demo-gif      - Record the README quick-start demo GIF (VHS)"
 	@echo "  make zero-to-hero-transcript - Verify the ordered 0→hero lifecycle transcript"
 	@echo "  make inner-loop    - Verify scaffold → run/chat/inspect → deploy dry-run contract"
 	@echo "  make cli-wayfinding - Verify installed first-agent CLI wayfinding commands"
@@ -58,6 +59,12 @@ harness:
 	$(MAKE) zero-to-hero-transcript
 	go run ./internal/harness/agent-flow
 	$(MAKE) provider-conformance-mock
+
+# Record the README quick-start demo GIF with VHS (no provider key needed).
+# See internal/demo/README.md for the keyed hero demo (prompt-demo.tape).
+demo-gif:
+	@command -v vhs >/dev/null || { echo "vhs not found — install with: go install github.com/charmbracelet/vhs@latest (needs ttyd + ffmpeg)"; exit 1; }
+	vhs internal/demo/first-run.tape
 
 # Verify the maintained 0→hero transcript in the same order documented for new
 # developers: scaffold → run/chat/inspect → support-agent chat → flow history →

--- a/README.md
+++ b/README.md
@@ -3,9 +3,47 @@
 Go Micro is an **agent harness** and service framework for Go.
 
 ## Overview
-A harness is the runtime around an agent: the tools it can call, the memory it keeps, the guardrails that bound it, the workflows that trigger it, the services it depends on, and the protocols other agents use to reach it. 
+
+A harness is the runtime around an agent: the tools it can call, the memory it keeps, the guardrails that bound it, the workflows that trigger it, the services it depends on, and the protocols other agents use to reach it.
 
 Go Micro gives you the harness as Go code. Build an agent and it gets a model, memory, tools, planning, delegation, guardrails, and service discovery; it is reachable over [MCP](https://modelcontextprotocol.io/) and [A2A](https://a2a-protocol.org). Write services and every endpoint becomes an AI-callable tool. Orchestrate the deterministic parts with durable flows. Agents, services, and flows share one runtime because an agent is a distributed system, and building one is building a service.
+
+## See it
+
+Describe a system and Go Micro designs the services, writes the handlers, compiles them, starts them, and gives you an agent to talk to:
+
+```
+$ micro run --prompt "a task management system with categories"
+
+Services:
+  ● task — Task management with status tracking
+  ● project — Project organization
+
+Generate? [Y/n]
+
+> Create a project called Launch, then add three tasks to it
+
+→ project_Project_Create({"name":"Launch"})
+→ task_Task_Create({"title":"Design specs","project_id":"p1..."})
+→ task_Task_Create({"title":"Write code","project_id":"p1..."})
+→ task_Task_Create({"title":"Ship it","project_id":"p1..."})
+
+Created project Launch and added three tasks to it.
+```
+
+And when the agent needs a capability that doesn't exist, it builds the service mid-conversation:
+
+```
+> I need to track shipping. Create a shipment for order 123 to London.
+
+  ⚡ generating shipping service...
+  ✓ shipping
+  → shipping_Shipping_Create({"order_id":"123","destination":"London"})
+
+  Created shipment for order 123 going to London.
+```
+
+The generated code is plain Go on disk — edit it by hand at any time; re-running preserves your changes. No key? The [no-secret path below](#fastest-start--no-api-key) works without any provider.
 
 ## Sponsors
 
@@ -17,14 +55,6 @@ Go Micro gives you the harness as Go code. Build an agent and it gets a model, m
 
 **Want to support Go Micro and see your logo here?** [Become a sponsor](https://discord.gg/G8Gk5j3uXr) — reach out on Discord.
 
-## Community
-
-Questions, ideas, or just want to build alongside us? [Join the Discord](https://discord.gg/G8Gk5j3uXr).
-
-## Commercial Support
-
-Running Go Micro in production, or building on it and want help? Paid **support, consulting, training, and retainers** are available directly from the maintainer — and they're what keep the project maintained. See [**Support**](SUPPORT.md) for the tiers, or [open a request](https://github.com/micro/go-micro/issues/new?template=commercial_support.md).
-
 ## Contents
 
 - [Quick Start](#quick-start)
@@ -34,11 +64,12 @@ Running Go Micro in production, or building on it and want help? Paid **support,
 - [Building Agents](#building-agents) — [Plan & Delegate](#plan--delegate), [Pluggable](#batteries-included-pluggable), [Paid tools (x402)](#paid-tools-x402), [A2A](#reachable-by-other-agents-a2a)
 - [Features](#features)
 - [CLI](#cli)
-- [Autonomous improvement loop](#autonomous-improvement-loop)
 - [Multi-Service Projects](#multi-service-projects)
 - [Data Model](#data-model)
 - [AI Providers](#ai-providers)
 - [Examples](#examples)
+- [Autonomous improvement loop](#autonomous-improvement-loop)
+- [Community](#community)
 - [Commercial Support](#commercial-support)
 - [Docs](#docs)
 
@@ -54,7 +85,7 @@ curl -fsSL https://go-micro.dev/install.sh | sh
 go install go-micro.dev/v6/cmd/micro@latest
 ```
 
-If install or `PATH` checks fail, use the [install troubleshooting guide](internal/website/docs/guides/install-troubleshooting.md) before scaffolding your first service.
+If install or `PATH` checks fail, use the [install troubleshooting guide](internal/website/docs/guides/install-troubleshooting.md).
 
 ### Fastest start — no API key
 
@@ -66,14 +97,6 @@ cd helloworld
 micro run
 ```
 
-Prefer Docker? The `micro` image (Docker Hub `micro/micro` or GitHub Container Registry `ghcr.io/micro/go-micro`) bundles the CLI and its runtime dependencies:
-
-```bash
-docker pull micro/micro:latest          # or ghcr.io/micro/go-micro:latest
-docker run --rm -it micro/micro new helloworld
-docker run --rm -it --network host -v "$(pwd)":/micro/helloworld micro/micro run
-```
-
 Then in another terminal:
 
 ```bash
@@ -81,132 +104,32 @@ curl -X POST http://localhost:8080/api/helloworld/Helloworld.Call \
   -H 'Content-Type: application/json' -d '{"name":"World"}'
 ```
 
-This install → scaffold → run → call path is covered by no-secret CI harnesses. To
-verify just the local installer and first-run CLI boundaries without network
-access or provider keys, use:
+Prefer Docker? The `micro` image (Docker Hub `micro/micro` or `ghcr.io/micro/go-micro`) bundles the CLI:
 
 ```bash
-make install-smoke
-```
-
-To verify the focused CLI inner-loop contract — scaffold → run/chat/inspect → deploy dry-run — use:
-
-```bash
-make inner-loop
-```
-
-To run only the ordered [0→hero services → agents → workflows transcript](internal/website/docs/guides/zero-to-hero.md) that CI guards, use:
-
-```bash
-make zero-to-hero-transcript
-```
-
-To run the broader local contract (including that transcript, chat/inspect CLI boundaries, and deploy dry-run), use:
-
-```bash
-make harness
+docker run --rm -it micro/micro new helloworld
+docker run --rm -it --network host -v "$(pwd)":/micro/helloworld micro/micro run
 ```
 
 ### First agent on-ramp
 
-After install and the first `micro new`/`micro run` smoke check, take the
-walkable agent path in this order:
+New to agents? The shortest path, in order — every step works without a provider key:
 
-1. [Install troubleshooting](internal/website/docs/guides/install-troubleshooting.md) — verify the binary installer or `go install`, `PATH`, `micro --version`, and the no-secret smoke path before agent work.
-
-Run `make docs-wayfinding` to verify the focused no-secret docs/CLI contract that keeps these README and website commands aligned with the installed CLI.
-
-2. `micro agent demo` — print the provider-free first-agent demo command and next docs steps from the installed CLI.
-3. `micro agent quickcheck` (or `micro agent debug`) — when scaffold → run → chat → inspect stalls, print the short recovery map before you dive into the full debugging guide.
-4. `micro examples` — print the maintained provider-free runnable examples in copy/paste order.
-5. `micro zero-to-hero` — print the maintained one-command no-secret lifecycle harness and runnable examples.
-6. [Examples wayfinding index](examples/INDEX.md) — choose the smallest no-secret first-agent, maintained [0→hero support reference](examples/support/), and next interop examples from one map.
-7. [Smallest first-agent example](examples/first-agent/) — run one service-backed agent with a mock model and no provider key.
-8. [No-secret first-agent transcript](internal/website/docs/guides/no-secret-first-agent.md) — run the
-   maintained support agent with a mock model and see services → agents → workflows succeed without a key.
-9. [Your First Agent](internal/website/docs/guides/your-first-agent.md) — build a
-   service-backed agent and talk to it with `micro chat`.
-10. [Debugging your agent](internal/website/docs/guides/debugging-agents.md) — use
-   `micro agent preflight` before `micro run`, `micro agent doctor` after `micro run`,
-   then `micro chat` and `micro inspect agent <name>` to recover run history, memory,
-   and provider checks when the first conversation does something unexpected.
-11. [0→hero Reference](internal/website/docs/guides/zero-to-hero.md) — complete the
-   services → agents → workflows loop with scaffold, run, chat, inspect, flow
-   history, and deploy dry-run commands that match the maintained harness.
-
-### Autonomous improvement loop
-
-Want the same services → agents → workflows lifecycle applied to your
-repository? `micro loop` scaffolds the autonomous improvement loop used by Go
-Micro itself: a North Star, ranked issue queue, role prompts, GitHub Actions
-workflows, and verification for CI-gated PRs.
-
-```bash
-micro loop init --roles all
-micro loop verify
-```
-
-Before turning on the schedule, configure a dispatch token such as
-`CODEX_TRIGGER_TOKEN`, protect the default branch with required CI checks
-(`go build ./...`, `go test ./...`, and `golangci-lint run ./...` for this
-repository), and seed `.github/loop/PRIORITIES.md` with one scoped issue per
-increment. See the [`micro loop` quickstart](internal/website/docs/guides/micro-loop.md)
-for the setup checklist and operating model.
+1. **Verify the install** — the [install troubleshooting guide](internal/website/docs/guides/install-troubleshooting.md) covers `PATH`, `micro --version`, and first-run checks. (`make docs-wayfinding` keeps these steps aligned with the installed CLI.)
+2. **Run the built-in demo** — `micro agent demo` prints the provider-free first-agent walkthrough, and `micro agent quickcheck` prints the short recovery map if a step stalls; `micro examples` and `micro zero-to-hero` print the runnable examples and the one-command lifecycle harness. Start from the [smallest first-agent example](examples/first-agent/) or the [examples wayfinding index](examples/INDEX.md).
+3. **Build your own** — follow [No-secret first agent](internal/website/docs/guides/no-secret-first-agent.md) (mock model, no key), then [Your First Agent](internal/website/docs/guides/your-first-agent.md), and talk to it with `micro chat`.
+4. **When something's off** — `micro agent preflight` before `micro run`, `micro agent doctor` after; the [debugging guide](internal/website/docs/guides/debugging-agents.md) walks the full recovery path, and `micro inspect agent <name>` recovers run history, memory, and provider checks. The [0→hero reference](internal/website/docs/guides/zero-to-hero.md) then closes the loop — services → agents → workflows — with the maintained [support example](examples/support/) as the reference app.
 
 ### Generate from a prompt — with an LLM key
 
-Set a provider key, describe what you want, and the AI designs services, writes handlers, compiles, and starts them:
+The [See it](#see-it) transcript above is real. Set a provider key and run it:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY, GEMINI_API_KEY, ...
 micro run --prompt "a task management system with categories" --provider anthropic
 ```
 
-The AI designs the architecture, you review it, then it generates handlers with real business logic, compiles them, and starts them:
-
-```
-Services:
-  ● task — Task management with status tracking
-  ● project — Project organization
-
-Generate? [Y/n]
-
-Micro
-  Services:
-    ● task
-    ● project
-  Agents:
-    ◆ agent
-```
-
-Then talk to your services from the console:
-
-```
-> Create a project called Launch, then add three tasks to it
-
-→ project_Project_Create({"name":"Launch"})
-← {"record":{"id":"p1..."},"success":true}
-→ task_Task_Create({"title":"Design specs","project_id":"p1..."})
-→ task_Task_Create({"title":"Write code","project_id":"p1..."})
-→ task_Task_Create({"title":"Ship it","project_id":"p1..."})
-
-Created project Launch and added three tasks to it.
-```
-
-When you need a capability that doesn't exist, the agent generates a new service mid-conversation:
-
-```
-> I need to track shipping. Create a shipment for order 123 to London.
-
-  ⚡ generating shipping service...
-  ✓ shipping
-  → shipping_Shipping_Create({"order_id":"123","destination":"London"})
-  ← {"record":{"id":"xyz...","status":"pending"}}
-
-  Created shipment for order 123 going to London.
-```
-
-Edit the generated code by hand at any time — re-running preserves your changes. [Read more](https://go-micro.dev/blog/13).
+The AI designs the architecture, you review it, then it generates handlers with real business logic, compiles them, and starts them — and the console drops you into a conversation with your running system. [Read more](https://go-micro.dev/blog/13).
 
 ## Why an Agent Harness
 
@@ -506,6 +429,25 @@ New to agents? Follow the [first-agent on-ramp](#first-agent-on-ramp), then use 
 
 See [all examples](examples/README.md).
 
+## Autonomous improvement loop
+
+Go Micro maintains itself with the same services → agents → workflows lifecycle it ships: a scheduled loop of AI agents opens issues, writes increments, and merges CI-gated PRs, with a human setting direction. `micro loop` scaffolds that loop for your own repository — a North Star, ranked issue queue, role prompts, GitHub Actions workflows, and verification:
+
+```bash
+micro loop init --roles all
+micro loop verify
+```
+
+See the [`micro loop` quickstart](internal/website/docs/guides/micro-loop.md) for the setup checklist (dispatch token, branch protection, seeded priorities) and operating model.
+
+## Community
+
+Questions, ideas, or just want to build alongside us? [Join the Discord](https://discord.gg/G8Gk5j3uXr).
+
+## Commercial Support
+
+Running Go Micro in production, or building on it and want help? Paid **support, consulting, training, and retainers** are available directly from the maintainer — and they're what keep the project maintained. See [**Support**](SUPPORT.md) for the tiers, or [open a request](https://github.com/micro/go-micro/issues/new?template=commercial_support.md).
+
 ## Docs
 
 - [Getting Started](internal/website/docs/getting-started.md)
@@ -521,5 +463,7 @@ See [all examples](examples/README.md).
 - [Data Model](internal/website/docs/model.md)
 - [Deployment](internal/website/docs/deployment.md)
 - [Plugins](internal/website/docs/plugins.md)
+
+Every path in this README is guarded by CI: `make install-smoke` verifies install → first run, `make inner-loop` verifies scaffold → run/chat/inspect → deploy dry-run, `make zero-to-hero-transcript` verifies the ordered [0→hero lifecycle](internal/website/docs/guides/zero-to-hero.md), and `make harness` runs the broader local contract.
 
 Package reference: https://pkg.go.dev/go-micro.dev/v6

--- a/internal/demo/README.md
+++ b/internal/demo/README.md
@@ -1,0 +1,37 @@
+# Demo recordings
+
+Terminal demos for the README and website, scripted with
+[VHS](https://github.com/charmbracelet/vhs) so they are reproducible and never
+rot: edit the `.tape`, re-record, commit the new GIF.
+
+## Tapes
+
+| Tape | What it shows | Needs a key? |
+|------|---------------|--------------|
+| `first-run.tape` | Quick start: `micro new` → `micro run` → `curl` | No |
+| `prompt-demo.tape` | Hero demo: `micro run --prompt` designs, builds, and starts services; mid-conversation service generation | Yes (`ANTHROPIC_API_KEY`) |
+
+## Recording
+
+Install VHS and its dependencies (ttyd, ffmpeg), and make sure the `micro`
+CLI being demoed is on `PATH`:
+
+```bash
+go install github.com/charmbracelet/vhs@latest
+make demo-gif                       # records first-run.gif (no key needed)
+vhs internal/demo/prompt-demo.tape  # manual: live-provider timing, tune sleeps
+```
+
+Record in a scratch directory — the tapes scaffold real services where they run.
+
+## Embedding
+
+Once recorded, embed at the top of the README (below the Overview) and on the
+website homepage:
+
+```markdown
+![micro run --prompt demo](internal/demo/prompt-demo.gif)
+```
+
+Keep GIFs under ~10MB so GitHub renders them inline. `first-run.gif` is the
+fallback if the prompt demo is too heavy.

--- a/internal/demo/first-run.tape
+++ b/internal/demo/first-run.tape
@@ -1,0 +1,35 @@
+# VHS tape: the no-key quick start — scaffold → run → call.
+# Record with: vhs internal/demo/first-run.tape  (see internal/demo/README.md)
+# Requires: vhs, ttyd, ffmpeg, and the micro CLI on PATH. No provider key needed.
+
+Output internal/demo/first-run.gif
+
+Set Shell "bash"
+Set FontSize 15
+Set Width 1100
+Set Height 620
+Set TypingSpeed 40ms
+Set Padding 12
+
+Type "micro new helloworld"
+Enter
+Sleep 4s
+
+Type "cd helloworld"
+Enter
+Sleep 500ms
+
+# Loopback bind → auth off → the curl below needs no token.
+Type "micro run -d &"
+Enter
+Sleep 8s
+
+Type `curl -s -X POST localhost:8080/api/helloworld/Helloworld.Call -H 'Content-Type: application/json' -d '{"name":"World"}'`
+Enter
+Sleep 4s
+
+Hide
+Type "kill %1"
+Enter
+Sleep 1s
+Show

--- a/internal/demo/prompt-demo.tape
+++ b/internal/demo/prompt-demo.tape
@@ -1,0 +1,38 @@
+# VHS tape: the hero demo — generate a system from a prompt and talk to it.
+# Record with: ANTHROPIC_API_KEY=... vhs internal/demo/prompt-demo.tape
+#
+# MANUAL RECORDING ONLY: generation time depends on the live provider, so the
+# sleeps below are generous estimates — expect to tune them (or trim the video)
+# per recording. Record in an empty scratch directory.
+
+Output internal/demo/prompt-demo.gif
+
+Set Shell "bash"
+Set FontSize 15
+Set Width 1100
+Set Height 700
+Set TypingSpeed 40ms
+Set Padding 12
+
+Type `micro run --prompt "a task management system with categories" --provider anthropic`
+Enter
+# Wait for the design proposal (Services: task / project ... Generate? [Y/n])
+Sleep 25s
+
+Type "y"
+Enter
+# Wait for codegen + compile + start + console banner
+Sleep 60s
+
+Type "Create a project called Launch, then add three tasks to it"
+Enter
+# Tool calls stream: project_Project_Create, task_Task_Create x3
+Sleep 30s
+
+Type "I need to track shipping. Create a shipment for order 123 to London."
+Enter
+# The mid-conversation service generation moment — the money shot.
+Sleep 60s
+
+Ctrl+C
+Sleep 2s


### PR DESCRIPTION
## Why

Clean-slate read of the README as a first-time visitor: the best asset — the `micro run --prompt` transcript, including an agent generating a new service *mid-conversation* — was buried at ~line 200, under an 11-step on-ramp and four paragraphs of internal CI `make` targets, with monetization sections above the first code sample. The substance is strong; the front door was hiding it.

## Changes

**README restructure (every CI-guarded wayfinding contract preserved):**
- **New "See it" hero** right after the Overview: the condensed `--prompt` transcript with the mid-chat shipping-service generation moment — the wow in the first screen.
- **Quick Start decluttered**: install → no-key start → on-ramp → prompt generation. The four harness `make`-target paragraphs are consolidated into one line at the bottom of Docs (`install-smoke`, `inner-loop`, `zero-to-hero-transcript`, `harness` all still referenced).
- **First agent on-ramp: 11 steps → 4**, preserving every canonical wayfinding marker (`micro agent demo/quickcheck/preflight/doctor`, `micro examples`, `micro zero-to-hero`, `micro chat`, `micro inspect agent <name>`, all guide links, `examples/first-agent`, `examples/support`, `examples/INDEX.md`, `make docs-wayfinding`) **and their required order** (no-secret → first-agent → debugging → 0→hero).
- **Community + Commercial Support moved below the value demonstration**; sponsor logos stay near the top (credibility signal).
- **Autonomous improvement loop** tightened, moved out of Quick Start, and reframed to lead with "Go Micro maintains itself".

**Demo tapes (`internal/demo/`):**
- `first-run.tape` — reproducible no-key quick-start GIF ([VHS](https://github.com/charmbracelet/vhs)); `make demo-gif` records it. Uses the new loopback-no-auth behavior, so the curl needs no token.
- `prompt-demo.tape` — the keyed hero demo (manual recording; live-provider timing).
- `internal/demo/README.md` — recording + embedding instructions (embed at the top of the README once recorded).

## Verification

- `go test ./internal/harness/zero-to-hero-ci/ -count=1` — the full docs/wayfinding harness passes unchanged (ordered Quick Start markers, on-ramp link order, link-target resolution, examples lifecycle maps).
- `go test ./cmd/micro -count=1` — CLI wayfinding contracts pass.

## Follow-ups (not in this PR)

- Record `first-run.gif` (`make demo-gif`, needs vhs/ttyd/ffmpeg) and the keyed `prompt-demo.gif`, then embed at the top of the README + website homepage.
- Refresh dated provider defaults in the AI Providers table (needs the code defaults updated in `ai/*` first, so the table stays truthful).
- Mirror the same declutter on the website getting-started/quickstart pages (their own harness contracts pin them; separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_