### PR TITLE
config: backport loader close fix to v4

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -126,7 +126,9 @@ func (c *config) run() {
 			case <-c.exit:
 			}
 			err := w.Stop()
-			fmt.Println(err.Error())
+			if err != nil {
+				fmt.Println(err.Error())
+			}
 		}()
 
 		// block watch
@@ -184,13 +186,17 @@ func (c *config) Sync() error {
 }
 
 func (c *config) Close() error {
+	c.Lock()
 	select {
 	case <-c.exit:
+		c.Unlock()
 		return nil
 	default:
 		close(c.exit)
 	}
-	return nil
+	c.Unlock()
+
+	return c.opts.Loader.Close()
 }
 
 func (c *config) Get(path ...string) reader.Value {

--- a/config/default_test.go
+++ b/config/default_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,11 +10,24 @@ import (
 	"testing"
 	"time"
 
+	"go-micro.dev/v4/config/loader"
+	loadermemory "go-micro.dev/v4/config/loader/memory"
 	"go-micro.dev/v4/config/source"
 	"go-micro.dev/v4/config/source/env"
 	"go-micro.dev/v4/config/source/file"
 	"go-micro.dev/v4/config/source/memory"
 )
+
+type closeTrackingLoader struct {
+	loader.Loader
+	err   error
+	calls int
+}
+
+func (l *closeTrackingLoader) Close() error {
+	l.calls++
+	return l.err
+}
 
 func createFileForIssue18(t *testing.T, content string) *os.File {
 	data := []byte(content)
@@ -43,6 +57,28 @@ func createFileForTest(t *testing.T) *os.File {
 	}
 
 	return fh
+}
+
+func TestConfigCloseClosesLoader(t *testing.T) {
+	wantErr := errors.New("loader close failed")
+	l := &closeTrackingLoader{
+		Loader: loadermemory.NewLoader(loadermemory.WithWatcherDisabled()),
+		err:    wantErr,
+	}
+	conf, err := NewConfig(WithLoader(l), WithWatcherDisabled())
+	if err != nil {
+		t.Fatalf("Expected no error but got %v", err)
+	}
+
+	if err := conf.Close(); !errors.Is(err, wantErr) {
+		t.Fatalf("Expected loader close error %v but got %v", wantErr, err)
+	}
+	if err := conf.Close(); err != nil {
+		t.Fatalf("Expected repeated close to be idempotent but got %v", err)
+	}
+	if l.calls != 1 {
+		t.Fatalf("Expected loader to be closed once but got %d calls", l.calls)
+	}
 }
 
 func TestConfigLoadWithGoodFile(t *testing.T) {


### PR DESCRIPTION
## Summary
- backport the config watcher nil-error guard to the v4 maintenance line
- close the configured loader from Config.Close so file watchers and handles are released
- serialize Close calls and verify loader errors and idempotency with a regression test

## Testing
- `go build ./...`
- `go test ./config/...`
- `go test ./...` *(unrelated existing failures in api/client, client, events, and transport)*
- `golangci-lint run ./...` *(installed golangci-lint rejects this historical unversioned configuration)*

Closes #4913
