### PR TITLE
docs: align agent and flow durability guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,14 @@ agent := micro.NewAgent("assistant",
 )
 ```
 
-**Memory** is durable and store-backed by default (Postgres, NATS KV, or file), so an agent picks up where it left off after a restart — or supply your own with `AgentMemory`. Long-running agents can opt into `AgentCompactMemory(maxMessages, keepRecent)`: older turns are collapsed into a deterministic summary, recent turns stay verbatim, and relevant archived turns are recalled on future asks without replaying the whole conversation. **Tools** are your services automatically, plus any function you register with `AgentTool`.
+**Memory** is durable and store-backed by default (Postgres, NATS KV, or file), so an agent restores its conversation history after a restart — or supply your own with `AgentMemory`. Long-running agents can opt into `AgentCompactMemory(maxMessages, keepRecent)`: older turns are collapsed into a deterministic summary, recent turns stay verbatim, and relevant archived turns are recalled on future asks without replaying the whole conversation. **Tools** are your services automatically, plus any function you register with `AgentTool`.
+
+Conversation recovery is separate from execution recovery: interrupted agent runs
+need an explicit `AgentWithCheckpoint` and resume call. Flow steps resume from
+successfully saved boundaries; an interrupted step may execute again. See
+[Durability and Recovery](internal/website/content/en/docs/guides/durability.md)
+for storage requirements, retry semantics, tool replay, and the exactly-once and
+multi-replica limitations.
 
 ### Paid tools (x402)
 
@@ -307,7 +314,7 @@ MCP exposes your services as tools; A2A exposes your agents as agents. See the [
 | Guardrails | `MaxSteps` (stop on count), `LoopLimit` (stop repeated no-progress calls), `ApproveTool` (human-in-the-loop) |
 | Tool middleware | `AgentWrapTool` — wrap tool execution for logging, metrics, or retries (like client/server wrappers) |
 | Workflows | `micro.NewFlow()` — event-driven; one step, ordered durable steps, or triggers an agent |
-| Durable execution | Checkpointed flow steps survive a crash and resume where they stopped; store-backed by default, pluggable backend |
+| Durable execution | Flow steps resume from saved boundaries with a persistent store; interrupted steps can repeat, pluggable backend |
 | MCP gateway | Every endpoint is an AI tool automatically |
 | A2A gateway | Every agent is reachable over the Agent2Agent protocol; cards generated from the registry (`micro a2a`) |
 | Payments (x402) | Opt-in per-call payments for tools via the x402 standard; pluggable facilitator (Base, Solana, …) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,11 @@ gateways (both directions, including A2A streaming,
 push notifications, and multi-turn continuation), x402 paid tools, secure by
 default.
 
+The shipped durability contract is documented in
+[Durability and Recovery](internal/website/content/en/docs/guides/durability.md):
+agent run checkpoints are opt-in, recovery is explicit, and external side effects
+are not exactly-once. The older internal design note is historical.
+
 ## Principles
 
 1. Build into what people run, never a separate product (no hosted platform, no

--- a/examples/agent-durable/README.md
+++ b/examples/agent-durable/README.md
@@ -23,8 +23,10 @@ called a second time during resume.
 Use a durable flow when the path is known ahead of time: ordered service calls,
 retries, timers, compensation, and a precise resume stage such as `reserve` or
 `charge`. Use a checkpointed agent run when the path is open-ended and the model
-may choose tools dynamically, but completed tool side effects still must not be
-replayed after a crash or provider failure.
+may choose tools dynamically, and reuse tool results whose completion has already been saved. A side effect
+that succeeds before its checkpoint is saved can still repeat. See the
+[durability contract](../../internal/website/content/en/docs/guides/durability.md)
+for tool identity, storage failure, and recovery limitations.
 
 They compose: keep deterministic business process in `flow-durable`, then hand
 off the judgment-heavy step to a checkpointed agent when the workflow needs

--- a/examples/flow-durable/README.md
+++ b/examples/flow-durable/README.md
@@ -6,8 +6,9 @@ A `flow` can be an ordered list of **steps** — a task with stages —
 instead of a single LLM turn. Each step is checkpointed before and after
 through a pluggable `Checkpoint` (store-backed by default), so if the
 process dies mid-run, the run resumes at the step it stopped on, without
-re-running the steps that already completed (and already had their side
-effects).
+re-running steps whose completion was successfully checkpointed. A step
+interrupted before that save can repeat its side effects; see the
+[durability contract](../../internal/website/content/en/docs/guides/durability.md).
 
 ## What this shows
 
@@ -55,9 +56,9 @@ f.Resume(ctx, pending[0].ID) // continues from charge to the end
 - **`Checkpoint`** persists each `Run`. The built-in is store-backed and
   keeps each flow's runs in their own store table (database `flow`, table
   `checkout`) via `store.Scope`, so one flow's runs don't share a table
-  with another's — or with agent or service state. Point the default
-  store at Postgres or NATS KV and a run survives a real process restart,
-  or implement the interface to plug in Temporal, Restate, etc.
+  with another's — or with agent or service state. The default file store survives a process restart when its files are
+  retained. Other stores can be selected explicitly; `Checkpoint` alone does
+  not supply an external-engine adapter or exactly-once execution.
 - A real step would be `flow.Call(service, endpoint)` (an RPC),
   `flow.Dispatch(agent)` (hand off to an agent), or `flow.LLM(prompt)`
   (one model turn). Here they're plain funcs so durability is the only

--- a/internal/docs/DURABLE_EXECUTION_DESIGN.md
+++ b/internal/docs/DURABLE_EXECUTION_DESIGN.md
@@ -1,6 +1,15 @@
 # Durable Execution: Flow Steps & Checkpoint
 
-**Status:** Design proposal — not yet implemented.
+**Status:** Historical design proposal, partly implemented. The shipped contract is
+[Durability and Recovery](../website/content/en/docs/guides/durability.md).
+
+Ordered flow steps, store-backed checkpoints, flow waiting/resume-with-input,
+opt-in agent checkpoints, and run tracing now exist. The proposal below is kept
+for design history: its pseudocode, API sketches, rollout sequence, and suggested
+idempotency behavior are not a description of current guarantees. In particular,
+`Step.Retry == 0` inherits the flow default; checkpoints do not provide
+exactly-once side effects or multi-replica leases. Consult the current guide and
+linked implementation before using a proposed API or planning follow-up work.
 
 This note sketches two related changes:
 

--- a/internal/website/content/en/docs/guides/agent-loops.md
+++ b/internal/website/content/en/docs/guides/agent-loops.md
@@ -87,9 +87,10 @@ micro.FlowOnIteration(func(iter int, s micro.FlowState) {
 ## Durability
 
 A loop runs as a **single flow step**. The flow checkpoints the loop's outcome
-(before and after the step) through its [Checkpoint](../deployment.md), and a
+(before and after the step) through its [Checkpoint](durability.md), and a
 resume re-enters the step — so keep loop bodies safe to repeat. For long loops,
-use `FlowOnIteration` to persist per-pass progress.
+use `FlowOnIteration` for application-owned progress recording; the callback does
+not change the engine's resume boundary or automatically skip completed iterations.
 
 ## Run it
 

--- a/internal/website/content/en/docs/guides/agents-and-workflows.md
+++ b/internal/website/content/en/docs/guides/agents-and-workflows.md
@@ -49,7 +49,7 @@ This is the clean seam between the two halves of the taxonomy: the *workflow* (d
 
 ### Ordered, durable steps
 
-A flow can be a **task made of ordered steps** rather than a single turn — the predefined path made explicit. Each step is checkpointed before and after, so if the process dies mid-run the run **resumes at the step it stopped on**, without re-running the steps that already completed (and already had their side effects). This is durable execution, store-backed by default, with no separate workflow engine.
+A flow can be a **task made of ordered steps** rather than a single turn — the predefined path made explicit. Each step is checkpointed before and after, so if the process dies mid-run the run **resumes at the step it stopped on**, without re-running steps whose completion was successfully checkpointed. An interrupted step can repeat its side effects. This is durable execution, store-backed by default, with no separate workflow engine.
 
 ```go
 f := micro.NewFlow("checkout",
@@ -60,14 +60,14 @@ f := micro.NewFlow("checkout",
         micro.FlowStep{Name: "charge",  Run: micro.FlowCall("payment", "Payment.Charge")},
         micro.FlowStep{Name: "welcome", Run: micro.FlowDispatch("comms")}, // hand a step to an agent
     ),
-    // Durable by default; point the default store at Postgres/NATS KV to
-    // survive a real restart, or plug in Temporal/Restate via Checkpoint.
+    // The default file store must live on persistent storage across restarts.
+    // WithCheckpoint can supply another backend; no external-engine adapter is implied.
 )
 ```
 
 A step's action is an RPC (`FlowCall`), an agent hand-off (`FlowDispatch`), one model turn (`FlowLLM`), or any function. `State` carries a typed payload (`Set`/`Scan`) plus a `Stage` marker — the resume point. Runs are retained for success and failure (audit) unless you set `FlowDeleteOnSuccess`. On restart, `f.Pending(ctx)` lists incomplete runs and `f.Resume(ctx, runID)` continues one. See [examples/flow-durable](https://github.com/micro/go-micro/tree/master/examples/flow-durable).
 
-The pluggability is the usual go-micro shape: the built-in `Checkpoint` is store-backed (swap the store backend freely); implement the `Checkpoint` interface to delegate durability to an external engine. Most teams need neither — the default is durable.
+The pluggability is the usual go-micro shape: the built-in `Checkpoint` is store-backed (swap the store backend freely); implement the `Checkpoint` interface to delegate durability to an external engine. The default file store survives a process restart only while its files are retained. See [Durability and Recovery](durability.md) for waiting/input, retries, agent checkpoints, and replay limitations.
 
 ## Agent ↔ `agent`
 

--- a/internal/website/content/en/docs/guides/durability.md
+++ b/internal/website/content/en/docs/guides/durability.md
@@ -1,0 +1,124 @@
+---
+title: "Durability and Recovery"
+---
+
+# Durability and recovery
+
+Go Micro implements checkpointed flow steps and opt-in checkpointed agent runs.
+Conversation memory, execution checkpoints, and tracing are separate mechanisms.
+This page describes the shipped contract; the original
+[design note](https://github.com/micro/go-micro/blob/master/internal/docs/DURABLE_EXECUTION_DESIGN.md)
+is historical, not an implementation checklist.
+
+## Storage and recovery boundaries
+
+| Mechanism | Default and persisted state | Recovery boundary |
+|---|---|---|
+| Agent memory | Store-backed conversation history, unless custom or in-memory memory is selected | Restores conversation context; does not by itself resume interrupted tool execution |
+| Ordered flow | Store-backed `flow.Checkpoint` when `Steps` is non-empty | Saves before and after each step; resumes from the saved `State.Stage` |
+| Agent run | Opt in with `agent.WithCheckpoint` / `micro.AgentWithCheckpoint` | Saves run input, status, completed tool results, and final response for explicit resume |
+| OpenTelemetry | Configure a trace provider | Observes runs and steps; spans are not the checkpoint store or a recovery scheduler |
+
+`store.DefaultStore` is the file store under `~/micro/store/`. Its files must
+survive the process/container lifetime; an ephemeral volume is not restart
+recovery. `store.NewMemoryStore()` does not survive process exit. A custom store
+or checkpoint backend determines its own persistence and failure guarantees.
+`flow.StoreCheckpoint(store, scope)` isolates runs in database `flow`, table
+`scope`; reuse the same backend and scope when recovering.
+
+Recovery is explicit. Reconstruct the flow/agent with compatible configuration
+and call the appropriate resume API. Persisting a checkpoint does not install a
+background recovery worker or migrate checkpoints when step names/configuration
+change.
+
+## Flow runs, waiting, and retries
+
+`flow.Run` holds the run ID and parent ID, flow name, state (`Stage` and serialized
+`Data`), step records, status, optional awaited input, and timestamps. Successful
+and failed runs are retained unless `DeleteOnSuccess` is enabled.
+
+- `Resume(ctx, runID)` continues from the saved stage; a completed run is a no-op.
+  A step whose completion was successfully saved is skipped. A step still
+  recorded as `in_progress` can execute again.
+- `Pending` excludes completed and `waiting` runs. `ResumePending` processes
+  pending runs oldest first and stops at the first error, returning its run ID.
+- `Await` / `AwaitStep` save a `waiting` run and return cleanly. `Waiting` lists
+  those runs. `ResumeWith(ctx, runID, input)` uses the supplied string as the
+  awaited step's output state and continues at the next step; it does not merge
+  the string into the previous JSON payload automatically.
+- `Retry(n)` allows up to `n` retries after the first attempt. A positive
+  `Step.Retry` overrides it; `Step.Retry == 0` inherits the flow default, so zero
+  does not disable an inherited retry policy. Context cancellation/deadlines
+  stop retries, including backoff waits.
+- `Loop` is one flow step. Its iterations are not independently checkpointed by
+  the engine. `OnIteration` is a callback for application-owned progress; it does
+  not automatically make the loop resume at that iteration.
+
+A `Dispatch` step calls `Agent.Chat` and propagates the parent run ID. That
+lineage is not an instruction to resume an existing child agent run: replaying
+an interrupted dispatch can create another agent invocation.
+
+## Agent runs and tool replay
+
+With a checkpoint configured, `agent.Resume` returns a completed run's saved
+response without invoking the model again. An unfinished resumable run re-enters
+agent execution with its saved input and completed tool history; model work can
+run again. `ResumeStreamAsk` supplies the streaming resume path. A human-input
+pause requires `ResumeInput`, rather than plain `Resume`.
+
+Completed tool results are reused within the run by **tool name plus
+JSON-serialized input**, not by the provider's tool-call ID. Identical calls in
+one run therefore share a completed result. This is not a cross-run idempotency
+key and does not guarantee that a model will choose the same arguments after a
+restart.
+
+Agent pending runs exclude terminal `done`, `canceled`, `timeout`,
+`rate_limited`, and `expired` statuses. Paused runs can still appear in pending
+results; an input-required pause needs the input helper, so an unattended
+`ResumePending` loop can stop there.
+
+## What is not guaranteed
+
+- **No exactly-once external side effects.** A crash after an external action
+  succeeds but before its completion is saved can repeat that action. Flow
+  retries can repeat it too. Use application/callee idempotency or reconciliation
+  for payments, provisioning, and other irreversible actions.
+- **No checkpoint transaction spanning an external service.** Flow checkpoint
+  errors are returned, but the agent tool wrapper's intermediate saves are
+  best-effort. Do not rely on replay suppression after a storage failure.
+- **No multi-replica execution lease in the `Checkpoint` interface.** Its methods
+  are Save, Load, Delete, and List; coordinate concurrent recovery externally.
+- **No universal external-engine adapter.** `Checkpoint` is an extension seam;
+  it does not itself provide a Temporal/Restate integration or their guarantees.
+
+Checkpoint payloads and tool results can contain application data. Conversation
+memory and checkpoints are not made private merely by enabling tracing; choose
+appropriate storage access, retention, and redaction for each separately.
+
+## No-secret verification
+
+From the repository root, run the existing deterministic tests:
+
+```sh
+go test ./flow -run 'TestFlow(CheckpointResume|AwaitAndResumeWith|StepRetry|CheckpointSaveFailureStopsRun)'
+go test ./agent -run 'Test(ResumeFailedCheckpointAfterFreshAgentRestart|ResumePendingAfterFreshAgentRestartDoesNotReplayCompletedTool|HumanInputPauseResumesSameRunWithInput|ResumeStreamAskDoesNotReplayCompletedTool)'
+go test ./agent ./flow -run 'Test.*(OTel|Trace|Span)'
+go run ./examples/agent-durable
+```
+
+These tests use controlled models/stores; the agent example uses an in-memory
+store and demonstrates a checkpointed tool result being reused after a simulated
+interruption. Fresh-agent tests reconstruct the agent over the same test store.
+They are not process-kill, disk-loss, multi-replica, or real-provider guarantees.
+For deployment validation, also exercise restart with the actual persistent
+backend and volume configuration.
+
+## Source of truth
+
+- [Flow records, checkpoint backend, resume and retry](https://github.com/micro/go-micro/blob/master/flow/steps.go)
+- [Loop boundary](https://github.com/micro/go-micro/blob/master/flow/loop.go)
+- [Agent checkpoint and tool deduplication](https://github.com/micro/go-micro/blob/master/agent/checkpoint.go)
+- [Agent execution and memory setup](https://github.com/micro/go-micro/blob/master/agent/agent.go)
+- [Streaming resume](https://github.com/micro/go-micro/blob/master/agent/stream.go)
+- [Default store](https://github.com/micro/go-micro/blob/master/store/store.go)
+- [Remaining agent/flow design discussion](https://github.com/micro/go-micro/issues/4816)

--- a/internal/website/content/en/docs/roadmap.md
+++ b/internal/website/content/en/docs/roadmap.md
@@ -14,6 +14,10 @@ The foundation is in place:
 - **Interop** — the MCP gateway (services as tools) and the A2A gateway (agents as agents, both directions, including A2A streaming, push notifications, and multi-turn continuation), both generated from the registry; x402 for paid tools.
 - **Secure by default** — TLS verification on, state scoped per component.
 
+See [Durability and Recovery](guides/durability.md) for the exact shipped
+boundaries: opt-in agent checkpoints, explicit recovery, and no exactly-once
+external side-effect or multi-replica lease guarantee.
+
 ## Principles
 
 These constrain everything below:


### PR DESCRIPTION
Closes #4846.

The README implied that conversation memory resumes interrupted execution, while the durable execution design note still described shipped features as unimplemented. Add a source-linked durability contract and align the README, roadmaps, workflow/loop guides, and durable examples with it.

The guide distinguishes memory, flow checkpoints, opt-in agent checkpoints, and tracing; documents saved-stage recovery, waiting/input, retry inheritance, tool-result deduplication, and explicit resume; and identifies the limits around storage failures, repeated side effects, and concurrent recovery. The historical proposal remains available with a clear status banner. Remaining architectural work links to #4816.

Validation (Go 1.25.12):
- `go build ./...` and `go test ./...`: passed.
- `go test ./agent ./flow`: passed.
- `make harness`: passed, including mock provider conformance (6 passed).
- `go run ./examples/agent-durable`: passed; resumed with one tool execution.
- New relative documentation links, guide frontmatter, and `git diff --check`: passed.
- `golangci-lint run ./...` (v2.5.0): reports 8 existing findings in unchanged Go files: two unchecked watcher errors and six spelling findings in AI code/tests. No Go source, dependency, or lint configuration changes are included.

The documented no-secret checks use controlled models/stores and simulated interruption; they do not claim real process-kill or production-backend recovery coverage. This documentation audit was implemented and validated by Codex.
