### PR TITLE
fix(ai): providers keep offering tools on follow-ups, and keep going

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -174,13 +174,15 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		var allToolCalls []ai.ToolCall
 		var toolResults []string
 		pendingToolCalls := append([]ai.ToolCall(nil), resp.ToolCalls...)
-		followUpMessages := append(messages, map[string]any{
+		// Copied rather than aliased: append on a slice that shares an array
+		// with messages would overwrite it on a later round.
+		followUpMessages := append(append([]map[string]any(nil), messages...), map[string]any{
 			"role":       "assistant",
 			"content":    rawMessage["content"],
 			"tool_calls": rawMessage["tool_calls"],
 		})
 
-		for attempt := 0; len(pendingToolCalls) > 0 && attempt < 4; attempt++ {
+		for attempt := 0; len(pendingToolCalls) > 0 && attempt < maxToolRounds; attempt++ {
 			for _, tc := range pendingToolCalls {
 				result := p.opts.ToolHandler(ctx, tc)
 				if result.Refused != "" {
@@ -202,6 +204,9 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 			followUpReq := map[string]any{
 				"model":    p.opts.Model,
 				"messages": followUpMessages,
+			}
+			if p.opts.MaxTokens > 0 {
+				followUpReq["max_tokens"] = p.opts.MaxTokens
 			}
 			if len(tools) > 0 {
 				// Keep the tool schema available during follow-up turns. Minimax
@@ -251,6 +256,12 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 
 	return resp, nil
 }
+
+// maxToolRounds bounds the tool-execution loop in a single Generate. Each
+// round is a model call plus the tools it asks for, so this is the ceiling on
+// one question's cost as well as its length; it is high enough that no honest
+// piece of multi-step work reaches it.
+const maxToolRounds = 12
 
 func atlascloudAnswerWithRequiredToolMarkers(answer string, toolResults []string, toolCalls []ai.ToolCall) string {
 	if strings.Contains(answer, "agent-conformance") || !atlascloudSawRefusedDelegate(toolCalls) {

--- a/ai/gemini/gemini.go
+++ b/ai/gemini/gemini.go
@@ -98,41 +98,70 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		return resp, nil
 	}
 
+	// Tool execution loop: execute tools, send results back, and keep the
+	// function declarations on offer so the model can take the next step. A
+	// follow-up without tools asks the model to continue with its hands tied —
+	// the call it wanted comes back written out as prose — and without a loop
+	// a second step is impossible whatever the model wants. Bounded so a model
+	// that never stops asking cannot run forever.
 	if p.opts.ToolHandler != nil {
-		var resultParts []map[string]any
-		for _, tc := range resp.ToolCalls {
-			result := p.opts.ToolHandler(ctx, tc).Value
-			resultParts = append(resultParts, map[string]any{
-				"functionResponse": map[string]any{
-					"name":     tc.Name,
-					"id":       tc.ID,
-					"response": result,
-				},
-			})
-		}
-
-		followUpContents := append(contents,
-			map[string]any{"role": "model", "parts": rawParts},
-			map[string]any{"role": "user", "parts": resultParts},
-		)
-
-		followUpReq := map[string]any{
-			"contents": followUpContents,
-		}
-		if req.SystemPrompt != "" {
-			followUpReq["system_instruction"] = map[string]any{
-				"parts": []map[string]any{{"text": req.SystemPrompt}},
+		// Copied rather than aliased: append on a slice that shares an array
+		// with contents would overwrite it on a later round.
+		followUpContents := append([]map[string]any(nil), contents...)
+		pending := resp.ToolCalls
+		raw := rawParts
+		for round := 0; len(pending) > 0 && round < maxToolRounds; round++ {
+			var resultParts []map[string]any
+			for _, tc := range pending {
+				result := p.opts.ToolHandler(ctx, tc).Value
+				resultParts = append(resultParts, map[string]any{
+					"functionResponse": map[string]any{
+						"name":     tc.Name,
+						"id":       tc.ID,
+						"response": result,
+					},
+				})
 			}
-		}
 
-		followUpResp, _, err := p.callAPI(ctx, followUpReq)
-		if err == nil && followUpResp.Reply != "" {
-			resp.Answer = followUpResp.Reply
+			followUpContents = append(followUpContents,
+				map[string]any{"role": "model", "parts": raw},
+				map[string]any{"role": "user", "parts": resultParts},
+			)
+
+			followUpReq := map[string]any{
+				"contents": followUpContents,
+			}
+			if req.SystemPrompt != "" {
+				followUpReq["system_instruction"] = map[string]any{
+					"parts": []map[string]any{{"text": req.SystemPrompt}},
+				}
+			}
+			if len(tools) > 0 {
+				followUpReq["tools"] = []map[string]any{
+					{"functionDeclarations": tools},
+				}
+			}
+
+			followUpResp, followUpRaw, err := p.callAPI(ctx, followUpReq)
+			if err != nil {
+				break
+			}
+			if followUpResp.Reply != "" {
+				resp.Answer = followUpResp.Reply
+			}
+			pending, raw = followUpResp.ToolCalls, followUpRaw
+			resp.ToolCalls = append(resp.ToolCalls, followUpResp.ToolCalls...)
 		}
 	}
 
 	return resp, nil
 }
+
+// maxToolRounds bounds the tool-execution loop in a single Generate. Each
+// round is a model call plus the tools it asks for, so this is the ceiling on
+// one question's cost as well as its length; it is high enough that no honest
+// piece of multi-step work reaches it.
+const maxToolRounds = 12
 
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
 	apiReq := map[string]any{

--- a/ai/groq/groq.go
+++ b/ai/groq/groq.go
@@ -95,31 +95,61 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		return resp, nil
 	}
 
+	// Tool execution loop: execute tools, send results back, and keep the
+	// tools on offer so the model can take the next step. A follow-up without
+	// "tools" asks the model to continue with its hands tied — the call it
+	// wanted comes back written out as prose — and without a loop a second
+	// step is impossible whatever the model wants. Bounded so a model that
+	// never stops asking cannot run forever.
 	if p.opts.ToolHandler != nil {
-		followUpMessages := append(messages, map[string]any{
-			"role":       "assistant",
-			"content":    rawMessage["content"],
-			"tool_calls": rawMessage["tool_calls"],
-		})
-		for _, tc := range resp.ToolCalls {
-			content := p.opts.ToolHandler(ctx, tc).Content
+		// Copied rather than aliased: append on a slice that shares an array
+		// with messages would overwrite it on a later round.
+		followUpMessages := append([]map[string]any(nil), messages...)
+		pending := resp.ToolCalls
+		raw := rawMessage
+		for round := 0; len(pending) > 0 && round < maxToolRounds; round++ {
 			followUpMessages = append(followUpMessages, map[string]any{
-				"role":         "tool",
-				"tool_call_id": tc.ID,
-				"content":      content,
+				"role":       "assistant",
+				"content":    raw["content"],
+				"tool_calls": raw["tool_calls"],
 			})
-		}
-		followUpResp, _, err := p.callAPI(ctx, map[string]any{
-			"model":    p.opts.Model,
-			"messages": followUpMessages,
-		})
-		if err == nil && followUpResp.Reply != "" {
-			resp.Answer = followUpResp.Reply
+			for _, tc := range pending {
+				content := p.opts.ToolHandler(ctx, tc).Content
+				followUpMessages = append(followUpMessages, map[string]any{
+					"role":         "tool",
+					"tool_call_id": tc.ID,
+					"content":      content,
+				})
+			}
+
+			followUpReq := map[string]any{
+				"model":    p.opts.Model,
+				"messages": followUpMessages,
+			}
+			if len(tools) > 0 {
+				followUpReq["tools"] = tools
+			}
+
+			followUpResp, followUpRaw, err := p.callAPI(ctx, followUpReq)
+			if err != nil {
+				break
+			}
+			if followUpResp.Reply != "" {
+				resp.Answer = followUpResp.Reply
+			}
+			pending, raw = followUpResp.ToolCalls, followUpRaw
+			resp.ToolCalls = append(resp.ToolCalls, followUpResp.ToolCalls...)
 		}
 	}
 
 	return resp, nil
 }
+
+// maxToolRounds bounds the tool-execution loop in a single Generate. Each
+// round is a model call plus the tools it asks for, so this is the ceiling on
+// one question's cost as well as its length; it is high enough that no honest
+// piece of multi-step work reaches it.
+const maxToolRounds = 12
 
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
 	return openaiapi.Stream(ctx, p.opts, req, "/v1/chat/completions")

--- a/ai/minimax/minimax.go
+++ b/ai/minimax/minimax.go
@@ -106,31 +106,61 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		return resp, nil
 	}
 
+	// Tool execution loop: execute tools, send results back, and keep the
+	// tools on offer so the model can take the next step. A follow-up without
+	// "tools" asks the model to continue with its hands tied — the call it
+	// wanted comes back written out as prose — and without a loop a second
+	// step is impossible whatever the model wants. Bounded so a model that
+	// never stops asking cannot run forever.
 	if p.opts.ToolHandler != nil {
-		followUpMessages := append(messages, map[string]any{
-			"role":       "assistant",
-			"content":    rawMessage["content"],
-			"tool_calls": rawMessage["tool_calls"],
-		})
-		for _, tc := range resp.ToolCalls {
-			content := p.opts.ToolHandler(ctx, tc).Content
+		// Copied rather than aliased: append on a slice that shares an array
+		// with messages would overwrite it on a later round.
+		followUpMessages := append([]map[string]any(nil), messages...)
+		pending := resp.ToolCalls
+		raw := rawMessage
+		for round := 0; len(pending) > 0 && round < maxToolRounds; round++ {
 			followUpMessages = append(followUpMessages, map[string]any{
-				"role":         "tool",
-				"tool_call_id": tc.ID,
-				"content":      content,
+				"role":       "assistant",
+				"content":    raw["content"],
+				"tool_calls": raw["tool_calls"],
 			})
-		}
-		followUpResp, _, err := p.callAPI(ctx, map[string]any{
-			"model":    p.opts.Model,
-			"messages": followUpMessages,
-		})
-		if err == nil && followUpResp.Reply != "" {
-			resp.Answer = followUpResp.Reply
+			for _, tc := range pending {
+				content := p.opts.ToolHandler(ctx, tc).Content
+				followUpMessages = append(followUpMessages, map[string]any{
+					"role":         "tool",
+					"tool_call_id": tc.ID,
+					"content":      content,
+				})
+			}
+
+			followUpReq := map[string]any{
+				"model":    p.opts.Model,
+				"messages": followUpMessages,
+			}
+			if len(tools) > 0 {
+				followUpReq["tools"] = tools
+			}
+
+			followUpResp, followUpRaw, err := p.callAPI(ctx, followUpReq)
+			if err != nil {
+				break
+			}
+			if followUpResp.Reply != "" {
+				resp.Answer = followUpResp.Reply
+			}
+			pending, raw = followUpResp.ToolCalls, followUpRaw
+			resp.ToolCalls = append(resp.ToolCalls, followUpResp.ToolCalls...)
 		}
 	}
 
 	return resp, nil
 }
+
+// maxToolRounds bounds the tool-execution loop in a single Generate. Each
+// round is a model call plus the tools it asks for, so this is the ceiling on
+// one question's cost as well as its length; it is high enough that no honest
+// piece of multi-step work reaches it.
+const maxToolRounds = 12
 
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
 	return openaiapi.Stream(ctx, p.opts, req, "/v1/chat/completions")

--- a/ai/mistral/mistral.go
+++ b/ai/mistral/mistral.go
@@ -95,31 +95,61 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		return resp, nil
 	}
 
+	// Tool execution loop: execute tools, send results back, and keep the
+	// tools on offer so the model can take the next step. A follow-up without
+	// "tools" asks the model to continue with its hands tied — the call it
+	// wanted comes back written out as prose — and without a loop a second
+	// step is impossible whatever the model wants. Bounded so a model that
+	// never stops asking cannot run forever.
 	if p.opts.ToolHandler != nil {
-		followUpMessages := append(messages, map[string]any{
-			"role":       "assistant",
-			"content":    rawMessage["content"],
-			"tool_calls": rawMessage["tool_calls"],
-		})
-		for _, tc := range resp.ToolCalls {
-			content := p.opts.ToolHandler(ctx, tc).Content
+		// Copied rather than aliased: append on a slice that shares an array
+		// with messages would overwrite it on a later round.
+		followUpMessages := append([]map[string]any(nil), messages...)
+		pending := resp.ToolCalls
+		raw := rawMessage
+		for round := 0; len(pending) > 0 && round < maxToolRounds; round++ {
 			followUpMessages = append(followUpMessages, map[string]any{
-				"role":         "tool",
-				"tool_call_id": tc.ID,
-				"content":      content,
+				"role":       "assistant",
+				"content":    raw["content"],
+				"tool_calls": raw["tool_calls"],
 			})
-		}
-		followUpResp, _, err := p.callAPI(ctx, map[string]any{
-			"model":    p.opts.Model,
-			"messages": followUpMessages,
-		})
-		if err == nil && followUpResp.Reply != "" {
-			resp.Answer = followUpResp.Reply
+			for _, tc := range pending {
+				content := p.opts.ToolHandler(ctx, tc).Content
+				followUpMessages = append(followUpMessages, map[string]any{
+					"role":         "tool",
+					"tool_call_id": tc.ID,
+					"content":      content,
+				})
+			}
+
+			followUpReq := map[string]any{
+				"model":    p.opts.Model,
+				"messages": followUpMessages,
+			}
+			if len(tools) > 0 {
+				followUpReq["tools"] = tools
+			}
+
+			followUpResp, followUpRaw, err := p.callAPI(ctx, followUpReq)
+			if err != nil {
+				break
+			}
+			if followUpResp.Reply != "" {
+				resp.Answer = followUpResp.Reply
+			}
+			pending, raw = followUpResp.ToolCalls, followUpRaw
+			resp.ToolCalls = append(resp.ToolCalls, followUpResp.ToolCalls...)
 		}
 	}
 
 	return resp, nil
 }
+
+// maxToolRounds bounds the tool-execution loop in a single Generate. Each
+// round is a model call plus the tools it asks for, so this is the ceiling on
+// one question's cost as well as its length; it is high enough that no honest
+// piece of multi-step work reaches it.
+const maxToolRounds = 12
 
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
 	return openaiapi.Stream(ctx, p.opts, req, "/v1/chat/completions")

--- a/ai/openai/openai.go
+++ b/ai/openai/openai.go
@@ -121,41 +121,67 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		return resp, nil
 	}
 
-	// If tool handler is provided, execute tools and get final answer
+	// Tool execution loop: execute tools, send results back, and keep the
+	// tools on offer so the model can take the next step. A follow-up without
+	// "tools" asks the model to continue with its hands tied — the call it
+	// wanted comes back written out as prose — and without a loop a second
+	// step is impossible whatever the model wants. Bounded so a model that
+	// never stops asking cannot run forever.
 	if p.opts.ToolHandler != nil {
-		// Build follow-up messages
-		followUpMessages := append(messages, map[string]any{
-			"role":       "assistant",
-			"content":    rawMessage["content"],
-			"tool_calls": rawMessage["tool_calls"],
-		})
-
-		for _, tc := range resp.ToolCalls {
-			content := p.opts.ToolHandler(ctx, tc).Content
+		// Copied rather than aliased: append on a slice that shares an array
+		// with messages would overwrite it on a later round.
+		followUpMessages := append([]map[string]any(nil), messages...)
+		pending := resp.ToolCalls
+		raw := rawMessage
+		for round := 0; len(pending) > 0 && round < maxToolRounds; round++ {
 			followUpMessages = append(followUpMessages, map[string]any{
-				"role":         "tool",
-				"tool_call_id": tc.ID,
-				"content":      content,
+				"role":       "assistant",
+				"content":    raw["content"],
+				"tool_calls": raw["tool_calls"],
 			})
-		}
+			for _, tc := range pending {
+				content := p.opts.ToolHandler(ctx, tc).Content
+				followUpMessages = append(followUpMessages, map[string]any{
+					"role":         "tool",
+					"tool_call_id": tc.ID,
+					"content":      content,
+				})
+			}
 
-		followUpReq := map[string]any{
-			"model":    p.opts.Model,
-			"messages": followUpMessages,
-		}
-		if p.opts.Effort != "" {
-			followUpReq["reasoning_effort"] = p.opts.Effort
-		}
+			followUpReq := map[string]any{
+				"model":    p.opts.Model,
+				"messages": followUpMessages,
+			}
+			if p.opts.MaxTokens > 0 {
+				followUpReq["max_tokens"] = p.opts.MaxTokens
+			}
+			if p.opts.Effort != "" {
+				followUpReq["reasoning_effort"] = p.opts.Effort
+			}
+			if len(openaiTools) > 0 {
+				followUpReq["tools"] = openaiTools
+			}
 
-		// Make follow-up API call
-		followUpResp, _, err := p.callAPI(ctx, followUpReq)
-		if err == nil && followUpResp.Reply != "" {
-			resp.Answer = followUpResp.Reply
+			followUpResp, followUpRaw, err := p.callAPI(ctx, followUpReq)
+			if err != nil {
+				break
+			}
+			if followUpResp.Reply != "" {
+				resp.Answer = followUpResp.Reply
+			}
+			pending, raw = followUpResp.ToolCalls, followUpRaw
+			resp.ToolCalls = append(resp.ToolCalls, followUpResp.ToolCalls...)
 		}
 	}
 
 	return resp, nil
 }
+
+// maxToolRounds bounds the tool-execution loop in a single Generate. Each
+// round is a model call plus the tools it asks for, so this is the ceiling on
+// one question's cost as well as its length; it is high enough that no honest
+// piece of multi-step work reaches it.
+const maxToolRounds = 12
 
 // Stream generates a streaming response from the OpenAI chat completions API.
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {

--- a/ai/openai/tool_loop_test.go
+++ b/ai/openai/tool_loop_test.go
@@ -1,0 +1,120 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go-micro.dev/v6/ai"
+)
+
+// A multi-step task needs the provider to (a) loop while the model keeps
+// calling tools and (b) keep offering the tools on every follow-up request.
+// Without (a) a second step is impossible; without (b) the model writes the
+// call it wanted as prose. This pins both, plus the loop bound.
+func TestGenerateToolLoopKeepsOfferingTools(t *testing.T) {
+	var requests []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		requests = append(requests, body)
+
+		call := len(requests)
+		w.Header().Set("Content-Type", "application/json")
+		if call <= 2 {
+			// Rounds 1 and 2: the model asks for a tool.
+			fmt.Fprintf(w, `{"choices":[{"message":{"role":"assistant","content":"",
+				"tool_calls":[{"id":"call-%d","type":"function","function":{"name":"step","arguments":"{\"n\":%d}"}}]}}]}`, call, call)
+			return
+		}
+		// Round 3: done.
+		fmt.Fprint(w, `{"choices":[{"message":{"role":"assistant","content":"all steps done"}}]}`)
+	}))
+	defer srv.Close()
+
+	toolRuns := 0
+	p := &Provider{}
+	if err := p.Init(
+		ai.WithAPIKey("test"),
+		ai.WithBaseURL(srv.URL),
+		ai.WithModel("test-model"),
+		ai.WithToolHandler(func(ctx context.Context, tc ai.ToolCall) ai.ToolResult {
+			toolRuns++
+			return ai.ToolResult{ID: tc.ID, Content: "done"}
+		}),
+	); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	resp, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "do a two-step task",
+		Tools:  []ai.Tool{{Name: "step", Description: "one step", Properties: map[string]any{}}},
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(requests) != 3 {
+		t.Fatalf("model calls = %d, want 3 (two tool rounds + final answer)", len(requests))
+	}
+	if toolRuns != 2 {
+		t.Fatalf("tool executions = %d, want 2", toolRuns)
+	}
+	// Every follow-up must keep the tools on offer.
+	for i, req := range requests[1:] {
+		if _, ok := req["tools"]; !ok {
+			t.Errorf("follow-up request %d omitted tools — the model is being asked to continue with its hands tied", i+1)
+		}
+	}
+	if resp.Answer != "all steps done" {
+		t.Errorf("Answer = %q, want the final reply", resp.Answer)
+	}
+	if len(resp.ToolCalls) != 2 {
+		t.Errorf("recorded tool calls = %d, want 2", len(resp.ToolCalls))
+	}
+}
+
+// A model that never stops asking for tools must be cut off at the bound
+// rather than looping forever.
+func TestGenerateToolLoopIsBounded(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"choices":[{"message":{"role":"assistant","content":"",
+			"tool_calls":[{"id":"call-%d","type":"function","function":{"name":"step","arguments":"{}"}}]}}]}`, calls)
+	}))
+	defer srv.Close()
+
+	p := &Provider{}
+	if err := p.Init(
+		ai.WithAPIKey("test"),
+		ai.WithBaseURL(srv.URL),
+		ai.WithModel("test-model"),
+		ai.WithToolHandler(func(ctx context.Context, tc ai.ToolCall) ai.ToolResult {
+			return ai.ToolResult{ID: tc.ID, Content: "done"}
+		}),
+	); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if _, err := p.Generate(context.Background(), &ai.Request{
+		Prompt: "never finish",
+		Tools:  []ai.Tool{{Name: "step", Description: "one step", Properties: map[string]any{}}},
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	// Initial call + at most maxToolRounds follow-ups.
+	if calls > maxToolRounds+1 {
+		t.Fatalf("model calls = %d, want at most %d — the loop must be bounded", calls, maxToolRounds+1)
+	}
+	if calls < maxToolRounds {
+		t.Fatalf("model calls = %d — expected the loop to keep going while tool calls keep coming", calls)
+	}
+}

--- a/ai/together/together.go
+++ b/ai/together/together.go
@@ -95,31 +95,61 @@ func (p *Provider) Generate(ctx context.Context, req *ai.Request, opts ...ai.Gen
 		return resp, nil
 	}
 
+	// Tool execution loop: execute tools, send results back, and keep the
+	// tools on offer so the model can take the next step. A follow-up without
+	// "tools" asks the model to continue with its hands tied — the call it
+	// wanted comes back written out as prose — and without a loop a second
+	// step is impossible whatever the model wants. Bounded so a model that
+	// never stops asking cannot run forever.
 	if p.opts.ToolHandler != nil {
-		followUpMessages := append(messages, map[string]any{
-			"role":       "assistant",
-			"content":    rawMessage["content"],
-			"tool_calls": rawMessage["tool_calls"],
-		})
-		for _, tc := range resp.ToolCalls {
-			content := p.opts.ToolHandler(ctx, tc).Content
+		// Copied rather than aliased: append on a slice that shares an array
+		// with messages would overwrite it on a later round.
+		followUpMessages := append([]map[string]any(nil), messages...)
+		pending := resp.ToolCalls
+		raw := rawMessage
+		for round := 0; len(pending) > 0 && round < maxToolRounds; round++ {
 			followUpMessages = append(followUpMessages, map[string]any{
-				"role":         "tool",
-				"tool_call_id": tc.ID,
-				"content":      content,
+				"role":       "assistant",
+				"content":    raw["content"],
+				"tool_calls": raw["tool_calls"],
 			})
-		}
-		followUpResp, _, err := p.callAPI(ctx, map[string]any{
-			"model":    p.opts.Model,
-			"messages": followUpMessages,
-		})
-		if err == nil && followUpResp.Reply != "" {
-			resp.Answer = followUpResp.Reply
+			for _, tc := range pending {
+				content := p.opts.ToolHandler(ctx, tc).Content
+				followUpMessages = append(followUpMessages, map[string]any{
+					"role":         "tool",
+					"tool_call_id": tc.ID,
+					"content":      content,
+				})
+			}
+
+			followUpReq := map[string]any{
+				"model":    p.opts.Model,
+				"messages": followUpMessages,
+			}
+			if len(tools) > 0 {
+				followUpReq["tools"] = tools
+			}
+
+			followUpResp, followUpRaw, err := p.callAPI(ctx, followUpReq)
+			if err != nil {
+				break
+			}
+			if followUpResp.Reply != "" {
+				resp.Answer = followUpResp.Reply
+			}
+			pending, raw = followUpResp.ToolCalls, followUpRaw
+			resp.ToolCalls = append(resp.ToolCalls, followUpResp.ToolCalls...)
 		}
 	}
 
 	return resp, nil
 }
+
+// maxToolRounds bounds the tool-execution loop in a single Generate. Each
+// round is a model call plus the tools it asks for, so this is the ceiling on
+// one question's cost as well as its length; it is high enough that no honest
+// piece of multi-step work reaches it.
+const maxToolRounds = 12
 
 func (p *Provider) Stream(ctx context.Context, req *ai.Request, opts ...ai.GenerateOption) (ai.Stream, error) {
 	return openaiapi.Stream(ctx, p.opts, req, "/v1/chat/completions")


### PR DESCRIPTION
## Origin

A downstream patch (against their pinned v6.3.10) fixed atlascloud's one-round tool limitation: the follow-up request carried tool results but **no `tools` key**, and there was no loop — so a second tool call was impossible whatever the model wanted. The symptom is deceptive: asked to continue with tools it can no longer call, a model writes the call it wanted as ordinary text, so the reply reads as "model that can't format a tool call" (likely the same failure mode behind #4729).

## Audit: this was a class of bug, not an atlascloud bug

| Provider | Loops? | Tools on follow-up? |
|---|---|---|
| anthropic | ✅ (10 rounds) | ✅ |
| ollama | ✅ (10 rounds) | ✅ |
| atlascloud | ✅ (4 rounds, on master) | ✅ |
| **openai, gemini, groq, mistral, together, minimax** | ❌ one shot | ❌ |

Six of nine providers had the bug in its original form — and since tool execution lives inside the provider's `Generate`, provider-level looping **is** the multi-step mechanism. Everything an agent does in one step worked; read-then-edit, list-then-act could not.

## Changes

- **openai, gemini, groq, mistral, together, minimax** — the single follow-up becomes a bounded tool-execution loop (`maxToolRounds = 12`, per the patch's reasoning) that carries the tools (and, where the package sets them, `max_tokens`/reasoning options) on every round, accumulates `ToolCalls`, and defensively copies the message slice so rounds can't clobber each other through a shared backing array. Gemini's variant threads `functionDeclarations`/`functionResponse` parts.
- **atlascloud** — master already looped with tools (the patch author's pinned release predates it); adopted the patch's remaining deltas: named `maxToolRounds` bound (4 → 12), `max_tokens` on follow-up requests (initial + repair requests already set it), and the defensive copy.
- **New tests** (`ai/openai/tool_loop_test.go`): a two-step task makes three model calls with `tools` present on every follow-up (2 tool executions, final `Answer`, accumulated `ToolCalls`); a model that never stops asking is cut off at the bound.

## Verification

- `go build ./...`, `go vet ./ai/...`, gofmt — clean.
- `go test` green across all seven touched providers + `agent/`; mock conformance 6/6. (`TestConfiguredProviderStreamsSkipWithoutCredentials` fails without credentials on clean master too — pre-existing, noted in the downstream report.)

## Credit

Patch and analysis by the same downstream user who reported the agent double-send (#4896) and the `cmd` linkage drag (#4897) — their atlascloud fix generalized to the ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_