### PR TITLE
config: close loader when config closes

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -198,7 +198,7 @@ func (c *config) Close() error {
 
 	close(c.exit)
 	c.closed = true
-	return nil
+	return c.opts.Loader.Close()
 }
 
 func (c *config) Get(path ...string) (reader.Value, error) {

--- a/config/default_test.go
+++ b/config/default_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,11 +11,24 @@ import (
 	"testing"
 	"time"
 
+	"go-micro.dev/v6/config/loader"
+	loadermemory "go-micro.dev/v6/config/loader/memory"
 	"go-micro.dev/v6/config/source"
 	"go-micro.dev/v6/config/source/env"
 	"go-micro.dev/v6/config/source/file"
 	"go-micro.dev/v6/config/source/memory"
 )
+
+type closeTrackingLoader struct {
+	loader.Loader
+	err   error
+	calls int
+}
+
+func (l *closeTrackingLoader) Close() error {
+	l.calls++
+	return l.err
+}
 
 func createFileForIssue18(t *testing.T, content string) *os.File {
 	data := []byte(content)
@@ -67,6 +81,28 @@ func TestConfigCloseConcurrentIdempotent(t *testing.T) {
 
 	if err := conf.Close(); err != nil {
 		t.Fatalf("Expected repeated close to be idempotent but got %v", err)
+	}
+}
+
+func TestConfigCloseClosesLoader(t *testing.T) {
+	wantErr := errors.New("loader close failed")
+	l := &closeTrackingLoader{
+		Loader: loadermemory.NewLoader(loadermemory.WithWatcherDisabled()),
+		err:    wantErr,
+	}
+	conf, err := NewConfig(WithLoader(l), WithWatcherDisabled())
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	if err := conf.Close(); !errors.Is(err, wantErr) {
+		t.Fatalf("Expected loader close error %v but got %v", wantErr, err)
+	}
+	if err := conf.Close(); err != nil {
+		t.Fatalf("Expected repeated close to be idempotent but got %v", err)
+	}
+	if l.calls != 1 {
+		t.Fatalf("Expected loader to be closed once but got %d calls", l.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- close the configured loader when a config is closed so source watchers and file handles are released
- preserve concurrent idempotency and propagate the loader's close error
- add regression coverage that verifies the loader is closed exactly once

## Testing
- `go build ./...`
- `go test ./config/...`
- `go test ./...` *(fails in environment-dependent AI and loopback gRPC tests)*
- `golangci-lint run ./...` *(cannot run because installed golangci-lint was built with Go 1.24 while the project targets Go 1.25.12)*

Closes #4913
