### PR TITLE
flow: persist agent and service run lineage

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -272,11 +272,15 @@ func (a *agentImpl) Stream(ctx context.Context, message string) (ai.Stream, erro
 		return nil, fmt.Errorf("discover tools: %w", err)
 	}
 	runID := uuid.New().String()
-	ctx = ai.WithRunInfo(ctx, ai.RunInfo{
-		RunID:    runID,
-		ParentID: a.parentRunID,
-		Agent:    a.opts.Name,
-	})
+	info, _ := ai.RunInfoFrom(ctx)
+	parentRunID := a.parentRunID
+	if parentRunID == "" {
+		parentRunID = info.RunID
+	}
+	info.RunID = runID
+	info.ParentID = parentRunID
+	info.Agent = a.opts.Name
+	ctx = ai.WithRunInfo(ctx, info)
 	// Messages carries the history; Prompt carries the turn being answered.
 	// Providers build their payload as Messages followed by Prompt, so
 	// appending the current message here would send it to the model twice.
@@ -391,13 +395,18 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 	a.calls = map[string]int{}
 	a.pause = nil
 
-	// Correlate this run's tool calls and surface lineage to wrappers.
+	// Correlate this run's tool calls and surface lineage to wrappers. Keep
+	// the flow origin recovered from RPC metadata while assigning this agent
+	// execution its own child run identity.
 	a.runID = runID
-	ctx = ai.WithRunInfo(ctx, ai.RunInfo{
-		RunID:    a.runID,
-		ParentID: parentRunID,
-		Agent:    a.opts.Name,
-	})
+	info, _ := ai.RunInfoFrom(ctx)
+	if parentRunID == "" {
+		parentRunID = info.RunID
+	}
+	info.RunID = a.runID
+	info.ParentID = parentRunID
+	info.Agent = a.opts.Name
+	ctx = ai.WithRunInfo(ctx, info)
 	run := a.newCheckpointRun(runID, message, parentRunID, existing)
 	a.currentRun = &run
 	defer func() { a.currentRun = nil }()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -400,6 +400,20 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 	// execution its own child run identity.
 	a.runID = runID
 	info, _ := ai.RunInfoFrom(ctx)
+	if existing != nil {
+		if info.Flow == "" {
+			info.Flow = existing.OriginFlow
+		}
+		if info.Step == "" {
+			info.Step = existing.OriginStep
+		}
+		if info.Dispatch == "" {
+			info.Dispatch = existing.Dispatch
+		}
+		if info.Trigger == "" {
+			info.Trigger = existing.Trigger
+		}
+	}
 	if parentRunID == "" {
 		parentRunID = info.RunID
 	}
@@ -407,7 +421,7 @@ func (a *agentImpl) askLocked(ctx context.Context, runID, message, parentRunID s
 	info.ParentID = parentRunID
 	info.Agent = a.opts.Name
 	ctx = ai.WithRunInfo(ctx, info)
-	run := a.newCheckpointRun(runID, message, parentRunID, existing)
+	run := a.newCheckpointRun(runID, message, parentRunID, info, existing)
 	a.currentRun = &run
 	defer func() { a.currentRun = nil }()
 	if err := a.saveRun(ctx, run); err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -6,6 +6,7 @@ import (
 
 	pb "go-micro.dev/v6/agent/proto"
 	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/flow"
 	"go-micro.dev/v6/metadata"
 	"go-micro.dev/v6/store"
 )
@@ -145,6 +146,39 @@ func TestChatPreservesTransportedFlowLineageThroughToolExecution(t *testing.T) {
 	if summary.ParentID != origin.RunID || summary.Flow != origin.Flow || summary.Step != origin.Step ||
 		summary.Dispatch != origin.Dispatch || summary.Trigger != origin.Trigger {
 		t.Fatalf("persisted summary = %#v, want flow origin", summary)
+	}
+	for _, event := range record.Events {
+		if event.Flow != origin.Flow || event.Step != origin.Step || event.Dispatch != origin.Dispatch || event.Trigger != origin.Trigger {
+			t.Fatalf("event %q lineage = %#v, want flow origin on every event", event.Kind, event)
+		}
+	}
+}
+
+func TestResumeRestoresPersistedFlowLineage(t *testing.T) {
+	cp := flow.StoreCheckpoint(store.NewMemoryStore(), "ops-agent")
+	run := flow.Run{
+		ID: "agent-run-resume", ParentID: "flow-run-resume", Flow: "ops-agent",
+		OriginFlow: "daily-ops", OriginStep: "summarize", Dispatch: "schedule", Trigger: "daily-review",
+		State: flow.State{Stage: "ask", Data: []byte("resume review")},
+		Steps: []flow.StepRecord{{Name: "ask", Status: "failed"}}, Status: "failed",
+	}
+	if err := cp.Save(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	var got ai.RunInfo
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		got, _ = ai.RunInfoFrom(ctx)
+		return &ai.Response{Reply: "resumed"}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	a := newTestAgent(Name("ops-agent"), WithCheckpoint(cp))
+	if _, err := Resume(context.Background(), a, run.ID); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if got.RunID != run.ID || got.ParentID != run.ParentID || got.Flow != run.OriginFlow || got.Step != run.OriginStep ||
+		got.Dispatch != run.Dispatch || got.Trigger != run.Trigger {
+		t.Fatalf("resumed RunInfo = %#v, want persisted flow lineage", got)
 	}
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -6,6 +6,8 @@ import (
 
 	pb "go-micro.dev/v6/agent/proto"
 	"go-micro.dev/v6/ai"
+	"go-micro.dev/v6/metadata"
+	"go-micro.dev/v6/store"
 )
 
 func TestNew(t *testing.T) {
@@ -90,6 +92,59 @@ func TestChatRequestParentIDPropagatesToResponse(t *testing.T) {
 	}
 	if rsp.ParentId != "flow-run-123" {
 		t.Errorf("ParentId = %q, want flow-run-123", rsp.ParentId)
+	}
+}
+
+func TestChatPreservesTransportedFlowLineageThroughToolExecution(t *testing.T) {
+	origin := ai.RunInfo{
+		RunID:    "flow-run-123",
+		Flow:     "daily-ops",
+		Step:     "summarize",
+		Dispatch: "schedule",
+		Trigger:  "daily-review",
+	}
+	transportCtx := ai.WithRunInfo(context.Background(), origin)
+	md, ok := metadata.FromContext(transportCtx)
+	if !ok {
+		t.Fatal("flow lineage was not attached to metadata")
+	}
+	serverCtx := metadata.NewContext(context.Background(), md)
+
+	var modelInfo, toolInfo ai.RunInfo
+	fakeGen = func(ctx context.Context, opts ai.Options, req *ai.Request) (*ai.Response, error) {
+		modelInfo, _ = ai.RunInfoFrom(ctx)
+		result := opts.ToolHandler(ctx, ai.ToolCall{ID: "call-1", Name: "lookup"})
+		return &ai.Response{Reply: result.Content}, nil
+	}
+	defer func() { fakeGen = nil }()
+
+	st := store.NewMemoryStore()
+	a := newTestAgent(Name("ops-agent"), WithStore(st), WithTool("lookup", "look up service state", nil,
+		func(ctx context.Context, _ map[string]any) (string, error) {
+			toolInfo, _ = ai.RunInfoFrom(ctx)
+			return "ready", nil
+		}))
+	var rsp pb.ChatResponse
+	if err := a.Chat(serverCtx, &pb.ChatRequest{Message: "review", ParentId: origin.RunID}, &rsp); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if rsp.RunId == "" || rsp.RunId == origin.RunID {
+		t.Fatalf("child run id = %q, want a distinct agent run", rsp.RunId)
+	}
+	for label, got := range map[string]ai.RunInfo{"model": modelInfo, "tool": toolInfo} {
+		if got.RunID != rsp.RunId || got.ParentID != origin.RunID || got.Agent != "ops-agent" ||
+			got.Flow != origin.Flow || got.Step != origin.Step || got.Dispatch != origin.Dispatch || got.Trigger != origin.Trigger {
+			t.Fatalf("%s RunInfo = %#v, want transported flow lineage and child agent identity", label, got)
+		}
+	}
+	record, err := LoadRunRecord(st, "ops-agent", rsp.RunId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	summary := record.Summary
+	if summary.ParentID != origin.RunID || summary.Flow != origin.Flow || summary.Step != origin.Step ||
+		summary.Dispatch != origin.Dispatch || summary.Trigger != origin.Trigger {
+		t.Fatalf("persisted summary = %#v, want flow origin", summary)
 	}
 }
 

--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -18,17 +18,21 @@ const (
 	agentInputStep    = "input-required"
 )
 
-func (a *agentImpl) newCheckpointRun(runID, message, parentRunID string, existing *flow.Run) flow.Run {
+func (a *agentImpl) newCheckpointRun(runID, message, parentRunID string, info ai.RunInfo, existing *flow.Run) flow.Run {
 	now := time.Now()
 	run := flow.Run{
-		ID:       runID,
-		ParentID: parentRunID,
-		Flow:     a.opts.Name,
-		State:    flow.State{Stage: agentAskStep, Data: []byte(message)},
-		Steps:    []flow.StepRecord{{Name: agentAskStep, Status: "in_progress"}},
-		Status:   "running",
-		Started:  now,
-		Updated:  now,
+		ID:         runID,
+		ParentID:   parentRunID,
+		Flow:       a.opts.Name,
+		OriginFlow: info.Flow,
+		OriginStep: info.Step,
+		Dispatch:   info.Dispatch,
+		Trigger:    info.Trigger,
+		State:      flow.State{Stage: agentAskStep, Data: []byte(message)},
+		Steps:      []flow.StepRecord{{Name: agentAskStep, Status: "in_progress"}},
+		Status:     "running",
+		Started:    now,
+		Updated:    now,
 	}
 	if existing != nil {
 		run = *existing

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -218,6 +218,7 @@ func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.
 			usage = resp.Usage
 		}
 		e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "model", Provider: provider, Model: model, Attempt: info.Attempt, MaxAttempts: info.MaxAttempts, LatencyMS: dur, Tokens: usage}
+		applyRunInfoToEvent(&e, info)
 		if err != nil {
 			e.Error = err.Error()
 			e.ErrorKind = string(ai.ClassifyError(err))
@@ -257,6 +258,7 @@ func (m *tracedModel) Generate(ctx context.Context, req *ai.Request, opts ...ai.
 		span.SetStatus(codes.Ok, "")
 	}
 	e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "model", Provider: provider, Model: model, Attempt: info.Attempt, MaxAttempts: info.MaxAttempts, LatencyMS: dur, Tokens: usage}
+	applyRunInfoToEvent(&e, info)
 	if err != nil {
 		e.Error = err.Error()
 		e.ErrorKind = string(ai.ClassifyError(err))
@@ -275,7 +277,9 @@ func (m *tracedModel) Stream(ctx context.Context, req *ai.Request, opts ...ai.Ge
 	if m.a.opts.TraceProvider == nil {
 		stream, err := m.Model.Stream(ctx, req, opts...)
 		if err != nil {
-			m.a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "stream", Provider: provider, Model: model, Attempt: info.Attempt, MaxAttempts: info.MaxAttempts, LatencyMS: time.Since(start).Milliseconds(), Error: err.Error(), ErrorKind: string(ai.ClassifyError(err))})
+			e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "stream", Provider: provider, Model: model, Attempt: info.Attempt, MaxAttempts: info.MaxAttempts, LatencyMS: time.Since(start).Milliseconds(), Error: err.Error(), ErrorKind: string(ai.ClassifyError(err))}
+			applyRunInfoToEvent(&e, info)
+			m.a.recordRunEvent(e)
 			return nil, err
 		}
 		return &tracedStream{Stream: stream, a: m.a, info: info, provider: provider, model: model, start: start}, nil
@@ -296,6 +300,7 @@ func (m *tracedModel) Stream(ctx context.Context, req *ai.Request, opts ...ai.Ge
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "stream", Provider: provider, Model: model, Attempt: info.Attempt, MaxAttempts: info.MaxAttempts, LatencyMS: dur, Error: err.Error(), ErrorKind: string(ai.ClassifyError(err))}
+		applyRunInfoToEvent(&e, info)
 		m.a.recordSpanEvent(span, e)
 		span.End()
 		return nil, err
@@ -343,6 +348,7 @@ func (s *tracedStream) finish(err error) {
 	s.closed = true
 	dur := time.Since(s.start).Milliseconds()
 	e := RunEvent{Time: time.Now(), RunID: s.info.RunID, ParentID: s.info.ParentID, Agent: s.info.Agent, Kind: "stream", Provider: s.provider, Model: s.model, Attempt: s.info.Attempt, MaxAttempts: s.info.MaxAttempts, LatencyMS: dur, Tokens: s.usage}
+	applyRunInfoToEvent(&e, s.info)
 	if err != nil {
 		e.Error = err.Error()
 		e.ErrorKind = string(ai.ClassifyError(err))
@@ -410,7 +416,9 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 			if toolAttempts <= 0 {
 				toolAttempts = 1
 			}
-			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, Attempt: toolAttempts, MaxAttempts: a.opts.ToolMaxAttempts, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr), Spent: a.spend, ToolSpend: a.spend - spentBefore})
+			e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, Attempt: toolAttempts, MaxAttempts: a.opts.ToolMaxAttempts, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr), Spent: a.spend, ToolSpend: a.spend - spentBefore}
+			applyRunInfoToEvent(&e, info)
+			a.recordRunEvent(e)
 			return res
 		}
 
@@ -452,7 +460,9 @@ func (a *agentImpl) traceTool(next ai.ToolHandler) ai.ToolHandler {
 		} else {
 			span.SetStatus(codes.Ok, "")
 		}
-		a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, Attempt: toolAttempts, MaxAttempts: a.opts.ToolMaxAttempts, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr), Spent: a.spend, ToolSpend: toolSpend})
+		e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "tool", Name: call.Name, Attempt: toolAttempts, MaxAttempts: a.opts.ToolMaxAttempts, LatencyMS: dur, Refused: res.Refused, Error: resErr, ErrorKind: classifyToolError(resErr), Spent: a.spend, ToolSpend: toolSpend}
+		applyRunInfoToEvent(&e, info)
+		a.recordSpanEvent(span, e)
 		span.End()
 		return res
 	}

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -62,6 +62,10 @@ type RunEvent struct {
 	Time        time.Time `json:"time"`
 	RunID       string    `json:"run_id"`
 	ParentID    string    `json:"parent_id,omitempty"`
+	Flow        string    `json:"flow,omitempty"`
+	Step        string    `json:"step,omitempty"`
+	Dispatch    string    `json:"dispatch,omitempty"`
+	Trigger     string    `json:"trigger,omitempty"`
 	TraceID     string    `json:"trace_id,omitempty"`
 	SpanID      string    `json:"span_id,omitempty"`
 	Agent       string    `json:"agent"`
@@ -107,6 +111,10 @@ type RunSummary struct {
 	RunID         string    `json:"run_id"`
 	Agent         string    `json:"agent"`
 	ParentID      string    `json:"parent_id,omitempty"`
+	Flow          string    `json:"flow,omitempty"`
+	Step          string    `json:"step,omitempty"`
+	Dispatch      string    `json:"dispatch,omitempty"`
+	Trigger       string    `json:"trigger,omitempty"`
 	TraceID       string    `json:"trace_id,omitempty"`
 	SpanID        string    `json:"span_id,omitempty"`
 	StartedAt     time.Time `json:"started_at"`
@@ -142,6 +150,7 @@ func (a *agentImpl) startRun(ctx context.Context, message string) (context.Conte
 	info, _ := ai.RunInfoFrom(ctx)
 	start := time.Now()
 	runEvent := RunEvent{Time: start, RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "run", InputChars: len(message)}
+	applyRunInfoToEvent(&runEvent, info)
 	if a.opts.TraceInputs {
 		runEvent.Name = message
 	}
@@ -151,10 +160,14 @@ func (a *agentImpl) startRun(ctx context.Context, message string) (context.Conte
 		return ctx, func(err error) {
 			latency := time.Since(start).Milliseconds()
 			if err != nil {
-				a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "error", LatencyMS: latency, Error: err.Error(), ErrorKind: string(ai.ClassifyError(err))})
+				e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "error", LatencyMS: latency, Error: err.Error(), ErrorKind: string(ai.ClassifyError(err))}
+				applyRunInfoToEvent(&e, info)
+				a.recordRunEvent(e)
 				return
 			}
-			a.recordRunEvent(RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "done", LatencyMS: latency})
+			e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "done", LatencyMS: latency}
+			applyRunInfoToEvent(&e, info)
+			a.recordRunEvent(e)
 		}
 	}
 
@@ -172,10 +185,14 @@ func (a *agentImpl) startRun(ctx context.Context, message string) (context.Conte
 			span.SetAttributes(attribute.String(AttrErrorKind, string(ai.ClassifyError(err))))
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "error", LatencyMS: latency, Error: err.Error(), ErrorKind: string(ai.ClassifyError(err))})
+			e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "error", LatencyMS: latency, Error: err.Error(), ErrorKind: string(ai.ClassifyError(err))}
+			applyRunInfoToEvent(&e, info)
+			a.recordSpanEvent(span, e)
 		} else {
 			span.SetStatus(codes.Ok, "")
-			a.recordSpanEvent(span, RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "done", LatencyMS: latency})
+			e := RunEvent{Time: time.Now(), RunID: info.RunID, ParentID: info.ParentID, Agent: info.Agent, Kind: "done", LatencyMS: latency}
+			applyRunInfoToEvent(&e, info)
+			a.recordSpanEvent(span, e)
 		}
 		span.End()
 	}
@@ -467,12 +484,31 @@ func classifyToolError(err string) string {
 }
 
 func (a *agentImpl) recordTimelineEvent(ctx context.Context, e RunEvent) {
+	if info, ok := ai.RunInfoFrom(ctx); ok {
+		applyRunInfoToEvent(&e, info)
+	}
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		a.recordSpanEvent(span, e)
 		return
 	}
 	a.recordRunEvent(e)
+}
+
+func applyRunInfoToEvent(e *RunEvent, info ai.RunInfo) {
+	if e.RunID == "" {
+		e.RunID = info.RunID
+	}
+	if e.ParentID == "" {
+		e.ParentID = info.ParentID
+	}
+	if e.Agent == "" {
+		e.Agent = info.Agent
+	}
+	e.Flow = info.Flow
+	e.Step = info.Step
+	e.Dispatch = info.Dispatch
+	e.Trigger = info.Trigger
 }
 
 func (a *agentImpl) recordSpanEvent(span trace.Span, e RunEvent) {
@@ -492,6 +528,18 @@ func runEventAttributes(e RunEvent) []attribute.KeyValue {
 	}
 	if e.ParentID != "" {
 		attrs = append(attrs, attribute.String(AttrParentRunID, e.ParentID))
+	}
+	if e.Flow != "" {
+		attrs = append(attrs, attribute.String(AttrFlowName, e.Flow))
+	}
+	if e.Step != "" {
+		attrs = append(attrs, attribute.String(AttrFlowStep, e.Step))
+	}
+	if e.Dispatch != "" {
+		attrs = append(attrs, attribute.String(AttrDispatch, e.Dispatch))
+	}
+	if e.Trigger != "" {
+		attrs = append(attrs, attribute.String(AttrTrigger, e.Trigger))
 	}
 	if e.Name != "" {
 		attrs = append(attrs, attribute.String("agent.event.name", e.Name))
@@ -650,6 +698,10 @@ func summarizeRunEvents(runID string, events []RunEvent) RunSummary {
 	last := events[len(events)-1]
 	summary.Agent = first.Agent
 	summary.ParentID = first.ParentID
+	summary.Flow = first.Flow
+	summary.Step = first.Step
+	summary.Dispatch = first.Dispatch
+	summary.Trigger = first.Trigger
 	summary.TraceID = first.TraceID
 	summary.SpanID = first.SpanID
 	summary.StartedAt = first.Time
@@ -664,6 +716,18 @@ func summarizeRunEvents(runID string, events []RunEvent) RunSummary {
 		}
 		if e.ParentID != "" {
 			summary.ParentID = e.ParentID
+		}
+		if e.Flow != "" {
+			summary.Flow = e.Flow
+		}
+		if e.Step != "" {
+			summary.Step = e.Step
+		}
+		if e.Dispatch != "" {
+			summary.Dispatch = e.Dispatch
+		}
+		if e.Trigger != "" {
+			summary.Trigger = e.Trigger
 		}
 		if e.TraceID != "" {
 			summary.TraceID = e.TraceID

--- a/ai/model.go
+++ b/ai/model.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+
+	"go-micro.dev/v6/metadata"
 )
 
 // Model provides an interface for interacting with AI model providers
@@ -143,14 +145,63 @@ type RunInfo struct {
 
 type runInfoKey struct{}
 
-// WithRunInfo attaches run info to ctx.
+const (
+	runHeaderID       = "Micro-Run-Id"
+	runHeaderParentID = "Micro-Run-Parent-Id"
+	runHeaderAgent    = "Micro-Run-Agent"
+	runHeaderFlow     = "Micro-Run-Flow"
+	runHeaderStep     = "Micro-Run-Step"
+	runHeaderDispatch = "Micro-Run-Dispatch"
+	runHeaderTrigger  = "Micro-Run-Trigger"
+)
+
+// WithRunInfo attaches run info to ctx and mirrors execution identity into RPC
+// metadata so services and agents across a transport boundary can recover the
+// same lineage with RunInfoFrom.
 func WithRunInfo(ctx context.Context, r RunInfo) context.Context {
-	return context.WithValue(ctx, runInfoKey{}, r)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = context.WithValue(ctx, runInfoKey{}, r)
+	return metadata.MergeContext(ctx, metadata.Metadata{
+		runHeaderID:       r.RunID,
+		runHeaderParentID: r.ParentID,
+		runHeaderAgent:    r.Agent,
+		runHeaderFlow:     r.Flow,
+		runHeaderStep:     r.Step,
+		runHeaderDispatch: r.Dispatch,
+		runHeaderTrigger:  r.Trigger,
+	}, true)
 }
 
-// RunInfoFrom returns the run info attached to ctx, and whether it was set.
+// RunInfoFrom returns run info attached locally or propagated through Go Micro
+// RPC metadata, and whether either representation was present.
 func RunInfoFrom(ctx context.Context) (RunInfo, bool) {
+	if ctx == nil {
+		return RunInfo{}, false
+	}
 	r, ok := ctx.Value(runInfoKey{}).(RunInfo)
+	if ok {
+		return r, true
+	}
+	fields := []struct {
+		key string
+		set func(string)
+	}{
+		{runHeaderID, func(v string) { r.RunID = v }},
+		{runHeaderParentID, func(v string) { r.ParentID = v }},
+		{runHeaderAgent, func(v string) { r.Agent = v }},
+		{runHeaderFlow, func(v string) { r.Flow = v }},
+		{runHeaderStep, func(v string) { r.Step = v }},
+		{runHeaderDispatch, func(v string) { r.Dispatch = v }},
+		{runHeaderTrigger, func(v string) { r.Trigger = v }},
+	}
+	for _, field := range fields {
+		if value, found := metadata.Get(ctx, field.key); found {
+			field.set(value)
+			ok = true
+		}
+	}
 	return r, ok
 }
 

--- a/ai/model.go
+++ b/ai/model.go
@@ -146,13 +146,13 @@ type RunInfo struct {
 type runInfoKey struct{}
 
 const (
-	runHeaderID       = "Micro-Run-Id"
-	runHeaderParentID = "Micro-Run-Parent-Id"
-	runHeaderAgent    = "Micro-Run-Agent"
-	runHeaderFlow     = "Micro-Run-Flow"
-	runHeaderStep     = "Micro-Run-Step"
-	runHeaderDispatch = "Micro-Run-Dispatch"
-	runHeaderTrigger  = "Micro-Run-Trigger"
+	runHeaderID       = "micro-run-id"
+	runHeaderParentID = "micro-run-parent-id"
+	runHeaderAgent    = "micro-run-agent"
+	runHeaderFlow     = "micro-run-flow"
+	runHeaderStep     = "micro-run-step"
+	runHeaderDispatch = "micro-run-dispatch"
+	runHeaderTrigger  = "micro-run-trigger"
 )
 
 // WithRunInfo attaches run info to ctx and mirrors execution identity into RPC

--- a/ai/run_info_test.go
+++ b/ai/run_info_test.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"go-micro.dev/v6/metadata"
@@ -21,6 +22,11 @@ func TestRunInfoCrossesMetadataBoundary(t *testing.T) {
 	md, ok := metadata.FromContext(origin)
 	if !ok {
 		t.Fatal("WithRunInfo did not attach RPC metadata")
+	}
+	for key := range md {
+		if key != strings.ToLower(key) {
+			t.Fatalf("metadata key %q is not gRPC-normalized", key)
+		}
 	}
 
 	// Rebuild the server-side context from metadata only, as an RPC

--- a/ai/run_info_test.go
+++ b/ai/run_info_test.go
@@ -1,0 +1,48 @@
+package ai
+
+import (
+	"context"
+	"testing"
+
+	"go-micro.dev/v6/metadata"
+)
+
+func TestRunInfoCrossesMetadataBoundary(t *testing.T) {
+	want := RunInfo{
+		RunID:    "flow-run-1",
+		ParentID: "parent-run-1",
+		Agent:    "checkout",
+		Flow:     "checkout",
+		Step:     "authorize",
+		Dispatch: "schedule",
+		Trigger:  "daily-settlement",
+	}
+	origin := WithRunInfo(context.Background(), want)
+	md, ok := metadata.FromContext(origin)
+	if !ok {
+		t.Fatal("WithRunInfo did not attach RPC metadata")
+	}
+
+	// Rebuild the server-side context from metadata only, as an RPC
+	// transport does. The process-local context value is intentionally gone.
+	server := metadata.NewContext(context.Background(), md)
+	got, ok := RunInfoFrom(server)
+	if !ok {
+		t.Fatal("RunInfoFrom did not recover transported metadata")
+	}
+	if got != want {
+		t.Fatalf("RunInfo = %#v, want %#v", got, want)
+	}
+}
+
+func TestRunInfoLocalValueTakesPrecedenceOverMetadata(t *testing.T) {
+	ctx := WithRunInfo(context.Background(), RunInfo{RunID: "local-run", Attempt: 2})
+	ctx = metadata.Set(ctx, runHeaderID, "transport-run")
+	got, ok := RunInfoFrom(ctx)
+	if !ok {
+		t.Fatal("RunInfoFrom returned no run info")
+	}
+	if got.RunID != "local-run" || got.Attempt != 2 {
+		t.Fatalf("RunInfo = %#v, want local value", got)
+	}
+}

--- a/cmd/micro/inspect/inspect.go
+++ b/cmd/micro/inspect/inspect.go
@@ -54,6 +54,7 @@ func inspectAgentFlags() []cli.Flag {
 func inspectFlowFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{Name: "json", Usage: "Print durable run history as JSON for automation"},
+		&cli.StringFlag{Name: "run", Usage: "Show the complete versioned record for this run id"},
 		&cli.BoolFlag{Name: "pending", Usage: "Only show runs that have not completed"},
 		&cli.StringFlag{Name: "status", Usage: "Only show runs with this status (running, done, failed)"},
 		&cli.IntFlag{Name: "limit", Usage: "Show the most recently updated N runs"},
@@ -120,6 +121,22 @@ func writeAgentRunRecord(w io.Writer, record goagent.RunRecord, asJSON bool) err
 		fmt.Fprintf(w, "  error=%q", summary.LastError)
 	}
 	fmt.Fprintln(w)
+	if summary.Flow != "" {
+		fmt.Fprintf(w, "  Origin  flow=%s", summary.Flow)
+		if summary.Step != "" {
+			fmt.Fprintf(w, "  step=%s", summary.Step)
+		}
+		if summary.Dispatch != "" {
+			fmt.Fprintf(w, "  dispatch=%s", summary.Dispatch)
+		}
+		if summary.Trigger != "" {
+			fmt.Fprintf(w, "  trigger=%q", summary.Trigger)
+		}
+		fmt.Fprintln(w)
+		if summary.ParentID != "" {
+			fmt.Fprintf(w, "    parent: micro inspect flow %s --run %s\n", summary.Flow, summary.ParentID)
+		}
+	}
 	fmt.Fprintln(w, "  Timeline")
 	for _, event := range record.Events {
 		fmt.Fprintf(w, "  %s  kind=%s", event.Time.Format(time.RFC3339Nano), event.Kind)
@@ -192,7 +209,16 @@ func writeAgentInspection(w io.Writer, name string, runs []goagent.RunSummary, a
 		if run.TraceID != "" {
 			fmt.Fprintf(w, "  trace=%s", shortID(run.TraceID))
 		}
+		if run.Flow != "" {
+			fmt.Fprintf(w, "  flow=%s", run.Flow)
+		}
+		if run.Step != "" {
+			fmt.Fprintf(w, "  step=%s", run.Step)
+		}
 		fmt.Fprintln(w)
+		if run.Flow != "" && run.ParentID != "" {
+			fmt.Fprintf(w, "    parent:  micro inspect flow %s --run %s\n", run.Flow, run.ParentID)
+		}
 		writeAgentRunBreadcrumbs(w, name, run)
 	}
 	return nil
@@ -226,12 +252,75 @@ func inspectFlow(c *cli.Context) error {
 	if name == "" {
 		return fmt.Errorf("flow name required: micro inspect flow <name>")
 	}
-	runs, err := aiflow.StoreCheckpoint(nil, name).List(context.Background())
+	checkpoint := aiflow.StoreCheckpoint(nil, name)
+	if runID := c.String("run"); runID != "" {
+		record, err := aiflow.LoadRunRecord(context.Background(), checkpoint, name, runID)
+		if err != nil {
+			return err
+		}
+		return writeFlowRunRecord(os.Stdout, record, c.Bool("json"))
+	}
+	runs, err := checkpoint.List(context.Background())
 	if err != nil {
 		return err
 	}
 	runs = filterFlowInspection(runs, c.Bool("pending"), c.String("status"), c.String("stage"), c.Int("limit"))
 	return writeFlowInspection(os.Stdout, name, runs, c.Bool("json"), c.Bool("pending"))
+}
+
+func writeFlowRunRecord(w io.Writer, record aiflow.RunRecord, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(record)
+	}
+	run := record.Run
+	if run.Status == "" {
+		fmt.Fprintf(w, "  No recorded flow %q run %q.\n", run.Flow, run.ID)
+		return nil
+	}
+	fmt.Fprintf(w, "  Flow %q run %q  schema=%d\n", run.Flow, run.ID, record.SchemaVersion)
+	fmt.Fprintf(w, "  status=%s  started=%s  updated=%s", run.Status, run.Started.Format(time.RFC3339Nano), run.Updated.Format(time.RFC3339Nano))
+	if run.ParentID != "" {
+		fmt.Fprintf(w, "  parent=%s", run.ParentID)
+	}
+	if run.Dispatch != "" {
+		fmt.Fprintf(w, "  dispatch=%s", run.Dispatch)
+	}
+	if run.Trigger != "" {
+		fmt.Fprintf(w, "  trigger=%q", run.Trigger)
+	}
+	if run.State.Stage != "" {
+		fmt.Fprintf(w, "  stage=%s", run.State.Stage)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  Steps")
+	for _, step := range run.Steps {
+		fmt.Fprintf(w, "  %s  status=%s  attempts=%d", step.Name, step.Status, step.Attempts)
+		if step.Service != "" {
+			fmt.Fprintf(w, "  service=%s  endpoint=%s", step.Service, step.Endpoint)
+		}
+		if step.Agent != "" {
+			fmt.Fprintf(w, "  agent=%s", step.Agent)
+		}
+		if step.ChildRunID != "" {
+			fmt.Fprintf(w, "  child_run=%s", step.ChildRunID)
+		}
+		if step.VerificationStatus != "" {
+			fmt.Fprintf(w, "  verification=%s", step.VerificationStatus)
+		}
+		if step.ErrorKind != "" {
+			fmt.Fprintf(w, "  error_kind=%s", step.ErrorKind)
+		}
+		if step.Error != "" {
+			fmt.Fprintf(w, "  error=%q", step.Error)
+		}
+		fmt.Fprintln(w)
+		if step.Agent != "" && step.ChildRunID != "" {
+			fmt.Fprintf(w, "    inspect: micro inspect agent %s --run %s\n", step.Agent, step.ChildRunID)
+		}
+	}
+	return nil
 }
 
 func filterFlowInspection(runs []aiflow.Run, pending bool, status, stage string, limit int) []aiflow.Run {
@@ -282,6 +371,11 @@ func writeFlowInspection(w io.Writer, name string, runs []aiflow.Run, asJSON, pe
 			}
 		}
 		fmt.Fprintln(w)
+		for _, step := range run.Steps {
+			if step.Agent != "" && step.ChildRunID != "" {
+				fmt.Fprintf(w, "    child: micro inspect agent %s --run %s\n", step.Agent, step.ChildRunID)
+			}
+		}
 	}
 	return nil
 }

--- a/cmd/micro/inspect/inspect_test.go
+++ b/cmd/micro/inspect/inspect_test.go
@@ -59,7 +59,8 @@ func TestWriteAgentRunRecordIncludesSummaryAndTimeline(t *testing.T) {
 		Summary: goagent.RunSummary{
 			RunID: "run-1", Agent: "support", Status: "timeout", Events: 2,
 			StartedAt: start, UpdatedAt: start.Add(2 * time.Second), DurationMS: 2000,
-			TraceID: "trace-1", LastError: "deadline exceeded", LastErrorKind: "timeout",
+			TraceID: "trace-1", ParentID: "flow-run-1", Flow: "daily-ops", Step: "summarize",
+			Dispatch: "schedule", Trigger: "daily-review", LastError: "deadline exceeded", LastErrorKind: "timeout",
 		},
 		Events: []goagent.RunEvent{
 			{Time: start, RunID: "run-1", Agent: "support", Kind: "run", InputChars: 18},
@@ -71,7 +72,7 @@ func TestWriteAgentRunRecordIncludesSummaryAndTimeline(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := out.String()
-	for _, want := range []string{`Agent "support" run "run-1"`, "schema=1", "status=timeout", "events=2", "duration_ms=2000", "trace=trace-1", "Timeline", "kind=run", "input_chars=18", "kind=error", "error_kind=timeout", `error="deadline exceeded"`} {
+	for _, want := range []string{`Agent "support" run "run-1"`, "schema=1", "status=timeout", "events=2", "duration_ms=2000", "trace=trace-1", "Origin", "flow=daily-ops", "step=summarize", "dispatch=schedule", `trigger="daily-review"`, "micro inspect flow daily-ops --run flow-run-1", "Timeline", "kind=run", "input_chars=18", "kind=error", "error_kind=timeout", `error="deadline exceeded"`} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q:\n%s", want, got)
 		}
@@ -123,5 +124,45 @@ func TestWriteFlowInspectionJSON(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].ID != "run-1" || got[0].Status != "done" {
 		t.Fatalf("decoded runs = %+v", got)
+	}
+}
+
+func TestWriteFlowRunRecordIncludesTargetsAndChildBreadcrumb(t *testing.T) {
+	start := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	record := aiflow.RunRecord{
+		SchemaVersion: aiflow.RunRecordSchemaVersion,
+		Run: aiflow.Run{
+			ID: "flow-run-1", Flow: "checkout", Status: "done", Dispatch: "schedule", Trigger: "nightly",
+			Started: start, Updated: start.Add(time.Second),
+			Steps: []aiflow.StepRecord{
+				{Name: "charge", Status: "done", Attempts: 1, Service: "payments", Endpoint: "Payments.Charge"},
+				{Name: "notify", Status: "done", Attempts: 1, Agent: "comms", ChildRunID: "agent-run-1"},
+			},
+		},
+	}
+	var out bytes.Buffer
+	if err := writeFlowRunRecord(&out, record, false); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{`Flow "checkout" run "flow-run-1"`, "schema=1", "status=done", "dispatch=schedule", `trigger="nightly"`, "Steps", "service=payments", "endpoint=Payments.Charge", "agent=comms", "child_run=agent-run-1", "micro inspect agent comms --run agent-run-1"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteFlowRunRecordJSONPreservesSchema(t *testing.T) {
+	record := aiflow.RunRecord{SchemaVersion: aiflow.RunRecordSchemaVersion, Run: aiflow.Run{ID: "flow-run-1", Flow: "checkout"}}
+	var out bytes.Buffer
+	if err := writeFlowRunRecord(&out, record, true); err != nil {
+		t.Fatal(err)
+	}
+	var got aiflow.RunRecord
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if got.SchemaVersion != aiflow.RunRecordSchemaVersion || got.Run.ID != "flow-run-1" {
+		t.Fatalf("decoded record = %#v", got)
 	}
 }

--- a/flow/dispatch_test.go
+++ b/flow/dispatch_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"go-micro.dev/v6/ai"
 	"go-micro.dev/v6/client"
 	codecbytes "go-micro.dev/v6/codec/bytes"
 	"go-micro.dev/v6/store"
@@ -14,11 +15,11 @@ import (
 // overrides Call with a test-supplied function.
 type fakeClient struct {
 	client.Client
-	callFn func(req client.Request, rsp interface{}) error
+	callFn func(ctx context.Context, req client.Request, rsp interface{}) error
 }
 
 func (c *fakeClient) Call(ctx context.Context, req client.Request, rsp interface{}, opts ...client.CallOption) error {
-	return c.callFn(req, rsp)
+	return c.callFn(ctx, req, rsp)
 }
 
 // A flow with Agent set hands the rendered prompt to that agent's
@@ -30,7 +31,7 @@ func TestExecuteDispatchesToAgent(t *testing.T) {
 	var svc, ep, parentID string
 	f.client = &fakeClient{
 		Client: client.DefaultClient,
-		callFn: func(req client.Request, rsp interface{}) error {
+		callFn: func(_ context.Context, req client.Request, rsp interface{}) error {
 			svc, ep = req.Service(), req.Endpoint()
 			reqFrame := req.Body().(*codecbytes.Frame)
 			var body map[string]string
@@ -79,9 +80,11 @@ func TestScheduledAgentRunHarnessContract(t *testing.T) {
 	)
 
 	var parentID string
+	var dispatched ai.RunInfo
 	f.client = &fakeClient{
 		Client: client.DefaultClient,
-		callFn: func(req client.Request, rsp interface{}) error {
+		callFn: func(ctx context.Context, req client.Request, rsp interface{}) error {
+			dispatched, _ = ai.RunInfoFrom(ctx)
 			if req.Service() != "ops-agent" || req.Endpoint() != "Agent.Chat" {
 				t.Fatalf("dispatched to %s.%s, want ops-agent.Agent.Chat", req.Service(), req.Endpoint())
 			}
@@ -95,7 +98,7 @@ func TestScheduledAgentRunHarnessContract(t *testing.T) {
 				t.Fatalf("message = %q, want scheduled payload", body["message"])
 			}
 			frame := rsp.(*codecbytes.Frame)
-			frame.Data = []byte(`{"reply":"review queued","agent":"ops-agent","parent_id":"` + parentID + `"}`)
+			frame.Data = []byte(`{"reply":"review queued","agent":"ops-agent","run_id":"agent-run-456","parent_id":"` + parentID + `"}`)
 			return nil
 		},
 	}
@@ -121,10 +124,53 @@ func TestScheduledAgentRunHarnessContract(t *testing.T) {
 	if run.Flow != "scheduled-contract" || run.Status != "done" {
 		t.Fatalf("run = %+v, want scheduled-contract done", run)
 	}
+	if run.Dispatch != "schedule" || run.Trigger != "schedule.daily" {
+		t.Fatalf("run origin = dispatch %q trigger %q, want scheduled schedule.daily", run.Dispatch, run.Trigger)
+	}
+	if dispatched.RunID != run.ID || dispatched.Flow != run.Flow || dispatched.Step != "summarize" ||
+		dispatched.Dispatch != run.Dispatch || dispatched.Trigger != run.Trigger {
+		t.Fatalf("dispatch RunInfo = %#v, want flow run lineage", dispatched)
+	}
 	if got := run.State.String(); got != "review queued" {
 		t.Fatalf("run result = %q, want agent reply", got)
 	}
 	if len(run.Steps) != 1 || run.Steps[0].Name != "summarize" || run.Steps[0].Status != "done" {
 		t.Fatalf("steps = %+v, want summarize done", run.Steps)
+	}
+	if run.Steps[0].Agent != "ops-agent" || run.Steps[0].ChildRunID != "agent-run-456" {
+		t.Fatalf("dispatch lineage = %+v, want ops-agent child run", run.Steps[0])
+	}
+}
+
+func TestCallRecordsServiceTargetAndPropagatesLineage(t *testing.T) {
+	ctx := context.Background()
+	cp := StoreCheckpoint(store.NewMemoryStore(), "service-call")
+	f := New("service-call", WithCheckpoint(cp), Steps(Step{Name: "charge", Run: Call("payments", "Payments.Charge")}))
+
+	var called ai.RunInfo
+	f.client = &fakeClient{
+		Client: client.DefaultClient,
+		callFn: func(callCtx context.Context, req client.Request, rsp interface{}) error {
+			called, _ = ai.RunInfoFrom(callCtx)
+			if req.Service() != "payments" || req.Endpoint() != "Payments.Charge" {
+				t.Fatalf("called %s.%s, want payments.Payments.Charge", req.Service(), req.Endpoint())
+			}
+			rsp.(*codecbytes.Frame).Data = []byte(`{"status":"paid"}`)
+			return nil
+		},
+	}
+	if err := f.Execute(ctx, `{"order":"123"}`); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	runs, err := cp.List(ctx)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("runs = %+v, err = %v", runs, err)
+	}
+	run := runs[0]
+	if called.RunID != run.ID || called.Flow != "service-call" || called.Step != "charge" || called.Dispatch != "direct" {
+		t.Fatalf("service RunInfo = %#v, want direct flow step lineage", called)
+	}
+	if len(run.Steps) != 1 || run.Steps[0].Service != "payments" || run.Steps[0].Endpoint != "Payments.Charge" {
+		t.Fatalf("persisted service target = %+v", run.Steps)
 	}
 }

--- a/flow/record.go
+++ b/flow/record.go
@@ -1,0 +1,29 @@
+package flow
+
+import "context"
+
+// RunRecordSchemaVersion is the current JSON schema version for RunRecord.
+const RunRecordSchemaVersion = 1
+
+// RunRecord is the versioned, durable representation of one flow execution.
+// Consumers should use SchemaVersion when decoding records across releases.
+type RunRecord struct {
+	SchemaVersion int `json:"schema_version"`
+	Run           Run `json:"run"`
+}
+
+// LoadRunRecord loads one versioned flow run from checkpoint storage. A
+// missing run returns an empty record carrying the requested flow and run id.
+func LoadRunRecord(ctx context.Context, checkpoint Checkpoint, flowName, runID string) (RunRecord, error) {
+	if checkpoint == nil {
+		checkpoint = StoreCheckpoint(nil, flowName)
+	}
+	run, ok, err := checkpoint.Load(ctx, runID)
+	if err != nil {
+		return RunRecord{}, err
+	}
+	if !ok {
+		run = Run{ID: runID, Flow: flowName}
+	}
+	return RunRecord{SchemaVersion: RunRecordSchemaVersion, Run: run}, nil
+}

--- a/flow/record_test.go
+++ b/flow/record_test.go
@@ -1,0 +1,53 @@
+package flow
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"go-micro.dev/v6/store"
+)
+
+func TestLoadRunRecordReturnsVersionedFlowExecution(t *testing.T) {
+	ctx := context.Background()
+	cp := StoreCheckpoint(store.NewMemoryStore(), "checkout")
+	want := Run{
+		ID: "flow-run-1", Flow: "checkout", Dispatch: "schedule", Trigger: "nightly", Status: "done",
+		Started: time.Unix(100, 0).UTC(),
+		Steps: []StepRecord{{Name: "charge", Status: "done", Attempts: 1, Service: "payments", Endpoint: "Payments.Charge"},
+			{Name: "notify", Status: "done", Attempts: 1, Agent: "comms", ChildRunID: "agent-run-1"}},
+	}
+	if err := cp.Save(ctx, want); err != nil {
+		t.Fatal(err)
+	}
+	record, err := LoadRunRecord(ctx, cp, "checkout", want.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.SchemaVersion != RunRecordSchemaVersion || record.Run.ID != want.ID ||
+		record.Run.Steps[1].ChildRunID != "agent-run-1" {
+		t.Fatalf("record = %#v", record)
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded RunRecord
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.SchemaVersion != RunRecordSchemaVersion || decoded.Run.Steps[0].Service != "payments" {
+		t.Fatalf("decoded record = %#v", decoded)
+	}
+}
+
+func TestLoadRunRecordMissingCarriesRequestedIdentity(t *testing.T) {
+	record, err := LoadRunRecord(context.Background(), StoreCheckpoint(store.NewMemoryStore(), "checkout"), "checkout", "missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.SchemaVersion != RunRecordSchemaVersion || record.Run.Flow != "checkout" || record.Run.ID != "missing" || record.Run.Status != "" {
+		t.Fatalf("missing record = %#v", record)
+	}
+}

--- a/flow/steps.go
+++ b/flow/steps.go
@@ -95,6 +95,10 @@ type StepRecord struct {
 	Name               string `json:"name"`
 	Status             string `json:"status"` // pending | in_progress | done | failed
 	Attempts           int    `json:"attempts"`
+	Service            string `json:"service,omitempty"`
+	Endpoint           string `json:"endpoint,omitempty"`
+	Agent              string `json:"agent,omitempty"`
+	ChildRunID         string `json:"child_run_id,omitempty"`
 	Result             string `json:"result,omitempty"`
 	Error              string `json:"error,omitempty"`
 	ErrorKind          string `json:"error_kind,omitempty"`
@@ -109,6 +113,8 @@ type Run struct {
 	ID       string       `json:"id"`
 	ParentID string       `json:"parent_id,omitempty"`
 	Flow     string       `json:"flow"`
+	Dispatch string       `json:"dispatch,omitempty"`
+	Trigger  string       `json:"trigger,omitempty"`
 	State    State        `json:"state"`
 	Steps    []StepRecord `json:"steps"`
 	Status   string       `json:"status"` // running | waiting | done | failed
@@ -229,6 +235,7 @@ type runDeps struct {
 	client client.Client
 	model  ai.Model
 	tools  *ai.Tools
+	step   *StepRecord
 }
 
 type runCtxKey struct{}
@@ -248,8 +255,14 @@ func depsFrom(ctx context.Context) *runDeps {
 func Call(service, endpoint string) StepFunc {
 	return func(ctx context.Context, in State) (State, error) {
 		cl := client.DefaultClient
-		if d := depsFrom(ctx); d != nil && d.client != nil {
-			cl = d.client
+		if d := depsFrom(ctx); d != nil {
+			if d.client != nil {
+				cl = d.client
+			}
+			if d.step != nil {
+				d.step.Service = service
+				d.step.Endpoint = endpoint
+			}
 		}
 		body := in.Data
 		if len(body) == 0 {
@@ -271,8 +284,14 @@ func Call(service, endpoint string) StepFunc {
 func Dispatch(name string) StepFunc {
 	return func(ctx context.Context, in State) (State, error) {
 		cl := client.DefaultClient
-		if d := depsFrom(ctx); d != nil && d.client != nil {
-			cl = d.client
+		d := depsFrom(ctx)
+		if d != nil {
+			if d.client != nil {
+				cl = d.client
+			}
+			if d.step != nil {
+				d.step.Agent = name
+			}
 		}
 		info, _ := ai.RunInfoFrom(ctx)
 		body, _ := json.Marshal(map[string]string{"message": in.String(), "parent_id": info.RunID})
@@ -283,8 +302,12 @@ func Dispatch(name string) StepFunc {
 		}
 		var out struct {
 			Reply string `json:"reply"`
+			RunID string `json:"run_id"`
 		}
 		_ = json.Unmarshal(rsp.Data, &out)
+		if d != nil && d.step != nil {
+			d.step.ChildRunID = out.RunID
+		}
 		in.Data = []byte(out.Reply)
 		return in, nil
 	}
@@ -391,14 +414,17 @@ func (f *Flow) startRun(ctx context.Context, data string) (Run, error) {
 	if err := validateSteps(f.opts.Steps); err != nil {
 		return Run{}, err
 	}
-	parentID := ""
-	if info, ok := ai.RunInfoFrom(ctx); ok {
-		parentID = info.RunID
+	info, _ := ai.RunInfoFrom(ctx)
+	dispatch := info.Dispatch
+	if dispatch == "" {
+		dispatch = "direct"
 	}
 	run := Run{
 		ID:       uuid.New().String(),
-		ParentID: parentID,
+		ParentID: info.RunID,
 		Flow:     f.name,
+		Dispatch: dispatch,
+		Trigger:  info.Trigger,
 		State:    State{Stage: f.opts.Steps[0].Name, Data: []byte(data)},
 		Status:   "running",
 		Started:  time.Now(),
@@ -548,12 +574,15 @@ func (f *Flow) ResumeWith(ctx context.Context, runID, input string) error {
 // checkpointing before and after each step.
 func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 	steps := f.opts.Steps
-	ctx = withDeps(ctx, &runDeps{client: f.client, model: f.model, tools: f.toolSet})
+	deps := &runDeps{client: f.client, model: f.model, tools: f.toolSet}
+	ctx = withDeps(ctx, deps)
 	info, _ := ai.RunInfoFrom(ctx)
 	info.RunID = run.ID
 	info.ParentID = run.ParentID
 	info.Agent = f.name
 	info.Flow = f.name
+	info.Dispatch = run.Dispatch
+	info.Trigger = run.Trigger
 	ctx = ai.WithRunInfo(ctx, info)
 	ctx, finishSpan := f.startRunSpan(ctx, run)
 	var spanErr error
@@ -570,6 +599,7 @@ func (f *Flow) runFrom(ctx context.Context, run Run) (Run, error) {
 
 	for i := start; i < len(steps); i++ {
 		step := steps[i]
+		deps.step = &run.Steps[i]
 		run.State.Stage = step.Name
 		run.Steps[i].Status = "in_progress"
 		if err := f.save(ctx, run); err != nil {

--- a/flow/steps.go
+++ b/flow/steps.go
@@ -110,17 +110,19 @@ type StepRecord struct {
 // saves and loads. It is retained for success and failure unless the flow
 // opts into cleanup with DeleteOnSuccess.
 type Run struct {
-	ID       string       `json:"id"`
-	ParentID string       `json:"parent_id,omitempty"`
-	Flow     string       `json:"flow"`
-	Dispatch string       `json:"dispatch,omitempty"`
-	Trigger  string       `json:"trigger,omitempty"`
-	State    State        `json:"state"`
-	Steps    []StepRecord `json:"steps"`
-	Status   string       `json:"status"` // running | waiting | done | failed
-	Await    *AwaitState  `json:"await,omitempty"`
-	Started  time.Time    `json:"started"`
-	Updated  time.Time    `json:"updated"`
+	ID         string       `json:"id"`
+	ParentID   string       `json:"parent_id,omitempty"`
+	Flow       string       `json:"flow"`
+	OriginFlow string       `json:"origin_flow,omitempty"`
+	OriginStep string       `json:"origin_step,omitempty"`
+	Dispatch   string       `json:"dispatch,omitempty"`
+	Trigger    string       `json:"trigger,omitempty"`
+	State      State        `json:"state"`
+	Steps      []StepRecord `json:"steps"`
+	Status     string       `json:"status"` // running | waiting | done | failed
+	Await      *AwaitState  `json:"await,omitempty"`
+	Started    time.Time    `json:"started"`
+	Updated    time.Time    `json:"updated"`
 }
 
 // Checkpoint persists and restores flow runs so a run survives a crash

--- a/flow/steps_test.go
+++ b/flow/steps_test.go
@@ -210,11 +210,14 @@ func TestFlowStepContextIncludesRunInfo(t *testing.T) {
 	if got.Step != "inspect" {
 		t.Fatalf("RunInfo.Step = %q, want inspect", got.Step)
 	}
+	if got.Dispatch != "direct" {
+		t.Fatalf("RunInfo.Dispatch = %q, want direct", got.Dispatch)
+	}
 	runs, err := StoreCheckpoint(mem, "correlated").List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if len(runs) != 1 || runs[0].ParentID != "agent-run-1" {
+	if len(runs) != 1 || runs[0].ParentID != "agent-run-1" || runs[0].Dispatch != "direct" {
 		t.Fatalf("persisted parent id = %+v, want agent-run-1", runs)
 	}
 }

--- a/internal/website/content/en/docs/_index.md
+++ b/internal/website/content/en/docs/_index.md
@@ -59,6 +59,7 @@ Otherwise continue to read the docs for more information about the framework.
 - [No-secret first-agent transcript](guides/no-secret-first-agent.md) - Run the first useful agent path without a provider key
 - [Your First Agent](guides/your-first-agent.md) - Build a service-backed agent and talk to it with `micro chat`
 - [Agent run records](guides/agent-run-records.md) - Inspect and safely export the versioned execution record for one run
+- [Flow run records](guides/flow-run-records.md) - Inspect a workflow's service targets and child agent runs
 - [Building AI-Native Services](guides/ai-native-services.md) - End-to-end tutorial for MCP-enabled services
 - [MCP Security Guide](guides/mcp-security.md) - Auth, scopes, rate limiting, and audit logging
 - [Tool Description Best Practices](guides/tool-descriptions.md) - Writing docs that make agents effective

--- a/internal/website/content/en/docs/guides/agent-run-records.md
+++ b/internal/website/content/en/docs/guides/agent-run-records.md
@@ -25,6 +25,11 @@ The JSON view emits the public `agent.RunRecord` contract:
   "summary": {
     "run_id": "01J...",
     "agent": "support",
+    "parent_id": "flow-01J...",
+    "flow": "daily-ops",
+    "step": "summarize",
+    "dispatch": "schedule",
+    "trigger": "daily-review",
     "status": "done",
     "events": 4
   },
@@ -57,9 +62,15 @@ process uses the same agent name and state store.
 
 ## Fields
 
-The summary contains run and parent ids, agent identity, trace/span correlation,
-start and update times, duration, event count, derived status, latest checkpoint
-and stage, latest event and error, and cumulative spend.
+The summary contains run and parent ids, agent identity, originating flow and
+step, dispatch and trigger, trace/span correlation, start and update times,
+duration, event count, derived status, latest checkpoint and stage, latest event
+and error, and cumulative spend. When a flow dispatched the agent, the human
+view prints the exact parent command:
+
+```sh
+micro inspect flow <flow> --run <parent-run-id>
+```
 
 Each event contains its timestamp, run lineage, trace/span correlation, agent,
 kind, and the metadata relevant to that kind. Model events can include provider,
@@ -72,6 +83,9 @@ Go callers can load the same contract directly:
 ```go
 record, err := agent.LoadRunRecord(stateStore, "support", runID)
 ```
+
+See [Flow run records](flow-run-records.md) for the parent side of the same
+execution graph, including service targets and child agent run ids.
 
 ## Privacy and redaction
 

--- a/internal/website/content/en/docs/guides/flow-run-records.md
+++ b/internal/website/content/en/docs/guides/flow-run-records.md
@@ -1,0 +1,61 @@
+---
+title: Flow run records
+description: "Inspect a versioned Go Micro flow execution and navigate its service and agent lineage."
+---
+
+A flow run record is the durable map of one workflow execution: how it started,
+which steps ran, which services they called, and which agent runs they created.
+List runs to find an id, then inspect the complete record:
+
+```sh
+micro inspect flow daily-ops
+micro inspect flow daily-ops --run <run-id>
+micro inspect flow daily-ops --run <run-id> --json
+```
+
+The human view prints dispatch and trigger origin followed by every step. A
+`flow.Call` step records its service and endpoint. A `flow.Dispatch` step records
+the agent name and returned child run id. For each child it prints a command you
+can follow directly:
+
+```sh
+micro inspect agent <agent> --run <child-run-id>
+```
+
+The JSON view emits the public `flow.RunRecord` contract:
+
+```json
+{
+  "schema_version": 1,
+  "run": {
+    "id": "flow-01J...",
+    "flow": "daily-ops",
+    "dispatch": "schedule",
+    "trigger": "daily-review",
+    "status": "done",
+    "steps": [
+      {"name": "load", "status": "done", "service": "reports", "endpoint": "Reports.Load"},
+      {"name": "summarize", "status": "done", "agent": "ops", "child_run_id": "agent-01J..."}
+    ]
+  }
+}
+```
+
+Use `schema_version` before decoding records across Go Micro releases. Go
+callers can load the same contract from any checkpoint implementation:
+
+```go
+record, err := flow.LoadRunRecord(ctx, checkpoint, "daily-ops", runID)
+```
+
+Execution identity also travels in Go Micro RPC metadata. A service or agent can
+call `ai.RunInfoFrom(ctx)` to recover the flow run, current step, dispatch, and
+trigger without changing its request schema. Agent runs replace the run id with
+their own identity and retain the flow run as `parent_id`; their service tools
+receive that same lineage.
+
+Unlike the agent event timeline, a flow checkpoint includes `state.data` and
+truncated step results so it can resume work. Treat the whole record as
+application data. Names, ids, errors, triggers, and endpoint names can also be
+sensitive. Apply the same access controls and retention policy used for flow
+checkpoints before exporting a record.


### PR DESCRIPTION
## Summary
- propagate stable flow/agent execution identity through Go Micro RPC metadata
- persist dispatch, trigger, service target, and child agent run lineage in durable records
- add versioned `flow.RunRecord` inspection with parent/child CLI breadcrumbs
- document flow run records and their data-handling considerations

## Testing
- added metadata boundary, flow dispatch/service, agent tool lineage, record serialization, and CLI rendering tests
- `git diff --check` passes locally
- Go build/test/lint delegated to required CI because the local runner does not include a Go toolchain