### PR TITLE
ai: discover tools in deterministic order

### DIFF
--- a/ai/tools.go
+++ b/ai/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -116,6 +117,13 @@ func (t *Tools) Discover() ([]Tool, error) {
 			})
 		}
 	}
+
+	// Deterministic order. The registry iterates a map, so without this the
+	// tool list is shuffled on every discovery — which silently defeats
+	// provider prompt caching (Anthropic cache_control, Gemini implicit
+	// caching): both key on a byte-identical prefix, and the tool catalogue
+	// is the bulk of that prefix.
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 	return out, nil
 }

--- a/ai/tools.go
+++ b/ai/tools.go
@@ -82,11 +82,22 @@ func (t *Tools) Discover() ([]Tool, error) {
 	}
 
 	var out []Tool
+	seen := map[string]bool{}
 	for _, svc := range services {
+		// ListServices returns one entry per registered version of a service;
+		// resolving each would duplicate every tool once per version.
+		if seen[svc.Name] {
+			continue
+		}
+		seen[svc.Name] = true
 		full, err := t.registry.GetService(svc.Name)
 		if err != nil || len(full) == 0 {
 			continue
 		}
+		// GetService returns the versions in map order. Pick the highest
+		// version so the same one — and therefore the same endpoint schemas
+		// and descriptions — is chosen on every discovery.
+		sort.Slice(full, func(i, j int) bool { return full[i].Version > full[j].Version })
 		for _, ep := range full[0].Endpoints {
 			original := fmt.Sprintf("%s.%s", svc.Name, ep.Name)
 			safe := strings.ReplaceAll(original, ".", "_")
@@ -123,7 +134,12 @@ func (t *Tools) Discover() ([]Tool, error) {
 	// provider prompt caching (Anthropic cache_control, Gemini implicit
 	// caching): both key on a byte-identical prefix, and the tool catalogue
 	// is the bulk of that prefix.
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].OriginalName < out[j].OriginalName
+	})
 
 	return out, nil
 }

--- a/ai/tools_test.go
+++ b/ai/tools_test.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"go-micro.dev/v6/registry"
@@ -135,13 +136,39 @@ func TestDiscoverOrderIsDeterministic(t *testing.T) {
 		}
 	}
 
+	// Two versions of one service, with different endpoint sets: discovery
+	// must not duplicate its tools, and must pick the same version — the
+	// highest — every time, or the serialized catalogue still churns.
+	for _, v := range []struct{ version, endpoint string }{
+		{"1.0.0", "Svc.Old"},
+		{"2.0.0", "Svc.New"},
+	} {
+		if err := reg.Register(&registry.Service{
+			Name:      "versioned",
+			Version:   v.version,
+			Endpoints: []*registry.Endpoint{{Name: v.endpoint}},
+			Nodes:     []*registry.Node{{Id: "versioned-" + v.version, Address: "127.0.0.1:0"}},
+		}); err != nil {
+			t.Fatalf("register versioned %s: %v", v.version, err)
+		}
+	}
+
 	tools := NewTools(reg)
 	first, err := tools.Discover()
 	if err != nil {
 		t.Fatalf("discover: %v", err)
 	}
-	if len(first) != 10 {
-		t.Fatalf("discovered %d tools, want 10", len(first))
+	if len(first) != 11 {
+		t.Fatalf("discovered %d tools, want 11 (10 + one from the versioned service, not one per version)", len(first))
+	}
+	var fromVersioned []string
+	for _, tool := range first {
+		if strings.HasPrefix(tool.Name, "versioned_") {
+			fromVersioned = append(fromVersioned, tool.Name)
+		}
+	}
+	if len(fromVersioned) != 1 || fromVersioned[0] != "versioned_Svc_New" {
+		t.Fatalf("versioned service tools = %v, want exactly [versioned_Svc_New] (highest version wins)", fromVersioned)
 	}
 	for i := 1; i < len(first); i++ {
 		if first[i-1].Name > first[i].Name {

--- a/ai/tools_test.go
+++ b/ai/tools_test.go
@@ -114,3 +114,50 @@ func TestWithTools(t *testing.T) {
 		t.Error("WithTools did not set a ToolHandler")
 	}
 }
+
+// Discovery order is deterministic. The registry iterates a map, so without
+// an explicit sort the tool list is shuffled on every call — which silently
+// defeats provider prompt caching: Anthropic cache_control and Gemini
+// implicit caching both key on a byte-identical prefix, and the tool
+// catalogue is the bulk of that prefix.
+func TestDiscoverOrderIsDeterministic(t *testing.T) {
+	reg := registry.NewMemoryRegistry()
+	for _, name := range []string{"zulu", "alpha", "mike", "bravo", "yankee"} {
+		if err := reg.Register(&registry.Service{
+			Name: name,
+			Endpoints: []*registry.Endpoint{
+				{Name: "Svc.Do"},
+				{Name: "Svc.List"},
+			},
+			Nodes: []*registry.Node{{Id: name + "-1", Address: "127.0.0.1:0"}},
+		}); err != nil {
+			t.Fatalf("register %s: %v", name, err)
+		}
+	}
+
+	tools := NewTools(reg)
+	first, err := tools.Discover()
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(first) != 10 {
+		t.Fatalf("discovered %d tools, want 10", len(first))
+	}
+	for i := 1; i < len(first); i++ {
+		if first[i-1].Name > first[i].Name {
+			t.Fatalf("tools not sorted: %q before %q", first[i-1].Name, first[i].Name)
+		}
+	}
+	// Map iteration order varies run to run; several rounds catch a shuffle.
+	for round := 0; round < 5; round++ {
+		again, err := tools.Discover()
+		if err != nil {
+			t.Fatalf("discover round %d: %v", round, err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("round %d: order changed at %d: %q != %q", round, i, again[i].Name, first[i].Name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Why

Follow-up to #4901 (Anthropic prompt caching), and the answer to "what's the Gemini equivalent."

Investigating Gemini caching turned up a bug that undermines **both**: `Tools.Discover` inherits the registry's iteration order, and the memory registry ranges over a map — so **the tool list is shuffled on every discovery**. Provider prompt caching (Anthropic `cache_control`, [Gemini implicit caching](https://developers.googleblog.com/gemini-2-5-models-now-support-implicit-caching/)) keys on a *byte-identical* request prefix, and the tool catalogue is the bulk of that prefix. A shuffled catalogue means a cache write on every turn instead of a hit — paying the write premium repeatedly while never caching.

## Change

Sort discovered tools by name in `Tools.Discover` (the free `DiscoverTools` delegates to it). Custom tools added via `AgentTool` keep their insertion order after the discovered set. Go's `encoding/json` already sorts map keys, so with the slice order fixed the serialized prefix is fully deterministic.

New test registers five services and asserts the order is sorted and survives repeated discovery across map-iteration shuffles.

## On Gemini specifically

No provider code needed: [implicit caching is on by default for Gemini 2.5+ models](https://ai.google.dev/gemini-api/docs/caching) (go-micro's default is `gemini-2.5-flash`) with ~90% off cached prefix tokens — it just requires the stable prefix this PR provides. Explicit `cachedContents` caching is a stateful resource with TTL + storage billing; enabling it silently could *raise* costs for idle agents, so it's deliberately not added. If wanted later, it should be an explicit opt-in.

## Verification

- `go test ./ai/` (new determinism test), `./agent/`, `./cmd/micro/`, mock conformance 6/6 — green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmdEY7pYmV5zzwCjNJ4ykL)_