### PR TITLE
agent: add a versioned inspectable run record

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -55,6 +55,9 @@ const (
 	AttrToolSpend        = "agent.tool.spend"
 )
 
+// RunEvent is one ordered, persisted observation from an agent run. Events
+// intentionally contain operational metadata rather than model or tool payloads;
+// Name contains the prompt only when TraceInputs is explicitly enabled.
 type RunEvent struct {
 	Time        time.Time `json:"time"`
 	RunID       string    `json:"run_id"`
@@ -98,7 +101,8 @@ type RunListOptions struct {
 	Limit int
 }
 
-// RunSummary is a compact index entry for a recorded agent run.
+// RunSummary is the derived, compact index entry for a recorded agent run. It
+// can be rebuilt from the run's events and is not a separate source of truth.
 type RunSummary struct {
 	RunID         string    `json:"run_id"`
 	Agent         string    `json:"agent"`
@@ -116,6 +120,18 @@ type RunSummary struct {
 	LastError     string    `json:"last_error,omitempty"`
 	LastErrorKind string    `json:"last_error_kind,omitempty"`
 	Spent         int64     `json:"spent,omitempty"`
+}
+
+// RunRecordSchemaVersion is the current JSON schema version for RunRecord.
+const RunRecordSchemaVersion = 1
+
+// RunRecord is the durable, inspectable representation of one agent execution.
+// Events are ordered oldest first and Summary is derived from those events.
+// Consumers should use SchemaVersion when decoding records across releases.
+type RunRecord struct {
+	SchemaVersion int        `json:"schema_version"`
+	Summary       RunSummary `json:"summary"`
+	Events        []RunEvent `json:"events"`
 }
 
 func (a *agentImpl) tracer() trace.Tracer {
@@ -605,49 +621,7 @@ func ListRunSummariesWithOptions(s store.Store, agentName string, opts RunListOp
 		if len(events) == 0 {
 			continue
 		}
-		first := events[0]
-		last := events[len(events)-1]
-		summary := RunSummary{
-			RunID:      id,
-			Agent:      first.Agent,
-			ParentID:   first.ParentID,
-			TraceID:    first.TraceID,
-			SpanID:     first.SpanID,
-			StartedAt:  first.Time,
-			UpdatedAt:  last.Time,
-			DurationMS: last.Time.Sub(first.Time).Milliseconds(),
-			Events:     len(events),
-			Status:     runStatus(events),
-			LastKind:   last.Kind,
-			LastError:  last.Error,
-		}
-		for _, e := range events {
-			if e.Agent != "" {
-				summary.Agent = e.Agent
-			}
-			if e.ParentID != "" {
-				summary.ParentID = e.ParentID
-			}
-			if e.TraceID != "" {
-				summary.TraceID = e.TraceID
-			}
-			if e.SpanID != "" {
-				summary.SpanID = e.SpanID
-			}
-			if e.Kind == "checkpoint" {
-				summary.Checkpoint = e.Status
-				summary.Stage = e.Name
-			}
-			if e.Error != "" {
-				summary.LastError = e.Error
-			}
-			if e.ErrorKind != "" {
-				summary.LastErrorKind = e.ErrorKind
-			}
-			if e.Spent > summary.Spent {
-				summary.Spent = e.Spent
-			}
-		}
+		summary := summarizeRunEvents(id, events)
 		if opts.Status != "" && summary.Status != opts.Status {
 			continue
 		}
@@ -665,6 +639,53 @@ func ListRunSummariesWithOptions(s store.Store, agentName string, opts RunListOp
 		}
 	}
 	return summaries, nil
+}
+
+func summarizeRunEvents(runID string, events []RunEvent) RunSummary {
+	summary := RunSummary{RunID: runID, Events: len(events)}
+	if len(events) == 0 {
+		return summary
+	}
+	first := events[0]
+	last := events[len(events)-1]
+	summary.Agent = first.Agent
+	summary.ParentID = first.ParentID
+	summary.TraceID = first.TraceID
+	summary.SpanID = first.SpanID
+	summary.StartedAt = first.Time
+	summary.UpdatedAt = last.Time
+	summary.DurationMS = last.Time.Sub(first.Time).Milliseconds()
+	summary.Status = runStatus(events)
+	summary.LastKind = last.Kind
+	summary.LastError = last.Error
+	for _, e := range events {
+		if e.Agent != "" {
+			summary.Agent = e.Agent
+		}
+		if e.ParentID != "" {
+			summary.ParentID = e.ParentID
+		}
+		if e.TraceID != "" {
+			summary.TraceID = e.TraceID
+		}
+		if e.SpanID != "" {
+			summary.SpanID = e.SpanID
+		}
+		if e.Kind == "checkpoint" {
+			summary.Checkpoint = e.Status
+			summary.Stage = e.Name
+		}
+		if e.Error != "" {
+			summary.LastError = e.Error
+		}
+		if e.ErrorKind != "" {
+			summary.LastErrorKind = e.ErrorKind
+		}
+		if e.Spent > summary.Spent {
+			summary.Spent = e.Spent
+		}
+	}
+	return summary
 }
 
 func runStatus(events []RunEvent) string {
@@ -726,4 +747,22 @@ func LoadRunEvents(s store.Store, agentName, runID string) ([]RunEvent, error) {
 		}
 	}
 	return events, nil
+}
+
+// LoadRunRecord loads the versioned record for one agent run. A run with no
+// recorded events returns an empty record carrying the requested identity.
+func LoadRunRecord(s store.Store, agentName, runID string) (RunRecord, error) {
+	events, err := LoadRunEvents(s, agentName, runID)
+	if err != nil {
+		return RunRecord{}, err
+	}
+	summary := summarizeRunEvents(runID, events)
+	if summary.Agent == "" {
+		summary.Agent = agentName
+	}
+	return RunRecord{
+		SchemaVersion: RunRecordSchemaVersion,
+		Summary:       summary,
+		Events:        events,
+	}, nil
 }

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -729,6 +729,10 @@ func runErrorStatus(kind string) string {
 }
 
 func LoadRunEvents(s store.Store, agentName, runID string) ([]RunEvent, error) {
+	return loadRunEvents(s, agentName, runID, false)
+}
+
+func loadRunEvents(s store.Store, agentName, runID string, strict bool) ([]RunEvent, error) {
 	st := store.Scope(s, "agent", agentName)
 	keys, err := st.List(store.ListPrefix("runs/" + runID + "/"))
 	if err != nil {
@@ -738,13 +742,26 @@ func LoadRunEvents(s store.Store, agentName, runID string) ([]RunEvent, error) {
 	events := make([]RunEvent, 0, len(keys))
 	for _, k := range keys {
 		recs, err := st.Read(k)
-		if err != nil || len(recs) == 0 {
+		if err != nil {
+			if strict {
+				return nil, fmt.Errorf("read agent run event %q: %w", k, err)
+			}
+			continue
+		}
+		if len(recs) == 0 {
+			if strict {
+				return nil, fmt.Errorf("read agent run event %q: no record returned", k)
+			}
 			continue
 		}
 		var e RunEvent
-		if json.Unmarshal(recs[0].Value, &e) == nil {
-			events = append(events, e)
+		if err := json.Unmarshal(recs[0].Value, &e); err != nil {
+			if strict {
+				return nil, fmt.Errorf("decode agent run event %q: %w", k, err)
+			}
+			continue
 		}
+		events = append(events, e)
 	}
 	return events, nil
 }
@@ -752,7 +769,7 @@ func LoadRunEvents(s store.Store, agentName, runID string) ([]RunEvent, error) {
 // LoadRunRecord loads the versioned record for one agent run. A run with no
 // recorded events returns an empty record carrying the requested identity.
 func LoadRunRecord(s store.Store, agentName, runID string) (RunRecord, error) {
-	events, err := LoadRunEvents(s, agentName, runID)
+	events, err := loadRunEvents(s, agentName, runID, true)
 	if err != nil {
 		return RunRecord{}, err
 	}

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -782,6 +782,66 @@ func TestListRunSummaries(t *testing.T) {
 	}
 }
 
+func TestLoadRunRecordReturnsVersionedTimelineAndDerivedSummary(t *testing.T) {
+	st := store.NewMemoryStore()
+	scoped := store.Scope(st, "agent", "runner")
+	start := time.Unix(100, 0).UTC()
+	events := []RunEvent{
+		{Time: start, RunID: "run-record", Agent: "runner", TraceID: "trace-1", Kind: "run", InputChars: 12},
+		{Time: start.Add(time.Second), RunID: "run-record", Agent: "runner", Kind: "checkpoint", Name: "approval", Status: "paused"},
+		{Time: start.Add(2 * time.Second), RunID: "run-record", Agent: "runner", Kind: "error", Error: "deadline exceeded", ErrorKind: string(ai.ErrorKindTimeout), Spent: 9},
+	}
+	for _, event := range events {
+		value, err := json.Marshal(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		key := "runs/" + event.RunID + "/" + event.Time.Format("20060102150405.000000000") + "-" + event.Kind
+		if err := scoped.Write(&store.Record{Key: key, Value: value}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	record, err := LoadRunRecord(st, "runner", "run-record")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.SchemaVersion != RunRecordSchemaVersion {
+		t.Fatalf("schema version = %d, want %d", record.SchemaVersion, RunRecordSchemaVersion)
+	}
+	if len(record.Events) != 3 || record.Events[0].Kind != "run" || record.Events[2].Kind != "error" {
+		t.Fatalf("unexpected ordered events: %#v", record.Events)
+	}
+	summary := record.Summary
+	if summary.RunID != "run-record" || summary.Agent != "runner" || summary.Status != "timeout" || summary.Events != 3 || summary.DurationMS != 2000 || summary.Checkpoint != "paused" || summary.Stage != "approval" || summary.LastErrorKind != string(ai.ErrorKindTimeout) || summary.Spent != 9 {
+		t.Fatalf("unexpected derived summary: %#v", summary)
+	}
+
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var shape map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &shape); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"schema_version", "summary", "events"} {
+		if _, ok := shape[field]; !ok {
+			t.Fatalf("serialized record missing %q: %s", field, encoded)
+		}
+	}
+}
+
+func TestLoadRunRecordMissingRunPreservesRequestedIdentity(t *testing.T) {
+	record, err := LoadRunRecord(store.NewMemoryStore(), "runner", "missing-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.SchemaVersion != RunRecordSchemaVersion || record.Summary.Agent != "runner" || record.Summary.RunID != "missing-run" || len(record.Events) != 0 {
+		t.Fatalf("unexpected empty record: %#v", record)
+	}
+}
+
 func TestRunStatusClassifiesOperationalErrorKinds(t *testing.T) {
 	tests := []struct {
 		name string

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -842,6 +842,44 @@ func TestLoadRunRecordMissingRunPreservesRequestedIdentity(t *testing.T) {
 	}
 }
 
+func TestLoadRunRecordRejectsCorruptTimeline(t *testing.T) {
+	st := store.NewMemoryStore()
+	scoped := store.Scope(st, "agent", "runner")
+	if err := scoped.Write(&store.Record{Key: "runs/run-corrupt/00000000000000000001-run", Value: []byte("not-json")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadRunRecord(st, "runner", "run-corrupt"); err == nil || !strings.Contains(err.Error(), "decode agent run event") {
+		t.Fatalf("LoadRunRecord() error = %v, want corrupt-event error", err)
+	}
+}
+
+type runReadErrorStore struct {
+	store.Store
+}
+
+func (s runReadErrorStore) Read(key string, opts ...store.ReadOption) ([]*store.Record, error) {
+	if strings.Contains(key, "run-unreadable") {
+		return nil, errors.New("read failed")
+	}
+	return s.Store.Read(key, opts...)
+}
+
+func TestLoadRunRecordPropagatesEventReadFailure(t *testing.T) {
+	base := store.NewMemoryStore()
+	scoped := store.Scope(base, "agent", "runner")
+	event := RunEvent{Time: time.Unix(0, 1), RunID: "run-unreadable", Agent: "runner", Kind: "run"}
+	value, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := scoped.Write(&store.Record{Key: "runs/run-unreadable/00000000000000000001-run", Value: value}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadRunRecord(runReadErrorStore{Store: base}, "runner", "run-unreadable"); err == nil || !strings.Contains(err.Error(), "read agent run event") {
+		t.Fatalf("LoadRunRecord() error = %v, want read failure", err)
+	}
+}
+
 func TestRunStatusClassifiesOperationalErrorKinds(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ai/anthropic/anthropic.go
+++ b/ai/anthropic/anthropic.go
@@ -94,8 +94,8 @@ func cacheableSystem(system string, tools []map[string]any, noCache bool) any {
 
 // cacheableTools returns the tools with a cache breakpoint on the last one,
 // but only when the system prompt cannot carry it: a request with an empty
-// system prompt and a large, stable tool catalogue is still worth caching,
-// and without this the whole catalogue would be re-sent and re-billed on
+// system prompt and a large, stable tool catalog is still worth caching,
+// and without this the whole catalog would be re-sent and re-billed on
 // every call. When a system prompt is present, cacheableSystem's single
 // breakpoint already covers the tools, and marking them again would spend a
 // second of the four breakpoints a request gets for nothing.
@@ -117,7 +117,7 @@ func cacheableTools(tools []map[string]any, system string, noCache bool) []map[s
 }
 
 // cachePrefixSize estimates the byte size of the cacheable prefix. The tools
-// are marshalled once as a slice — the real request marshals them again in
+// are marshaled once as a slice — the real request marshals them again in
 // callAPI, so this stays an estimate, not a second serialization per tool.
 func cachePrefixSize(system string, tools []map[string]any) int {
 	size := len(system)
@@ -130,7 +130,7 @@ func cachePrefixSize(system string, tools []map[string]any) int {
 }
 
 // minCacheBytes is the smallest prefix worth asking the API to cache, in
-// bytes (len of the UTF-8 text and marshalled tools, not characters): the
+// bytes (len of the UTF-8 text and marshaled tools, not characters): the
 // API's minimum cacheable prefix is 1024 tokens, at roughly four bytes each.
 const minCacheBytes = 4096
 

--- a/ai/anthropic/cache_test.go
+++ b/ai/anthropic/cache_test.go
@@ -10,7 +10,7 @@ import (
 //
 // An agent's request is mostly the same request every time: the tools and the
 // system prompt do not change between turns, or between the rounds of one tool
-// loop. Uncached that is the whole catalogue re-sent and re-billed on every
+// loop. Uncached that is the whole catalog re-sent and re-billed on every
 // call — for a caller with a hundred tools, tens of thousands of tokens a turn.
 func TestABigPrefixIsMarkedForCaching(t *testing.T) {
 	tools := []map[string]any{}
@@ -56,7 +56,7 @@ func TestTheToolsAreNotMarkedSeparately(t *testing.T) {
 }
 
 // Below the smallest cacheable prefix it stays a plain string. Asking the API
-// to cache less than it will cache is an error, and the thing being optimised
+// to cache less than it will cache is an error, and the thing being optimized
 // is not present anyway.
 func TestASmallRequestIsLeftAlone(t *testing.T) {
 	for _, tc := range []struct {

--- a/ai/anthropic/cache_test.go
+++ b/ai/anthropic/cache_test.go
@@ -89,8 +89,8 @@ func TestToolsCountTowardsTheThreshold(t *testing.T) {
 	}
 }
 
-// With no system prompt to carry the breakpoint, a large tool catalogue gets
-// it on the last tool instead — otherwise the whole catalogue is re-sent and
+// With no system prompt to carry the breakpoint, a large tool catalog gets
+// it on the last tool instead — otherwise the whole catalog is re-sent and
 // re-billed on every call of a system-prompt-less caller. The original slice
 // and its maps are left untouched.
 func TestAToolOnlyPrefixIsCachedOnTheLastTool(t *testing.T) {

--- a/ai/tools.go
+++ b/ai/tools.go
@@ -132,7 +132,7 @@ func (t *Tools) Discover() ([]Tool, error) {
 	// Deterministic order. The registry iterates a map, so without this the
 	// tool list is shuffled on every discovery — which silently defeats
 	// provider prompt caching (Anthropic cache_control, Gemini implicit
-	// caching): both key on a byte-identical prefix, and the tool catalogue
+	// caching): both key on a byte-identical prefix, and the tool catalog
 	// is the bulk of that prefix.
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Name != out[j].Name {

--- a/ai/tools_test.go
+++ b/ai/tools_test.go
@@ -120,7 +120,7 @@ func TestWithTools(t *testing.T) {
 // an explicit sort the tool list is shuffled on every call — which silently
 // defeats provider prompt caching: Anthropic cache_control and Gemini
 // implicit caching both key on a byte-identical prefix, and the tool
-// catalogue is the bulk of that prefix.
+// catalog is the bulk of that prefix.
 func TestDiscoverOrderIsDeterministic(t *testing.T) {
 	reg := registry.NewMemoryRegistry()
 	for _, name := range []string{"zulu", "alpha", "mike", "bravo", "yankee"} {
@@ -138,7 +138,7 @@ func TestDiscoverOrderIsDeterministic(t *testing.T) {
 
 	// Two versions of one service, with different endpoint sets: discovery
 	// must not duplicate its tools, and must pick the same version — the
-	// highest — every time, or the serialized catalogue still churns.
+	// highest — every time, or the serialized catalog still churns.
 	for _, v := range []struct{ version, endpoint string }{
 		{"1.0.0", "Svc.Old"},
 		{"2.0.0", "Svc.New"},

--- a/cmd/micro/inspect/inspect.go
+++ b/cmd/micro/inspect/inspect.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/urfave/cli/v2"
 	goagent "go-micro.dev/v6/agent"
@@ -42,7 +43,8 @@ It reads durable local run history, so it works after the agent or flow has stop
 
 func inspectAgentFlags() []cli.Flag {
 	return []cli.Flag{
-		&cli.BoolFlag{Name: "json", Usage: "Print run summaries as JSON for automation"},
+		&cli.BoolFlag{Name: "json", Usage: "Print run data as JSON for automation"},
+		&cli.StringFlag{Name: "run", Usage: "Show the complete versioned record for this run id"},
 		&cli.StringFlag{Name: "status", Usage: "Only show runs with this status (running, done, canceled, timeout, rate_limited, auth, configuration, unavailable, provider_error, error, refused)"},
 		&cli.StringFlag{Name: "trace", Usage: "Only show runs whose trace id matches this full id or prefix"},
 		&cli.IntFlag{Name: "limit", Usage: "Show the most recently updated N runs"},
@@ -64,12 +66,99 @@ func inspectAgent(c *cli.Context) error {
 	if name == "" {
 		return fmt.Errorf("agent name required: micro inspect agent <name>")
 	}
+	if runID := c.String("run"); runID != "" {
+		record, err := goagent.LoadRunRecord(store.DefaultStore, name, runID)
+		if err != nil {
+			return err
+		}
+		return writeAgentRunRecord(os.Stdout, record, c.Bool("json"))
+	}
 	opts := goagent.RunListOptions{Status: c.String("status"), TraceID: c.String("trace"), Limit: c.Int("limit")}
 	runs, err := goagent.ListRunSummariesWithOptions(store.DefaultStore, name, opts)
 	if err != nil {
 		return err
 	}
 	return writeAgentInspection(os.Stdout, name, runs, c.Bool("json"))
+}
+
+func writeAgentRunRecord(w io.Writer, record goagent.RunRecord, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(record)
+	}
+	if len(record.Events) == 0 {
+		fmt.Fprintf(w, "  No recorded events for agent %q run %q.\n", record.Summary.Agent, record.Summary.RunID)
+		return nil
+	}
+	summary := record.Summary
+	fmt.Fprintf(w, "  Agent %q run %q  schema=%d\n", summary.Agent, summary.RunID, record.SchemaVersion)
+	fmt.Fprintf(w, "  status=%s  events=%d  started=%s  updated=%s  duration_ms=%d",
+		summary.Status, summary.Events, summary.StartedAt.Format(time.RFC3339Nano), summary.UpdatedAt.Format(time.RFC3339Nano), summary.DurationMS)
+	if summary.ParentID != "" {
+		fmt.Fprintf(w, "  parent=%s", summary.ParentID)
+	}
+	if summary.TraceID != "" {
+		fmt.Fprintf(w, "  trace=%s", summary.TraceID)
+	}
+	if summary.SpanID != "" {
+		fmt.Fprintf(w, "  span=%s", summary.SpanID)
+	}
+	if summary.Checkpoint != "" {
+		fmt.Fprintf(w, "  checkpoint=%s", summary.Checkpoint)
+	}
+	if summary.Stage != "" {
+		fmt.Fprintf(w, "  stage=%s", summary.Stage)
+	}
+	if summary.LastErrorKind != "" {
+		fmt.Fprintf(w, "  error_kind=%s", summary.LastErrorKind)
+	}
+	if summary.Spent > 0 {
+		fmt.Fprintf(w, "  spent=%d", summary.Spent)
+	}
+	if summary.LastError != "" {
+		fmt.Fprintf(w, "  error=%q", summary.LastError)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  Timeline")
+	for _, event := range record.Events {
+		fmt.Fprintf(w, "  %s  kind=%s", event.Time.Format(time.RFC3339Nano), event.Kind)
+		if event.Name != "" {
+			fmt.Fprintf(w, "  name=%q", event.Name)
+		}
+		if event.Provider != "" || event.Model != "" {
+			fmt.Fprintf(w, "  provider=%s  model=%s", event.Provider, event.Model)
+		}
+		if event.Attempt > 0 || event.MaxAttempts > 0 {
+			fmt.Fprintf(w, "  attempt=%d/%d", event.Attempt, event.MaxAttempts)
+		}
+		if event.LatencyMS > 0 {
+			fmt.Fprintf(w, "  latency_ms=%d", event.LatencyMS)
+		}
+		if event.Tokens.TotalTokens > 0 {
+			fmt.Fprintf(w, "  tokens=%d/%d/%d", event.Tokens.InputTokens, event.Tokens.OutputTokens, event.Tokens.TotalTokens)
+		}
+		if event.Refused != "" {
+			fmt.Fprintf(w, "  refused=%q", event.Refused)
+		}
+		if event.Status != "" {
+			fmt.Fprintf(w, "  status=%s", event.Status)
+		}
+		if event.ErrorKind != "" {
+			fmt.Fprintf(w, "  error_kind=%s", event.ErrorKind)
+		}
+		if event.Error != "" {
+			fmt.Fprintf(w, "  error=%q", event.Error)
+		}
+		if event.InputChars > 0 {
+			fmt.Fprintf(w, "  input_chars=%d", event.InputChars)
+		}
+		if event.Spent > 0 || event.ToolSpend > 0 {
+			fmt.Fprintf(w, "  spent=%d  tool_spend=%d", event.Spent, event.ToolSpend)
+		}
+		fmt.Fprintln(w)
+	}
+	return nil
 }
 
 func writeAgentInspection(w io.Writer, name string, runs []goagent.RunSummary, asJSON bool) error {

--- a/cmd/micro/inspect/inspect_test.go
+++ b/cmd/micro/inspect/inspect_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	goagent "go-micro.dev/v6/agent"
 	aiflow "go-micro.dev/v6/flow"
@@ -48,6 +49,51 @@ func TestWriteAgentInspectionEmptyStateNamesInspectCommand(t *testing.T) {
 	}
 	if got := out.String(); !strings.Contains(got, "micro inspect agent support") {
 		t.Fatalf("empty state missing next step: %q", got)
+	}
+}
+
+func TestWriteAgentRunRecordIncludesSummaryAndTimeline(t *testing.T) {
+	start := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	record := goagent.RunRecord{
+		SchemaVersion: goagent.RunRecordSchemaVersion,
+		Summary: goagent.RunSummary{
+			RunID: "run-1", Agent: "support", Status: "timeout", Events: 2,
+			StartedAt: start, UpdatedAt: start.Add(2 * time.Second), DurationMS: 2000,
+			TraceID: "trace-1", LastError: "deadline exceeded", LastErrorKind: "timeout",
+		},
+		Events: []goagent.RunEvent{
+			{Time: start, RunID: "run-1", Agent: "support", Kind: "run", InputChars: 18},
+			{Time: start.Add(2 * time.Second), RunID: "run-1", Agent: "support", Kind: "error", Error: "deadline exceeded", ErrorKind: "timeout"},
+		},
+	}
+	var out bytes.Buffer
+	if err := writeAgentRunRecord(&out, record, false); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{`Agent "support" run "run-1"`, "schema=1", "status=timeout", "events=2", "duration_ms=2000", "trace=trace-1", "Timeline", "kind=run", "input_chars=18", "kind=error", "error_kind=timeout", `error="deadline exceeded"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteAgentRunRecordJSONPreservesSchema(t *testing.T) {
+	record := goagent.RunRecord{
+		SchemaVersion: goagent.RunRecordSchemaVersion,
+		Summary:       goagent.RunSummary{RunID: "run-1", Agent: "support"},
+		Events:        []goagent.RunEvent{},
+	}
+	var out bytes.Buffer
+	if err := writeAgentRunRecord(&out, record, true); err != nil {
+		t.Fatal(err)
+	}
+	var got goagent.RunRecord
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if got.SchemaVersion != goagent.RunRecordSchemaVersion || got.Summary.RunID != "run-1" || got.Events == nil {
+		t.Fatalf("decoded record = %#v", got)
 	}
 }
 

--- a/internal/website/content/en/docs/_index.md
+++ b/internal/website/content/en/docs/_index.md
@@ -58,6 +58,7 @@ Otherwise continue to read the docs for more information about the framework.
 - [0→hero Reference](guides/zero-to-hero.md) - Walk scaffold → run → chat → `micro inspect agent <name>` → deploy dry-run with CI-backed commands
 - [No-secret first-agent transcript](guides/no-secret-first-agent.md) - Run the first useful agent path without a provider key
 - [Your First Agent](guides/your-first-agent.md) - Build a service-backed agent and talk to it with `micro chat`
+- [Agent run records](guides/agent-run-records.md) - Inspect and safely export the versioned execution record for one run
 - [Building AI-Native Services](guides/ai-native-services.md) - End-to-end tutorial for MCP-enabled services
 - [MCP Security Guide](guides/mcp-security.md) - Auth, scopes, rate limiting, and audit logging
 - [Tool Description Best Practices](guides/tool-descriptions.md) - Writing docs that make agents effective

--- a/internal/website/content/en/docs/guides/agent-run-records.md
+++ b/internal/website/content/en/docs/guides/agent-run-records.md
@@ -1,0 +1,94 @@
+---
+title: Agent run records
+description: "Understand, inspect, and safely export the versioned execution record for a Go Micro agent run."
+---
+
+An agent run record is the durable operational history of one execution. It gives
+operators and automation one stable object for answering: what ran, how it was
+correlated, which model and tools were involved, where it checkpointed, and how
+it finished.
+
+List runs to find an id, then inspect the complete record:
+
+```sh
+micro inspect agent support
+micro inspect agent support --run <run-id>
+micro inspect agent support --run <run-id> --json
+```
+
+The human view prints a derived summary followed by the ordered event timeline.
+The JSON view emits the public `agent.RunRecord` contract:
+
+```json
+{
+  "schema_version": 1,
+  "summary": {
+    "run_id": "01J...",
+    "agent": "support",
+    "status": "done",
+    "events": 4
+  },
+  "events": [
+    {"time": "2026-09-06T12:00:00Z", "run_id": "01J...", "agent": "support", "kind": "run"},
+    {"time": "2026-09-06T12:00:01Z", "run_id": "01J...", "agent": "support", "kind": "done"}
+  ]
+}
+```
+
+Use `schema_version` before decoding records across Go Micro releases. The
+summary is derived from the events and can be rebuilt; the ordered event list is
+the source of truth.
+
+## Lifecycle
+
+A normal run begins with `run`, contains zero or more model, stream, tool,
+checkpoint, and resume events, and ends with `done` or `error`. A process can
+stop before a terminal event, so the derived status remains `running` until a
+later resume or terminal event is recorded. A refusal can set the status to
+`refused`; classified errors produce statuses such as `timeout`, `rate_limited`,
+`auth`, `configuration`, `unavailable`, or `provider_error`.
+
+Events are persisted under the agent's scoped state at
+`agent/<name>/runs/<run-id>/...` and are ordered oldest first when loaded. The
+record remains available after the process stops as long as the replacement
+process uses the same agent name and state store.
+
+## Fields
+
+The summary contains run and parent ids, agent identity, trace/span correlation,
+start and update times, duration, event count, derived status, latest checkpoint
+and stage, latest event and error, and cumulative spend.
+
+Each event contains its timestamp, run lineage, trace/span correlation, agent,
+kind, and the metadata relevant to that kind. Model events can include provider,
+model, attempt, latency, and token usage. Tool events can include tool name,
+attempt, refusal, errors, and spend. Checkpoint events use `name` for the stage
+and `status` for checkpoint state.
+
+Go callers can load the same contract directly:
+
+```go
+record, err := agent.LoadRunRecord(stateStore, "support", runID)
+```
+
+## Privacy and redaction
+
+Run records are metadata-first by default. Raw model replies, tool arguments,
+and tool results are not part of the persisted timeline. Raw prompt input is not
+stored unless `agent.TraceInputs(true)` is explicitly enabled; with that option,
+the initial event's `name` field contains the prompt.
+
+Treat records as potentially sensitive before exporting them:
+
+- Error and refusal strings originate at provider or application boundaries and
+  can contain user data or secrets. Redact them at those boundaries.
+- Memory and checkpoints are stored separately and may contain full conversation
+  or application state. A run record does not sanitize those stores.
+- Run, parent, trace, and span ids reveal execution relationships even when
+  payloads are absent.
+- `agent.OnRunEvent(...)` receives events before persistence. Apply the same
+  access controls and retention policy to any external sink.
+
+Keep `TraceInputs` disabled unless the state store and every observability sink
+are approved for prompt data. Prefer recording stable identifiers and counts
+over copying payloads into event names or error strings.

--- a/internal/website/content/en/docs/guides/agent-run-records.md
+++ b/internal/website/content/en/docs/guides/agent-run-records.md
@@ -37,7 +37,9 @@ The JSON view emits the public `agent.RunRecord` contract:
 
 Use `schema_version` before decoding records across Go Micro releases. The
 summary is derived from the events and can be rebuilt; the ordered event list is
-the source of truth.
+the source of truth. Loading a complete record fails if a listed event cannot be
+read or decoded, so callers never receive a silently truncated record. The older
+`agent.LoadRunEvents` API retains its tolerant best-effort behavior.
 
 ## Lifecycle
 

--- a/internal/website/content/en/docs/guides/debugging-agents.md
+++ b/internal/website/content/en/docs/guides/debugging-agents.md
@@ -116,7 +116,9 @@ micro inspect agent support --limit 1
 Run timelines are stored in the agent's state store under that agent's scoped
 state (`agent/<name>/runs/...`). The persisted timeline is recorded even without
 an OpenTelemetry exporter, so `micro inspect agent` remains useful in local
-no-secret development.
+no-secret development. Use `micro inspect agent support --run <run-id>` for the
+complete timeline, or read [Agent run records](agent-run-records.md) for the
+versioned JSON contract, lifecycle, and privacy guidance.
 
 Provider-free quickcheck: if you want to verify the documented inspect path
 before involving a live model, run the same smoke check CI uses:


### PR DESCRIPTION
## Summary

- add a public, versioned `agent.RunRecord` contract that combines the derived run summary with its ordered event timeline
- expose a complete record through `micro inspect agent <name> --run <run-id>` in human-readable and JSON forms
- fail complete-record loads on unreadable or corrupt events while preserving the legacy best-effort event loader
- document the record lifecycle, field semantics, storage behavior, and privacy/redaction boundaries
- add serialization, summary derivation, failure-mode, missing-run, and CLI rendering tests
- correct pre-existing comment misspellings surfaced by the repository-wide lint gate

## Verification

- `git diff --check`
- GitHub Actions: unit/integration tests, lint, harness, site build, and vulnerability scan
- Local Go tests were not run because the workspace does not include a Go toolchain; repository CI is the compile/test gate for this PR.

Closes #4848