### PR TITLE
Fix model package documentation after rename

### DIFF
--- a/cmd/protoc-gen-micro/plugin/micro/micro.go
+++ b/cmd/protoc-gen-micro/plugin/micro/micro.go
@@ -81,7 +81,6 @@ func (g *micro) Generate(file *generator.FileDescriptor) {
 	for i, service := range file.Service {
 		g.generateService(file, service, i)
 	}
-
 }
 
 // GenerateImports generates the import declaration for this file.

--- a/model/model.go
+++ b/model/model.go
@@ -1,4 +1,4 @@
-// Package ai provides abstraction for AI model providers
+// Package model provides abstraction for AI model providers
 package model
 
 import (


### PR DESCRIPTION
## Summary
- correct the root package comment to use the new `model` name
- remove an extra blank line left in the protoc plugin cleanup

## Testing
- `gofmt -w model/model.go cmd/protoc-gen-micro/plugin/micro/micro.go`

Follow-up to #4918.