### PR TITLE
ai/atlascloud: report token usage from Generate

### DIFF
--- a/ai/atlascloud/atlascloud.go
+++ b/ai/atlascloud/atlascloud.go
@@ -460,6 +460,19 @@ func (p *Provider) callAPI(ctx context.Context, phase string, req map[string]any
 				ToolCalls []atlasToolCall `json:"tool_calls"`
 			} `json:"message"`
 		} `json:"choices"`
+		// Token counts, which the API returns on every completion and this
+		// struct did not ask for.
+		//
+		// ai.Response has carried a Usage field from the start and the
+		// streaming path fills it in (see the final chunk after
+		// include_usage), so a caller metering spend got real numbers from a
+		// stream and zeroes from a plain Generate — indistinguishable from a
+		// call that cost nothing. An agent runs on Generate.
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
 	}
 
 	if err := json.Unmarshal(respBody, &chatResp); err != nil {
@@ -473,6 +486,11 @@ func (p *Provider) callAPI(ctx context.Context, phase string, req map[string]any
 	choice := chatResp.Choices[0]
 	response := &ai.Response{
 		Reply: choice.Message.Content,
+		Usage: ai.Usage{
+			InputTokens:  chatResp.Usage.PromptTokens,
+			OutputTokens: chatResp.Usage.CompletionTokens,
+			TotalTokens:  chatResp.Usage.TotalTokens,
+		},
 	}
 
 	for _, tc := range choice.Message.ToolCalls {

--- a/ai/atlascloud/usage_test.go
+++ b/ai/atlascloud/usage_test.go
@@ -1,0 +1,68 @@
+package atlascloud
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go-micro.dev/v6/ai"
+)
+
+// Generate reports what the completion cost, the same as Stream does.
+//
+// ai.Response has carried a Usage field from the start, and only the streaming
+// path filled it in — the final chunk after include_usage. The plain path
+// parsed choices and nothing else, so the API returned token counts on every
+// completion and the struct never asked for them.
+//
+// The two paths disagreeing is the whole bug: a caller metering spend got real
+// numbers from a stream and zeroes from Generate, and a zero is
+// indistinguishable from a call that cost nothing. An agent runs on Generate,
+// so the largest consumer of tokens was the one reporting none.
+func TestGenerateReportsUsage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"choices":[{"message":{"content":"hello"}}],
+			"usage":{"prompt_tokens":7,"completion_tokens":2,"total_tokens":9}
+		}`))
+	}))
+	defer ts.Close()
+
+	p := NewProvider(ai.WithAPIKey("test-key"), ai.WithBaseURL(ts.URL))
+	resp, err := p.Generate(context.Background(), &ai.Request{Prompt: "Hello"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if resp.Reply != "hello" {
+		t.Errorf("Reply = %q, want hello", resp.Reply)
+	}
+	want := ai.Usage{InputTokens: 7, OutputTokens: 2, TotalTokens: 9}
+	if resp.Usage != want {
+		t.Errorf("Usage = %+v, want %+v — a caller metering spend cannot tell a\n"+
+			"call that reported nothing from one that cost nothing", resp.Usage, want)
+	}
+}
+
+// A response with no usage in it is still a response. Not every deployment
+// returns the block, and a missing count is zero rather than an error.
+func TestGenerateWithoutUsageStillAnswers(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}]}`))
+	}))
+	defer ts.Close()
+
+	p := NewProvider(ai.WithAPIKey("test-key"), ai.WithBaseURL(ts.URL))
+	resp, err := p.Generate(context.Background(), &ai.Request{Prompt: "Hello"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if resp.Reply != "hello" {
+		t.Errorf("Reply = %q, want hello", resp.Reply)
+	}
+	if resp.Usage != (ai.Usage{}) {
+		t.Errorf("Usage = %+v, want zero", resp.Usage)
+	}
+}


### PR DESCRIPTION
ai.Response has carried a Usage field from the start and only Stream filled it in — the final chunk after include_usage. The plain path parsed choices and nothing else, so the API returned token counts on every completion and the struct never asked for them.

The two paths disagreeing is the bug. A caller metering spend got real numbers from a stream and zeroes from Generate, and a zero is indistinguishable from a call that cost nothing. An agent runs on Generate, so the largest consumer of tokens was the one reporting none: downstream, an instance with 1,870 completions behind it believed it had spent nothing on models at all.

A response with no usage block is still a response — not every deployment returns one — so a missing count stays zero rather than becoming an error.


Claude-Session: https://claude.ai/code/session_01P2r4ca9UPPf7FDk7y8eJLr