### PR TITLE
Remove Anthropic sponsorship listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ The generated code is plain Go on disk — edit it by hand at any time; re-runni
 
 ## Sponsors
 
-<a href="https://go-micro.dev/blog/2026/03/04/building-the-ai-native-future-of-go-micro-with-claude.html"><img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Anthropic_logo.svg" height="26" /></a>
-&nbsp;&nbsp;
 <a href="https://go-micro.dev/blog/2026/06/23/go-micro-joins-openai-s-codex-for-open-source.html"><img src="https://upload.wikimedia.org/wikipedia/commons/4/4d/OpenAI_Logo.svg" height="26" /></a>
 &nbsp;&nbsp;
 <a href="https://go-micro.dev/blog/2026/05/28/atlas-cloud-sponsors-go-micro-300-ai-models-one-integration.html"><img src="https://www.atlascloud.ai/logo.svg" height="26" /></a>

--- a/internal/website/content/en/_index.md
+++ b/internal/website/content/en/_index.md
@@ -209,7 +209,6 @@ Get the code
 <h2>Sponsors</h2>
 <p class="text-light mb-4">Go Micro is supported by companies building the future of AI infrastructure.</p>
 <div class="d-flex align-items-center justify-content-center gap-4 flex-wrap mb-5">
-<a href="/blog/2026/03/04/building-the-ai-native-future-of-go-micro-with-claude.html"><img src="/images/sponsors/anthropic.svg" alt="Anthropic" class="sponsor-logo" /></a>
 <a href="/blog/2026/06/23/go-micro-joins-openai-s-codex-for-open-source.html"><img src="/images/sponsors/openmodel.svg" alt="OpenAI" class="sponsor-logo" /></a>
 <a href="/blog/2026/05/28/atlas-cloud-sponsors-go-micro-300-ai-models-one-integration.html"><img src="/images/sponsors/atlas-cloud-logo.svg" alt="Atlas Cloud" class="sponsor-logo" /></a>
 </div>


### PR DESCRIPTION
## Summary
- remove the expired Anthropic sponsorship logo from the repository README
- remove the expired Anthropic sponsorship logo from the website landing page

## Testing
- `go build ./...`
- `go test ./...` *(fails in the environment because loopback connections are blocked; an Atlas Cloud credential also appears configured but invalid)*
- `golangci-lint run ./...` *(cannot run because the installed binary was built with Go 1.24 while the project targets Go 1.25.12)*