### PR TITLE
agent: let a caller observe run events as they happen

### DIFF
--- a/agent/options.go
+++ b/agent/options.go
@@ -124,6 +124,10 @@ type Options struct {
 	// timelines carry correlation and shape without leaking prompts.
 	TraceInputs bool
 
+	// OnRunEvent, if set, is called as each run event is recorded
+	// (see OnRunEvent).
+	OnRunEvent RunEventFunc
+
 	// tools are developer-registered custom tools (see WithTool).
 	tools []customTool
 	// wrappers are developer-registered tool-execution wrappers
@@ -427,4 +431,25 @@ func TraceProvider(tp trace.TracerProvider) Option {
 // prompt content.
 func TraceInputs(enabled bool) Option {
 	return func(o *Options) { o.TraceInputs = enabled }
+}
+
+// RunEventFunc is called with each event recorded on a run.
+type RunEventFunc func(RunEvent)
+
+// OnRunEvent registers f to be called as each run event is recorded: the model
+// calls with the tokens they used, the tool calls with what they spent, and the
+// errors and completion of the run itself.
+//
+// The timeline is written to the store either way, and LoadRunEvents reads it
+// back — this is for the caller that has to act on an event rather than look at
+// it afterwards. Billing is the case that needs it: token usage is known the
+// moment the model returns, and a caller holding the ledger cannot read a
+// timeline it does not have the run id of. A caller that only wants to look
+// should read the store.
+//
+// f is called on the run's own goroutine, before the event is written, so it
+// must not block and must not call back into the agent. A panic in it is the
+// caller's to prevent.
+func OnRunEvent(f RunEventFunc) Option {
+	return func(o *Options) { o.OnRunEvent = f }
 }

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -555,9 +555,15 @@ func appendRunInfoAttributes(attrs []attribute.KeyValue, info ai.RunInfo) []attr
 	return attrs
 }
 
+// recordRunEvent is where every run event ends up — the traced paths and the
+// untraced ones both funnel through here — which is why the observer hangs off
+// it rather than off each caller.
 func (a *agentImpl) recordRunEvent(e RunEvent) {
 	if e.RunID == "" {
 		return
+	}
+	if f := a.opts.OnRunEvent; f != nil {
+		f(e)
 	}
 	b, _ := json.Marshal(e)
 	key := fmt.Sprintf("runs/%s/%020d-%s", e.RunID, e.Time.UnixNano(), e.Kind)

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -573,6 +573,77 @@ func TestAgentRunTimelineRecordsModelAndToolWithoutTraceProvider(t *testing.T) {
 	}
 }
 
+// A caller can watch the run as it happens, which is what billing needs: the
+// tokens a model used are known when it returns, and a ledger cannot read back
+// a timeline it does not have the run id of.
+func TestOnRunEventObservesModelTokensAsTheyHappen(t *testing.T) {
+	var events []RunEvent
+	st := store.NewMemoryStore()
+	a := New(Name("observed"), Provider("oteltest"), WithStore(st),
+		OnRunEvent(func(e RunEvent) { events = append(events, e) }),
+		WithTool("probe", "probe", nil, func(context.Context, map[string]any) (string, error) { return "ok", nil }))
+	if _, err := a.Ask(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+
+	var model *RunEvent
+	seen := map[string]bool{}
+	for i, e := range events {
+		seen[e.Kind] = true
+		if e.Kind == "model" {
+			model = &events[i]
+		}
+	}
+	for _, kind := range []string{"run", "model", "tool", "done"} {
+		if !seen[kind] {
+			t.Fatalf("no %s event reached the observer: %#v", kind, events)
+		}
+	}
+	if model == nil {
+		t.Fatal("no model event")
+	}
+	// The tokens are the point. An observer that gets called with an empty
+	// Usage is the same as not being called.
+	if model.Tokens.InputTokens != 2 || model.Tokens.OutputTokens != 3 {
+		t.Errorf("model event carries no usage: %#v", model.Tokens)
+	}
+	if model.Model == "" && model.Provider == "" {
+		t.Errorf("model event names neither provider nor model, so nothing can price it: %#v", model)
+	}
+
+	// And the store still has the timeline: the observer is in addition to the
+	// record, not instead of it.
+	summaries, err := ListRunSummaries(st, "observed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("got %d summaries, want 1", len(summaries))
+	}
+}
+
+// The traced path funnels through the same place, so a caller does not get a
+// different set of events for having configured tracing.
+func TestOnRunEventFiresWithATraceProvider(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	var kinds []string
+	a := New(Name("observed-traced"), Provider("oteltest"), WithStore(store.NewMemoryStore()),
+		TraceProvider(trace.NewTracerProvider(trace.WithSyncer(exp))),
+		OnRunEvent(func(e RunEvent) { kinds = append(kinds, e.Kind) }))
+	if _, err := a.Ask(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	var haveModel bool
+	for _, k := range kinds {
+		if k == "model" {
+			haveModel = true
+		}
+	}
+	if !haveModel {
+		t.Fatalf("no model event with a TraceProvider set: %v", kinds)
+	}
+}
+
 func TestAgentCheckpointAndResumeTimelineEvents(t *testing.T) {
 	exp := tracetest.NewInMemoryExporter()
 	tp := trace.NewTracerProvider(trace.WithSyncer(exp))


### PR DESCRIPTION
The run timeline is written to the store and read back with LoadRunEvents, which serves an operator looking at what a run did. It does not serve a caller that has to act on an event: token usage is known the moment the model returns, and a caller holding a ledger cannot read back a timeline it does not have the run id of — least of all for a run that failed, where Ask returns an error and no Response, and the tokens already spent are the ones nothing accounts for.

OnRunEvent hands each event to the caller as it is recorded. It hangs off recordRunEvent because that is where every path already funnels — traced and untraced, model, tool, checkpoint and completion — so the caller sees the same events whether or not a TraceProvider is configured, which the test asserts both ways.


Claude-Session: https://claude.ai/code/session_01P2r4ca9UPPf7FDk7y8eJLr