### PR TITLE
a2a: configure network-specific NAT64 prefixes

### DIFF
--- a/gateway/a2a/a2a.go
+++ b/gateway/a2a/a2a.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -74,6 +75,12 @@ type Options struct {
 	// time (DNS-rebinding safe). Set this to permit a trusted in-cluster
 	// receiver, or to narrow delivery to an allowlist.
 	AllowPushURL func(*url.URL) error
+	// NAT64Prefixes lists network-specific RFC 6052 translation prefixes used
+	// by the gateway's network. Supported prefix lengths are /32, /40, /48,
+	// /56, /64, and /96. The default push URL guard decodes addresses under
+	// these prefixes and rejects callbacks whose embedded IPv4 is private or
+	// otherwise blocked.
+	NAT64Prefixes []net.IPNet
 	// AP2PublicKey, when set, verifies AP2 payment/checkout mandates carried on
 	// incoming A2A messages against this Ed25519 key and records the outcome in
 	// each task's ap2Verifications (signature + task/context binding). When
@@ -104,6 +111,7 @@ func New(opts Options) *Gateway {
 	}
 	opts.BaseURL = strings.TrimRight(opts.BaseURL, "/")
 	g := &Gateway{opts: opts, disp: newDispatcher()}
+	g.disp.setNAT64Prefixes(opts.NAT64Prefixes)
 	if opts.AllowPushURL != nil {
 		// Operator owns the trust decision: use their policy and skip the
 		// built-in private-IP dial guard so trusted in-cluster hosts resolve.
@@ -142,6 +150,14 @@ func WithPushURLPolicy(allow func(*url.URL) error) AgentHandlerOption {
 		}
 		d.allowPushURL = allow
 		d.guardPushDial = false
+	}
+}
+
+// WithPushNAT64Prefixes configures the network-specific RFC 6052 translation
+// prefixes used by an embedded agent handler. See Options.NAT64Prefixes.
+func WithPushNAT64Prefixes(prefixes ...net.IPNet) AgentHandlerOption {
+	return func(d *dispatcher) {
+		d.setNAT64Prefixes(prefixes)
 	}
 }
 
@@ -582,8 +598,10 @@ type dispatcher struct {
 	// allowPushURL authorizes an outbound push-notification callback URL; nil
 	// means the default SSRF-safe policy. guardPushDial applies the private-IP
 	// dial guard (on unless an operator supplied a custom policy).
-	allowPushURL  func(*url.URL) error
-	guardPushDial bool
+	allowPushURL   func(*url.URL) error
+	guardPushDial  bool
+	nat64Prefixes  []net.IPNet
+	pushHTTPClient *http.Client
 
 	// ap2Verify, when non-nil, verifies each AP2 mandate carried on a task and
 	// records the result in the task's AP2Verifications. Nil = carry unverified.
@@ -592,11 +610,12 @@ type dispatcher struct {
 
 func newDispatcher() *dispatcher {
 	return &dispatcher{
-		tasks:         map[string]*Task{},
-		pushConfigs:   map[string]PushNotificationConfig{},
-		watchers:      map[string]map[chan *Task]struct{}{},
-		allowPushURL:  defaultPushURLPolicy,
-		guardPushDial: true,
+		tasks:          map[string]*Task{},
+		pushConfigs:    map[string]PushNotificationConfig{},
+		watchers:       map[string]map[chan *Task]struct{}{},
+		allowPushURL:   defaultPushURLPolicy,
+		guardPushDial:  true,
+		pushHTTPClient: newPushGuardClient(nil),
 	}
 }
 

--- a/gateway/a2a/pushsecurity.go
+++ b/gateway/a2a/pushsecurity.go
@@ -30,6 +30,10 @@ var pushLookupIP = net.LookupIP
 // configured. It rejects non-http(s) schemes and hosts that resolve to a
 // loopback, private, link-local, multicast, or unspecified address.
 func defaultPushURLPolicy(u *url.URL) error {
+	return defaultPushURLPolicyWithPrefixes(u, nil)
+}
+
+func defaultPushURLPolicyWithPrefixes(u *url.URL, nat64Prefixes []net.IPNet) error {
 	switch u.Scheme {
 	case "http", "https":
 	default:
@@ -47,7 +51,7 @@ func defaultPushURLPolicy(u *url.URL) error {
 		return fmt.Errorf("push callback host %q did not resolve", host)
 	}
 	for _, ip := range ips {
-		if blockedPushIP(ip) {
+		if blockedPushIP(ip, nat64Prefixes...) {
 			return fmt.Errorf("push callback host %q resolves to a blocked address %s", host, ip)
 		}
 	}
@@ -64,7 +68,7 @@ func resolvePushHost(host string) ([]net.IP, error) {
 // blockedPushIP reports whether ip is one an outbound push callback must not
 // reach: loopback, private (RFC1918 / ULA), link-local (incl. 169.254.169.254
 // cloud metadata), multicast, or the unspecified address.
-func blockedPushIP(ip net.IP) bool {
+func blockedPushIP(ip net.IP, nat64Prefixes ...net.IPNet) bool {
 	if ip == nil ||
 		ip.IsLoopback() ||
 		ip.IsPrivate() ||
@@ -78,7 +82,7 @@ func blockedPushIP(ip net.IP) bool {
 	// IPv6 transition addresses (6to4, NAT64, Teredo, IPv4-compatible) embed an
 	// IPv4 address none of the checks above look at. Unwrap and re-check it so
 	// [2002:a9fe:a9fe::1] is treated as 169.254.169.254.
-	for _, inner := range embeddedIPv4(ip) {
+	for _, inner := range embeddedIPv4(ip, nat64Prefixes...) {
 		if blockedPushIP(inner) {
 			return true
 		}
@@ -89,10 +93,15 @@ func blockedPushIP(ip net.IP) bool {
 // embeddedIPv4 returns the IPv4 addresses carried inside an IPv6 transition
 // address, or nil when it carries none. Teredo yields two: the relay server and
 // the (obfuscated) client.
-func embeddedIPv4(ip net.IP) []net.IP {
+func embeddedIPv4(ip net.IP, nat64Prefixes ...net.IPNet) []net.IP {
 	v6 := ip.To16()
 	if v6 == nil || ip.To4() != nil {
 		return nil
+	}
+	for _, prefix := range nat64Prefixes {
+		if inner := rfc6052IPv4(v6, prefix); inner != nil {
+			return []net.IP{inner}
+		}
 	}
 	switch {
 	// 6to4 — RFC 3056, 2002::/16, IPv4 in bytes 2-6.
@@ -119,6 +128,38 @@ func embeddedIPv4(ip net.IP) []net.IP {
 	return nil
 }
 
+// rfc6052IPv4 extracts the IPv4 address from ip when prefix is a supported
+// network-specific RFC 6052 prefix. For prefix lengths up to /64, RFC 6052
+// places the reserved u octet at bits 64-71 and splits the IPv4 bits around it.
+func rfc6052IPv4(ip net.IP, prefix net.IPNet) net.IP {
+	bits, total := prefix.Mask.Size()
+	prefixIP := prefix.IP.To16()
+	if total != 128 || prefixIP == nil || !prefix.Contains(ip) {
+		return nil
+	}
+	var indexes []int
+	switch bits {
+	case 32:
+		indexes = []int{4, 5, 6, 7}
+	case 40:
+		indexes = []int{5, 6, 7, 9}
+	case 48:
+		indexes = []int{6, 7, 9, 10}
+	case 56:
+		indexes = []int{7, 9, 10, 11}
+	case 64:
+		indexes = []int{9, 10, 11, 12}
+	case 96:
+		indexes = []int{12, 13, 14, 15}
+	default:
+		return nil
+	}
+	if bits <= 64 && ip[8] != 0 {
+		return nil
+	}
+	return net.IPv4(ip[indexes[0]], ip[indexes[1]], ip[indexes[2]], ip[indexes[3]])
+}
+
 func allZeros(b []byte) bool {
 	for _, x := range b {
 		if x != 0 {
@@ -132,6 +173,10 @@ func allZeros(b []byte) bool {
 // resolved address — so it blocks a host that passed URL validation but was
 // rebound to an internal IP (DNS rebinding).
 func pushDialControl(_, address string, _ syscall.RawConn) error {
+	return pushDialControlWithPrefixes("", address, nil, nil)
+}
+
+func pushDialControlWithPrefixes(_ string, address string, _ syscall.RawConn, nat64Prefixes []net.IPNet) error {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
 		return err
@@ -140,23 +185,28 @@ func pushDialControl(_, address string, _ syscall.RawConn) error {
 	if ip == nil {
 		return fmt.Errorf("push callback: cannot parse dial address %q", address)
 	}
-	if blockedPushIP(ip) {
+	if blockedPushIP(ip, nat64Prefixes...) {
 		return fmt.Errorf("push callback: refusing to connect to blocked address %s", ip)
 	}
 	return nil
 }
 
-// pushGuardClient is the HTTP client used for default-policy push delivery. Its
-// dialer refuses connections to blocked addresses at connect time.
-var pushGuardClient = &http.Client{
-	Timeout: 10 * time.Second,
-	Transport: &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout: 5 * time.Second,
-			Control: pushDialControl,
-		}).DialContext,
-	},
+// newPushGuardClient creates the HTTP client used for default-policy push
+// delivery. Its dialer refuses connections to blocked addresses at connect
+// time.
+func newPushGuardClient(nat64Prefixes []net.IPNet) *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout: 5 * time.Second,
+				Control: func(network, address string, conn syscall.RawConn) error {
+					return pushDialControlWithPrefixes(network, address, conn, nat64Prefixes)
+				},
+			}).DialContext,
+		},
+	}
 }
 
 // checkPushURL validates a callback URL against the dispatcher's effective
@@ -173,12 +223,22 @@ func (d *dispatcher) checkPushURL(raw string) error {
 	return policy(u)
 }
 
+func (d *dispatcher) setNAT64Prefixes(prefixes []net.IPNet) {
+	d.nat64Prefixes = append([]net.IPNet(nil), prefixes...)
+	if d.guardPushDial {
+		d.allowPushURL = func(u *url.URL) error {
+			return defaultPushURLPolicyWithPrefixes(u, d.nat64Prefixes)
+		}
+		d.pushHTTPClient = newPushGuardClient(d.nat64Prefixes)
+	}
+}
+
 // pushClient is the HTTP client deliverPush uses: the guarded client under the
 // default policy, or the default client when an operator has taken over the
 // policy via Options.AllowPushURL (they own the trust decision then).
 func (d *dispatcher) pushClient() *http.Client {
 	if d.guardPushDial {
-		return pushGuardClient
+		return d.pushHTTPClient
 	}
 	return http.DefaultClient
 }

--- a/gateway/a2a/pushsecurity.go
+++ b/gateway/a2a/pushsecurity.go
@@ -65,14 +65,67 @@ func resolvePushHost(host string) ([]net.IP, error) {
 // reach: loopback, private (RFC1918 / ULA), link-local (incl. 169.254.169.254
 // cloud metadata), multicast, or the unspecified address.
 func blockedPushIP(ip net.IP) bool {
-	return ip == nil ||
+	if ip == nil ||
 		ip.IsLoopback() ||
 		ip.IsPrivate() ||
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() ||
 		ip.IsInterfaceLocalMulticast() ||
 		ip.IsMulticast() ||
-		ip.IsUnspecified()
+		ip.IsUnspecified() {
+		return true
+	}
+	// IPv6 transition addresses (6to4, NAT64, Teredo, IPv4-compatible) embed an
+	// IPv4 address none of the checks above look at. Unwrap and re-check it so
+	// [2002:a9fe:a9fe::1] is treated as 169.254.169.254.
+	for _, inner := range embeddedIPv4(ip) {
+		if blockedPushIP(inner) {
+			return true
+		}
+	}
+	return false
+}
+
+// embeddedIPv4 returns the IPv4 addresses carried inside an IPv6 transition
+// address, or nil when it carries none. Teredo yields two: the relay server and
+// the (obfuscated) client.
+func embeddedIPv4(ip net.IP) []net.IP {
+	v6 := ip.To16()
+	if v6 == nil || ip.To4() != nil {
+		return nil
+	}
+	switch {
+	// 6to4 — RFC 3056, 2002::/16, IPv4 in bytes 2-6.
+	case v6[0] == 0x20 && v6[1] == 0x02:
+		return []net.IP{net.IPv4(v6[2], v6[3], v6[4], v6[5])}
+	// NAT64 well-known prefix — RFC 6052, 64:ff9b::/96, IPv4 in the low 32 bits.
+	case v6[0] == 0x00 && v6[1] == 0x64 && v6[2] == 0xff && v6[3] == 0x9b && allZeros(v6[4:12]):
+		return []net.IP{net.IPv4(v6[12], v6[13], v6[14], v6[15])}
+	// NAT64 local-use prefix — RFC 8215, 64:ff9b:1::/48. Embedded IPv4 position
+	// depends on the operator's prefix length, so block the whole range.
+	case v6[0] == 0x00 && v6[1] == 0x64 && v6[2] == 0xff && v6[3] == 0x9b && v6[4] == 0x00 && v6[5] == 0x01:
+		return []net.IP{net.IPv4zero}
+	// Teredo — RFC 4380, 2001::/32. Server IPv4 in bytes 4-8, client IPv4 in
+	// bytes 12-16 obfuscated by XOR with 0xff.
+	case v6[0] == 0x20 && v6[1] == 0x01 && v6[2] == 0x00 && v6[3] == 0x00:
+		return []net.IP{
+			net.IPv4(v6[4], v6[5], v6[6], v6[7]),
+			net.IPv4(v6[12]^0xff, v6[13]^0xff, v6[14]^0xff, v6[15]^0xff),
+		}
+	// IPv4-compatible — deprecated ::a.b.c.d, not unwrapped by net.IP.To4.
+	case allZeros(v6[0:12]):
+		return []net.IP{net.IPv4(v6[12], v6[13], v6[14], v6[15])}
+	}
+	return nil
+}
+
+func allZeros(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // pushDialControl runs after DNS resolution, immediately before connect, on the

--- a/gateway/a2a/pushsecurity_test.go
+++ b/gateway/a2a/pushsecurity_test.go
@@ -28,17 +28,22 @@ func TestDefaultPushURLPolicy(t *testing.T) {
 	defer func() { pushLookupIP = orig }()
 
 	blocked := []string{
-		"http://127.0.0.1/hook",              // loopback
-		"http://169.254.169.254/latest/meta", // cloud metadata (link-local)
-		"http://10.0.0.5/hook",               // RFC1918
-		"http://[::1]/hook",                  // IPv6 loopback
-		"http://[fd00::1]/hook",              // IPv6 ULA (private)
-		"http://0.0.0.0/hook",                // unspecified
-		"http://internal.example/hook",       // hostname → private
-		"http://rebind.example/hook",         // one internal IP among many
-		"ftp://public.example/hook",          // non-http(s) scheme
-		"file:///etc/passwd",                 // scheme
-		"http:///nohost",                     // no host
+		"http://127.0.0.1/hook",                  // loopback
+		"http://169.254.169.254/latest/meta",     // cloud metadata (link-local)
+		"http://10.0.0.5/hook",                   // RFC1918
+		"http://[::1]/hook",                      // IPv6 loopback
+		"http://[fd00::1]/hook",                  // IPv6 ULA (private)
+		"http://0.0.0.0/hook",                    // unspecified
+		"http://internal.example/hook",           // hostname → private
+		"http://rebind.example/hook",             // one internal IP among many
+		"ftp://public.example/hook",              // non-http(s) scheme
+		"file:///etc/passwd",                     // scheme
+		"http:///nohost",                         // no host
+		"http://[2002:a9fe:a9fe::1]/hook",        // 6to4 → 169.254.169.254
+		"http://[64:ff9b::a9fe:a9fe]/hook",       // NAT64 well-known prefix → 169.254.169.254
+		"http://[64:ff9b:1::7f00:1]/hook",        // NAT64 local-use prefix
+		"http://[2001:0:0:0:0:0:80ff:fffe]/hook", // Teredo → client 127.0.0.1
+		"http://[::7f00:1]/hook",                 // IPv4-compatible → 127.0.0.1
 	}
 	for _, raw := range blocked {
 		u, err := url.Parse(raw)
@@ -51,8 +56,9 @@ func TestDefaultPushURLPolicy(t *testing.T) {
 	}
 
 	allowed := []string{
-		"http://93.184.216.34/hook",   // public literal IP
-		"https://public.example/hook", // hostname → public
+		"http://93.184.216.34/hook",      // public literal IP
+		"https://public.example/hook",    // hostname → public
+		"http://[64:ff9b::808:808]/hook", // NAT64 wrapping a public IPv4 (8.8.8.8)
 	}
 	for _, raw := range allowed {
 		u, _ := url.Parse(raw)
@@ -63,7 +69,10 @@ func TestDefaultPushURLPolicy(t *testing.T) {
 }
 
 func TestPushDialControlBlocksPrivate(t *testing.T) {
-	blocked := []string{"127.0.0.1:80", "169.254.169.254:80", "10.0.0.1:443", "[::1]:80", "0.0.0.0:80"}
+	blocked := []string{
+		"127.0.0.1:80", "169.254.169.254:80", "10.0.0.1:443", "[::1]:80", "0.0.0.0:80",
+		"[2002:a9fe:a9fe::1]:80", "[64:ff9b::a9fe:a9fe]:443",
+	}
 	for _, addr := range blocked {
 		if err := pushDialControl("tcp", addr, nil); err == nil {
 			t.Errorf("pushDialControl(%q) = nil, want blocked", addr)

--- a/gateway/a2a/pushsecurity_test.go
+++ b/gateway/a2a/pushsecurity_test.go
@@ -83,6 +83,54 @@ func TestPushDialControlBlocksPrivate(t *testing.T) {
 	}
 }
 
+func TestRFC6052NetworkSpecificPrefixes(t *testing.T) {
+	want := net.IPv4(169, 254, 169, 254)
+	cases := []struct {
+		bits    int
+		indexes [4]int
+	}{
+		{32, [4]int{4, 5, 6, 7}},
+		{40, [4]int{5, 6, 7, 9}},
+		{48, [4]int{6, 7, 9, 10}},
+		{56, [4]int{7, 9, 10, 11}},
+		{64, [4]int{9, 10, 11, 12}},
+		{96, [4]int{12, 13, 14, 15}},
+	}
+	for _, tc := range cases {
+		prefix := net.IPNet{IP: net.ParseIP("2001:db8::"), Mask: net.CIDRMask(tc.bits, 128)}
+		ip := append(net.IP(nil), prefix.IP.To16()...)
+		for i, index := range tc.indexes {
+			ip[index] = want[i+12]
+		}
+		if got := rfc6052IPv4(ip, prefix); got == nil || !got.Equal(want) {
+			t.Errorf("rfc6052IPv4(%s, /%d) = %v, want %s", ip, tc.bits, got, want)
+		}
+		if !blockedPushIP(ip, prefix) {
+			t.Errorf("blockedPushIP(%s, /%d) = false, want true", ip, tc.bits)
+		}
+	}
+
+	prefix := net.IPNet{IP: net.ParseIP("2001:db8:1234::"), Mask: net.CIDRMask(48, 128)}
+	nat64IP := func(v4 net.IP) net.IP {
+		ip := append(net.IP(nil), prefix.IP.To16()...)
+		for i, index := range cases[2].indexes {
+			ip[index] = v4.To4()[i]
+		}
+		return ip
+	}
+	private := nat64IP(want)
+	public := nat64IP(net.IPv4(8, 8, 8, 8))
+	if err := defaultPushURLPolicyWithPrefixes(&url.URL{Scheme: "http", Host: "[" + private.String() + "]"}, []net.IPNet{prefix}); err == nil {
+		t.Error("network-specific NAT64 URL wrapping link-local IPv4 was allowed")
+	}
+	if err := pushDialControlWithPrefixes("tcp", "["+private.String()+"]:80", nil, []net.IPNet{prefix}); err == nil {
+		t.Error("network-specific NAT64 dial wrapping link-local IPv4 was allowed")
+	}
+	if blockedPushIP(public, prefix) {
+		t.Error("network-specific NAT64 address wrapping public IPv4 was blocked")
+	}
+}
+
 // TestSetPushConfigRejectsSSRFURL: an untrusted caller cannot register a
 // callback pointing at an internal address — it is refused and nothing stored.
 func TestSetPushConfigRejectsSSRFURL(t *testing.T) {


### PR DESCRIPTION
## Summary
- add gateway and embedded-handler configuration for network-specific RFC 6052 NAT64 prefixes
- decode all permitted RFC 6052 prefix lengths in both URL validation and dial-time SSRF checks
- test private and public embedded IPv4 handling across /32, /40, /48, /56, /64, and /96 prefixes

This follow-up is based on the original IPv6 transition-address SSRF hardening and addresses the review feedback about network-specific NAT64 deployments.

## Testing
- `go build ./...`
- `go test -race ./gateway/a2a/`
- `go test ./...` *(environment failures: loopback connections are intercepted by the proxy; configured Atlas Cloud credentials also cause a provider conformance test to contact the service)*
- `golangci-lint run ./...` *(environment limitation: installed binary was built with Go 1.24 but this repository targets Go 1.25.12)*