### PR TITLE
a2a: block IPv6 transition addresses in the push callback SSRF guard

### DIFF
--- a/gateway/a2a/pushsecurity.go
+++ b/gateway/a2a/pushsecurity.go
@@ -65,14 +65,67 @@ func resolvePushHost(host string) ([]net.IP, error) {
 // reach: loopback, private (RFC1918 / ULA), link-local (incl. 169.254.169.254
 // cloud metadata), multicast, or the unspecified address.
 func blockedPushIP(ip net.IP) bool {
-	return ip == nil ||
+	if ip == nil ||
 		ip.IsLoopback() ||
 		ip.IsPrivate() ||
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() ||
 		ip.IsInterfaceLocalMulticast() ||
 		ip.IsMulticast() ||
-		ip.IsUnspecified()
+		ip.IsUnspecified() {
+		return true
+	}
+	// IPv6 transition addresses (6to4, NAT64, Teredo, IPv4-compatible) embed an
+	// IPv4 address none of the checks above look at. Unwrap and re-check it so
+	// [2002:a9fe:a9fe::1] is treated as 169.254.169.254.
+	for _, inner := range embeddedIPv4(ip) {
+		if blockedPushIP(inner) {
+			return true
+		}
+	}
+	return false
+}
+
+// embeddedIPv4 returns the IPv4 addresses carried inside an IPv6 transition
+// address, or nil when it carries none. Teredo yields two: the relay server and
+// the (obfuscated) client.
+func embeddedIPv4(ip net.IP) []net.IP {
+	v6 := ip.To16()
+	if v6 == nil || ip.To4() != nil {
+		return nil
+	}
+	switch {
+	// 6to4 — RFC 3056, 2002::/16, IPv4 in bytes 2-6.
+	case v6[0] == 0x20 && v6[1] == 0x02:
+		return []net.IP{net.IPv4(v6[2], v6[3], v6[4], v6[5])}
+	// NAT64 well-known prefix — RFC 6052, 64:ff9b::/96, IPv4 in the low 32 bits.
+	case v6[0] == 0x00 && v6[1] == 0x64 && v6[2] == 0xff && v6[3] == 0x9b && allZeros(v6[4:12]):
+		return []net.IP{net.IPv4(v6[12], v6[13], v6[14], v6[15])}
+	// NAT64 local-use prefix — RFC 8215, 64:ff9b:1::/48. Embedded IPv4 position
+	// depends on the operator's prefix length, so block the whole range.
+	case v6[0] == 0x00 && v6[1] == 0x64 && v6[2] == 0xff && v6[3] == 0x9b && v6[4] == 0x00 && v6[5] == 0x01:
+		return []net.IP{net.IPv4zero}
+	// Teredo — RFC 4380, 2001::/32. Server IPv4 in bytes 4-8, client IPv4 in
+	// bytes 12-16 obfuscated by XOR with 0xff.
+	case v6[0] == 0x20 && v6[1] == 0x01 && v6[2] == 0x00 && v6[3] == 0x00:
+		return []net.IP{
+			net.IPv4(v6[4], v6[5], v6[6], v6[7]),
+			net.IPv4(v6[12]^0xff, v6[13]^0xff, v6[14]^0xff, v6[15]^0xff),
+		}
+	// IPv4-compatible — deprecated ::a.b.c.d, not unwrapped by net.IP.To4.
+	case allZeros(v6[0:12]):
+		return []net.IP{net.IPv4(v6[12], v6[13], v6[14], v6[15])}
+	}
+	return nil
+}
+
+func allZeros(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // pushDialControl runs after DNS resolution, immediately before connect, on the

--- a/gateway/a2a/pushsecurity_test.go
+++ b/gateway/a2a/pushsecurity_test.go
@@ -28,17 +28,22 @@ func TestDefaultPushURLPolicy(t *testing.T) {
 	defer func() { pushLookupIP = orig }()
 
 	blocked := []string{
-		"http://127.0.0.1/hook",              // loopback
-		"http://169.254.169.254/latest/meta", // cloud metadata (link-local)
-		"http://10.0.0.5/hook",               // RFC1918
-		"http://[::1]/hook",                  // IPv6 loopback
-		"http://[fd00::1]/hook",              // IPv6 ULA (private)
-		"http://0.0.0.0/hook",                // unspecified
-		"http://internal.example/hook",       // hostname → private
-		"http://rebind.example/hook",         // one internal IP among many
-		"ftp://public.example/hook",          // non-http(s) scheme
-		"file:///etc/passwd",                 // scheme
-		"http:///nohost",                     // no host
+		"http://127.0.0.1/hook",                  // loopback
+		"http://169.254.169.254/latest/meta",     // cloud metadata (link-local)
+		"http://10.0.0.5/hook",                   // RFC1918
+		"http://[::1]/hook",                      // IPv6 loopback
+		"http://[fd00::1]/hook",                  // IPv6 ULA (private)
+		"http://0.0.0.0/hook",                    // unspecified
+		"http://internal.example/hook",           // hostname → private
+		"http://rebind.example/hook",             // one internal IP among many
+		"ftp://public.example/hook",              // non-http(s) scheme
+		"file:///etc/passwd",                     // scheme
+		"http:///nohost",                         // no host
+		"http://[2002:a9fe:a9fe::1]/hook",        // 6to4 → 169.254.169.254
+		"http://[64:ff9b::a9fe:a9fe]/hook",       // NAT64 well-known prefix → 169.254.169.254
+		"http://[64:ff9b:1::7f00:1]/hook",        // NAT64 local-use prefix
+		"http://[2001:0:0:0:0:0:80ff:fffe]/hook", // Teredo → client 127.0.0.1
+		"http://[::7f00:1]/hook",                 // IPv4-compatible → 127.0.0.1
 	}
 	for _, raw := range blocked {
 		u, err := url.Parse(raw)
@@ -51,8 +56,9 @@ func TestDefaultPushURLPolicy(t *testing.T) {
 	}
 
 	allowed := []string{
-		"http://93.184.216.34/hook",   // public literal IP
-		"https://public.example/hook", // hostname → public
+		"http://93.184.216.34/hook",      // public literal IP
+		"https://public.example/hook",    // hostname → public
+		"http://[64:ff9b::808:808]/hook", // NAT64 wrapping a public IPv4 (8.8.8.8)
 	}
 	for _, raw := range allowed {
 		u, _ := url.Parse(raw)
@@ -63,7 +69,10 @@ func TestDefaultPushURLPolicy(t *testing.T) {
 }
 
 func TestPushDialControlBlocksPrivate(t *testing.T) {
-	blocked := []string{"127.0.0.1:80", "169.254.169.254:80", "10.0.0.1:443", "[::1]:80", "0.0.0.0:80"}
+	blocked := []string{
+		"127.0.0.1:80", "169.254.169.254:80", "10.0.0.1:443", "[::1]:80", "0.0.0.0:80",
+		"[2002:a9fe:a9fe::1]:80", "[64:ff9b::a9fe:a9fe]:443",
+	}
 	for _, addr := range blocked {
 		if err := pushDialControl("tcp", addr, nil); err == nil {
 			t.Errorf("pushDialControl(%q) = nil, want blocked", addr)


### PR DESCRIPTION
The push-notification SSRF guard resolves the callback host and rejects any address that is loopback, private, link-local, etc., and re-checks the resolved IP at dial time to stop DNS rebinding. `blockedPushIP` does that check but never looks at the IPv4 address embedded in an IPv6 transition address, so a callback URL whose host is `[2002:a9fe:a9fe::1]` (6to4) or `[64:ff9b::a9fe:a9fe]` (NAT64 well-known prefix) passes both the URL policy and the dial-time check. On a host with NAT64/6to4 routing that address reaches the embedded IPv4, so an untrusted caller who can set `pushNotificationConfig` can still get the gateway to POST task state to `169.254.169.254` or a loopback service and read the response.

This unwraps 6to4, NAT64 (well-known and local-use prefixes), Teredo and the deprecated IPv4-compatible form and re-checks the embedded address in `blockedPushIP`, which covers both `defaultPushURLPolicy` and `pushDialControl`. A NAT64 address wrapping a public IPv4 stays allowed. Same class as CVE-2026-73087 (Dozzle).

Tested: `go test -race ./gateway/a2a/`. The new transition-address cases in `TestDefaultPushURLPolicy` and `TestPushDialControlBlocksPrivate` are accepted by the current guard and rejected after the change; the existing cases still pass. `gofmt` and `go vet` clean.
