### PR TITLE
Keep only Atlas Cloud in sponsor sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ The generated code is plain Go on disk — edit it by hand at any time; re-runni
 
 ## Sponsors
 
-<a href="https://go-micro.dev/blog/2026/06/23/go-micro-joins-openai-s-codex-for-open-source.html"><img src="https://upload.wikimedia.org/wikipedia/commons/4/4d/OpenAI_Logo.svg" height="26" /></a>
-&nbsp;&nbsp;
 <a href="https://go-micro.dev/blog/2026/05/28/atlas-cloud-sponsors-go-micro-300-ai-models-one-integration.html"><img src="https://www.atlascloud.ai/logo.svg" height="26" /></a>
 
 **Want to support Go Micro and see your logo here?** [Become a sponsor](https://discord.gg/G8Gk5j3uXr) — reach out on Discord.

--- a/internal/website/content/en/_index.md
+++ b/internal/website/content/en/_index.md
@@ -209,7 +209,6 @@ Get the code
 <h2>Sponsors</h2>
 <p class="text-light mb-4">Go Micro is supported by companies building the future of AI infrastructure.</p>
 <div class="d-flex align-items-center justify-content-center gap-4 flex-wrap mb-5">
-<a href="/blog/2026/06/23/go-micro-joins-openai-s-codex-for-open-source.html"><img src="/images/sponsors/openmodel.svg" alt="OpenAI" class="sponsor-logo" /></a>
 <a href="/blog/2026/05/28/atlas-cloud-sponsors-go-micro-300-ai-models-one-integration.html"><img src="/images/sponsors/atlas-cloud-logo.svg" alt="Atlas Cloud" class="sponsor-logo" /></a>
 </div>
 <p class="text-light mb-3">Want to support Go Micro and put your logo here? Or running it in production and need a hand?</p>


### PR DESCRIPTION
## Summary
- remove the OpenAI sponsor logo from the root README
- remove the OpenAI sponsor logo from the website landing page
- leave Atlas Cloud as the only logo in both sponsor sections

## Testing
- `go build ./...`
- `go test ./...` *(fails in the environment because loopback gRPC connections are forbidden and a configured Atlas Cloud credential returns HTTP 400)*
- `golangci-lint run ./...` *(cannot run because the installed binary was built with Go 1.24 while the project targets Go 1.25.12)*
- `git diff --check`

Follow-up to #4921.